### PR TITLE
fix usages of mut interface methods

### DIFF
--- a/kernel/modules/fs/devtmpfs.v
+++ b/kernel/modules/fs/devtmpfs.v
@@ -139,12 +139,12 @@ __global (
 	devtmpfs_root &VFSNode
 )
 
-fn (mut this DevTmpFS) instantiate() &FileSystem {
+fn (this DevTmpFS) instantiate() &FileSystem {
 	new := &DevTmpFS{}
 	return new
 }
 
-fn (mut this DevTmpFS) populate(node &VFSNode) {}
+fn (this DevTmpFS) populate(node &VFSNode) {}
 
 fn (mut this DevTmpFS) mount(parent &VFSNode, name string, source &VFSNode) ?&VFSNode {
 	if devtmpfs_dev_id == 0 {
@@ -157,6 +157,8 @@ fn (mut this DevTmpFS) mount(parent &VFSNode, name string, source &VFSNode) ?&VF
 	return devtmpfs_root
 }
 
+
+// TODO	should it be maybe `mut parent`? doesn't `create_node` mutate `parent` in `unsafe`(passing it to `mut` field)?
 fn (mut this DevTmpFS) create(parent &VFSNode, name string, mode int) &VFSNode {
 	mut new_node := create_node(this, parent, name, stat.isdir(mode))
 

--- a/kernel/modules/fs/tmpfs.v
+++ b/kernel/modules/fs/tmpfs.v
@@ -143,12 +143,12 @@ pub mut:
 	inode_counter u64
 }
 
-fn (mut this TmpFS) instantiate() &FileSystem {
+fn (this TmpFS) instantiate() &FileSystem {
 	new := &TmpFS{}
 	return new
 }
 
-fn (mut this TmpFS) populate(node &VFSNode) {}
+fn (this TmpFS) populate(node &VFSNode) {}
 
 fn (mut this TmpFS) mount(parent &VFSNode, name string, source &VFSNode) ?&VFSNode {
 	this.dev_id = resource.create_dev_id()

--- a/kernel/modules/fs/vfs.v
+++ b/kernel/modules/fs/vfs.v
@@ -22,6 +22,7 @@ pub const seek_set = 3
 interface FileSystem {
 	instantiate() &FileSystem
 	populate(&VFSNode)
+mut:
 	mount(&VFSNode, string, &VFSNode) ?&VFSNode
 	create(&VFSNode, string, int) &VFSNode
 	symlink(&VFSNode, string, string) &VFSNode
@@ -245,7 +246,7 @@ pub fn mount(parent &VFSNode, source string, target string, filesystem string) ?
 		return error('')
 	}
 
-	fs := filesystems[filesystem].instantiate()
+	mut fs := filesystems[filesystem].instantiate()
 
 	mut mount_node := fs.mount(parent_of_tgt_node, basename, source_node) ?
 


### PR DESCRIPTION
don't merge yet! a draft, preparing for https://github.com/vlang/v/pull/11963

where `create_node` is used(as commented in one of the places with `TODO`) should it maybe `mut parent`? doesn't `create_node` mutate  `parent`? i guess this is deliberately hidden for now