### PR TITLE
Format the whole codebase

### DIFF
--- a/base-files/root/hello.v
+++ b/base-files/root/hello.v
@@ -1,3 +1,3 @@
 fn main() {
-    println('Hello world')
+	println('Hello world')
 }

--- a/base-files/root/wayland-test/client.v
+++ b/base-files/root/wayland-test/client.v
@@ -3,6 +3,7 @@
 #include <wayland-client-core.h>
 
 struct C.wl_display {}
+
 fn C.wl_display_connect(voidptr) &C.wl_display
 fn C.wl_display_disconnect(&C.wl_display)
 
@@ -13,6 +14,8 @@ fn main() {
 		return
 	}
 
-	defer { C.wl_display_disconnect(dsp) }
-	println("connected to display")
+	defer {
+		C.wl_display_disconnect(dsp)
+	}
+	println('connected to display')
 }

--- a/base-files/root/wayland-test/server.v
+++ b/base-files/root/wayland-test/server.v
@@ -3,6 +3,7 @@
 #include <wayland-server-core.h>
 
 struct C.wl_display {}
+
 fn C.wl_display_create() &C.wl_display
 fn C.wl_display_destroy(&C.wl_display)
 fn C.wl_display_run(&C.wl_display)
@@ -11,19 +12,21 @@ fn C.wl_display_add_socket_auto(&C.wl_display) &char
 fn main() {
 	mut dsp := C.wl_display_create()
 	if dsp == voidptr(0) {
-		println('couldn\'t create display')
+		println("couldn't create display")
 		return
 	}
-	defer { C.wl_display_destroy(dsp) }
+	defer {
+		C.wl_display_destroy(dsp)
+	}
 	println('created display')
 
 	sock := C.wl_display_add_socket_auto(dsp)
 	if sock == voidptr(0) {
-		println('couldn\'t create socket')
+		println("couldn't create socket")
 		return
 	}
 
-	println('created socket: ' + unsafe{ sock.vstring() })
+	println('created socket: ' + unsafe { sock.vstring() })
 
 	C.wl_display_run(dsp)
 }

--- a/kernel/main.v
+++ b/kernel/main.v
@@ -1,7 +1,8 @@
 module main
 
 import lib
-import lib.stubs // unused, but needed for C function stubs
+import lib.stubs
+// unused, but needed for C function stubs
 import memory
 import stivale2
 import acpi
@@ -24,7 +25,6 @@ import dev.nvme
 import dev.streams
 import dev.random
 import syscall.table
-
 import socket
 
 fn C._vinit(argc int, argv voidptr)
@@ -53,13 +53,11 @@ fn kmain_thread(stivale2_struct &stivale2.Struct) {
 	nvme.initialise()
 	random.initialise()
 
-	userland.start_program(false, vfs_root, '/sbin/init', ['/sbin/init'],
-							['HOME=/root',
-							'TERM=linux',
-							'PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'],
-							'/dev/console', '/dev/console', '/dev/console') or {
-		panic('Could not start init process')
-	}
+	userland.start_program(false, vfs_root, '/sbin/init', ['/sbin/init'], [
+		'HOME=/root',
+		'TERM=linux',
+		'PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin',
+	], '/dev/console', '/dev/console', '/dev/console') or { panic('Could not start init process') }
 
 	sched.dequeue_and_die()
 }

--- a/kernel/modules/acpi/acpi.v
+++ b/kernel/modules/acpi/acpi.v
@@ -51,8 +51,8 @@ pub fn init(rsdp_ptr &RSDP) {
 		rsdt = unsafe { &RSDT(byteptr(usize(rsdp.rsdt_addr)) + higher_half) }
 	}
 
-	println('acpi: Revision:  ${rsdp.revision}')
-	println('acpi: Use XSDT:  ${use_xsdt()}')
+	println('acpi: Revision:  $rsdp.revision')
+	println('acpi: Use XSDT:  $use_xsdt()')
 	println('acpi: R/XSDT at: 0x${voidptr(rsdt):x}')
 
 	// We won't support HW reduced ACPI systems
@@ -84,10 +84,10 @@ pub fn find_sdt(signature string, index int) ?voidptr {
 				count++
 				continue
 			}
-			println('acpi: Found "${signature}" at 0x${voidptr(ptr):x}')
+			println('acpi: Found "$signature" at 0x${voidptr(ptr):x}')
 			return voidptr(ptr)
 		}
 	}
 
-	return error('acpi: "${signature}" not found')
+	return error('acpi: "$signature" not found')
 }

--- a/kernel/modules/acpi/madt.v
+++ b/kernel/modules/acpi/madt.v
@@ -55,17 +55,15 @@ pub:
 }
 
 __global (
-	madt &MADT
+	madt             &MADT
 	madt_local_apics []&MADTLocalApic
-	madt_io_apics []&MADTIoApic
-	madt_isos []&MADTISO
-	madt_nmis []&MADTNMI
+	madt_io_apics    []&MADTIoApic
+	madt_isos        []&MADTISO
+	madt_nmis        []&MADTNMI
 )
 
 fn madt_init() {
-	madt := &MADT(find_sdt('APIC', 0) or {
-		panic('System does not have a MADT')
-	})
+	madt := &MADT(find_sdt('APIC', 0) or { panic('System does not have a MADT') })
 
 	mut current := u64(0)
 
@@ -78,19 +76,19 @@ fn madt_init() {
 
 		match header.id {
 			0 {
-				println('acpi/madt: Found local APIC #${madt_local_apics.len}')
+				println('acpi/madt: Found local APIC #$madt_local_apics.len')
 				madt_local_apics << unsafe { &MADTLocalApic(header) }
 			}
 			1 {
-				println('acpi/madt: Found IO APIC #${madt_io_apics.len}')
+				println('acpi/madt: Found IO APIC #$madt_io_apics.len')
 				madt_io_apics << unsafe { &MADTIoApic(header) }
 			}
 			2 {
-				println('acpi/madt: Found ISO #${madt_isos.len}')
+				println('acpi/madt: Found ISO #$madt_isos.len')
 				madt_isos << unsafe { &MADTISO(header) }
 			}
 			4 {
-				println('acpi/madt: Found NMI #${madt_nmis.len}')
+				println('acpi/madt: Found NMI #$madt_nmis.len')
 				madt_nmis << unsafe { &MADTNMI(header) }
 			}
 			else {}

--- a/kernel/modules/bitmap/bitmap.v
+++ b/kernel/modules/bitmap/bitmap.v
@@ -6,7 +6,7 @@ import lib
 struct GenericBitmap {
 mut:
 	raw_bitmap voidptr
-	entry_cnt u64
+	entry_cnt  u64
 }
 
 pub fn (mut bitmap GenericBitmap) initialise(entry_cnt u64) {
@@ -25,7 +25,7 @@ pub fn (bitmap GenericBitmap) alloc() ?u64 {
 }
 
 pub fn (bitmap GenericBitmap) free_entry(index u64) {
-	if index < bitmap.entry_cnt { 
+	if index < bitmap.entry_cnt {
 		lib.bitreset(bitmap.raw_bitmap, index)
 	}
 }

--- a/kernel/modules/dev/nvme/nvme.v
+++ b/kernel/modules/dev/nvme/nvme.v
@@ -17,220 +17,220 @@ import block.partition
 import fs
 
 const (
-	nvme_class = 0x1
+	nvme_class    = 0x1
 	nvme_subclass = 0x8
-	nvme_progif = 0x2
+	nvme_progif   = 0x2
 )
 
 const (
-	opcode_delete_sq = 0x0
-	opcode_create_sq = 0x1
-	opcode_delete_cq = 0x4
-	opcode_create_cq = 0x5
-	opcode_identify = 0x6
-	opcode_abort = 0x8
-	opcode_set_features = 0x9
-	opcode_get_features = 0xa
+	opcode_delete_sq     = 0x0
+	opcode_create_sq     = 0x1
+	opcode_delete_cq     = 0x4
+	opcode_create_cq     = 0x5
+	opcode_identify      = 0x6
+	opcode_abort         = 0x8
+	opcode_set_features  = 0x9
+	opcode_get_features  = 0xa
 	opcode_ns_management = 0xd
-	opcode_format_cmd = 0x80
+	opcode_format_cmd    = 0x80
 )
 
 [packed]
 struct NVMERegisters {
 pub mut:
-	cap u64
-	vs u32
+	cap   u64
+	vs    u32
 	intms u32
 	intmc u32
-	cc u32
+	cc    u32
 	rsvd1 u32
-	csts u32
+	csts  u32
 	rsvd2 u32
-	aqa u32
-	asq u64
-	acq u64
+	aqa   u32
+	asq   u64
+	acq   u64
 }
 
 [packed]
 struct NVMECommandCreateCQ {
 pub mut:
-	rsvd1[5] u32
-	prp1 u64
-	rsvd2 u64
-	cqid u16
-	qsize u16
-	cq_flags u16
+	rsvd1      [5]u32
+	prp1       u64
+	rsvd2      u64
+	cqid       u16
+	qsize      u16
+	cq_flags   u16
 	irq_vector u16
-	rsvd3[4] u32
+	rsvd3      [4]u32
 }
 
 [packed]
 struct NVMECommandCreateSQ {
 pub mut:
-	rsvd1[5] u32
-	prp1 u64
-	rsvd2 u64
-	sqid u16
-	qsize u16
+	rsvd1    [5]u32
+	prp1     u64
+	rsvd2    u64
+	sqid     u16
+	qsize    u16
 	sq_flags u16
-	cqid u16
-	rsvd3[4] u32
+	cqid     u16
+	rsvd3    [4]u32
 }
 
 [packed]
 struct NVMECommandDeleteQ {
 pub mut:
-	rsvd1[9] u32
-	qid u16
+	rsvd1 [9]u32
+	qid   u16
 	rsvd2 u16
-	rsvd3[5] u32
+	rsvd3 [5]u32
 }
 
 [packed]
 struct NVMECommandAbort {
 pub mut:
-	rsvd1[9] u32
-	sqid u16
-	cid u16
-	rsvd2[5] u32
+	rsvd1 [9]u32
+	sqid  u16
+	cid   u16
+	rsvd2 [5]u32
 }
 
 [packed]
 struct NVMECommandFeatures {
 pub mut:
-	nsid u32
-	rsvd1[2] u64
-	prp1 u64
-	prp2 u64
-	fid u32
+	nsid    u32
+	rsvd1   [2]u64
+	prp1    u64
+	prp2    u64
+	fid     u32
 	dword11 u32
-	rsvd2[4] u32
+	rsvd2   [4]u32
 }
 
 [packed]
 struct NVMECommandIdentify {
 pub mut:
-	nsid u32
-	rsvd1[2] u64
-	prp1 u64
-	prp2 u64
-	cns u32
-	rsvd2[5] u32
+	nsid  u32
+	rsvd1 [2]u64
+	prp1  u64
+	prp2  u64
+	cns   u32
+	rsvd2 [5]u32
 }
 
 [packed]
 struct NVMECommandRW {
 pub mut:
-	nsid u32
-	rsvd1 u64
+	nsid     u32
+	rsvd1    u64
 	metadata u64
-	prp1 u64
-	prp2 u64
-	slba u64
-	length u16
-	control u16
-	dsmgmt u32
-	reftag u32
-	apptag u16
-	appmask u16
+	prp1     u64
+	prp2     u64
+	slba     u64
+	length   u16
+	control  u16
+	dsmgmt   u32
+	reftag   u32
+	apptag   u16
+	appmask  u16
 }
 
 union NVMECommandPrivate {
 pub mut:
-	create_cq NVMECommandCreateCQ
-	create_sq NVMECommandCreateSQ
+	create_cq    NVMECommandCreateCQ
+	create_sq    NVMECommandCreateSQ
 	delete_queue NVMECommandDeleteQ
-	abort NVMECommandAbort
-	features NVMECommandFeatures
-	identify NVMECommandIdentify
-	rw NVMECommandRW
+	abort        NVMECommandAbort
+	features     NVMECommandFeatures
+	identify     NVMECommandIdentify
+	rw           NVMECommandRW
 }
 
 [packed]
 struct NVMECommand {
 pub mut:
-	opcode u8
-	flags u8
-	cid u16
+	opcode  u8
+	flags   u8
+	cid     u16
 	private NVMECommandPrivate
 }
 
 [packed]
 struct NVMECompletion {
 pub mut:
-	result u32
-	rsvd u32
+	result  u32
+	rsvd    u32
 	sq_head u16
-	sq_id u16
-	cid u16
-	status u16
+	sq_id   u16
+	cid     u16
+	status  u16
 }
 
 [packed]
 struct NVMEPowerStateID {
 pub mut:
-	max_power u16
-	rsvd1 u8
-	flags u8
-	entry_lat u32
-	exit_lat u32
-	read_tput u8
-	read_lat u8
-	write_tput u8
-	write_lat u8
-	idle_power u16
-	idle_scale u8
-	rsvd2 u8
-	active_power u16
+	max_power         u16
+	rsvd1             u8
+	flags             u8
+	entry_lat         u32
+	exit_lat          u32
+	read_tput         u8
+	read_lat          u8
+	write_tput        u8
+	write_lat         u8
+	idle_power        u16
+	idle_scale        u8
+	rsvd2             u8
+	active_power      u16
 	active_work_scale u8
-	rsvd3[9] u8
+	rsvd3             [9]u8
 }
 
 [packed]
 struct NVMEControllerID {
 pub mut:
-	vid u16
-	ssvid u16
-	sn[20] char
-	mn[40] char
-	fr[8] char
-	rab u8
-	ieee[3] u8
-	mic u8
-	mdts u8
+	vid    u16
+	ssvid  u16
+	sn     [20]char
+	mn     [40]char
+	fr     [8]char
+	rab    u8
+	ieee   [3]u8
+	mic    u8
+	mdts   u8
 	cntlid u16
-	ver u32
-	rsvd1[172] u8
-	oacs u16
-	acl u8
-	aerl u8
-	frmw u8
-	lpa u8
-	elpe u8
-	npss u8
-	avscc u8
-	apsta u8
+	ver    u32
+	rsvd1  [172]u8
+	oacs   u16
+	acl    u8
+	aerl   u8
+	frmw   u8
+	lpa    u8
+	elpe   u8
+	npss   u8
+	avscc  u8
+	apsta  u8
 	wctemp u16
 	cctemp u16
-	rsvd2[242] u8
-	sqes u8
-	cqes u8
-	rsvd3[2] u8
-	nn u32
-	oncs u16
-	fuses u16
-	fna u8
-	vwc u8
-	awun u16
-	awupf u16
-	nvscc u8
-	rsvd4 u8
-	acwu u16
-	rsvd5[2] u8
-	sgls u32
-	rsvd6[1508] u8
-	psd[32] NVMEPowerStateID
-	vs[1024] u8
+	rsvd2  [242]u8
+	sqes   u8
+	cqes   u8
+	rsvd3  [2]u8
+	nn     u32
+	oncs   u16
+	fuses  u16
+	fna    u8
+	vwc    u8
+	awun   u16
+	awupf  u16
+	nvscc  u8
+	rsvd4  u8
+	acwu   u16
+	rsvd5  [2]u8
+	sgls   u32
+	rsvd6  [1508]u8
+	psd    [32]NVMEPowerStateID
+	vs     [1024]u8
 }
 
 [packed]
@@ -244,73 +244,73 @@ pub mut:
 [packed]
 struct NVMENamespaceID {
 pub mut:
-	nsze u64
-	ncap u64
-	nuse u64
-	nsfeat u8
-	nlbaf u8
-	flbas u8
-	mc u8
-	dpc u8
-	dps u8
-	nmic u8
-	rescap u8
-	fpi u8
-	rsvd1 u8
-	nawun u16
-	nawupf u16
-	nacwu u16
-	nabsn u16
-	nabo u16
-	nabspf u16
-	rsvd2 u16
-	nvmcap[2] u64
-	rsvd3[40] u8
-	nguid[16] u8
-	eui64[8] u8
-	lbaf_list[16] NVMELbaf
-	rsvd4[192] u8
-	vs[3712] u8
+	nsze      u64
+	ncap      u64
+	nuse      u64
+	nsfeat    u8
+	nlbaf     u8
+	flbas     u8
+	mc        u8
+	dpc       u8
+	dps       u8
+	nmic      u8
+	rescap    u8
+	fpi       u8
+	rsvd1     u8
+	nawun     u16
+	nawupf    u16
+	nacwu     u16
+	nabsn     u16
+	nabo      u16
+	nabspf    u16
+	rsvd2     u16
+	nvmcap    [2]u64
+	rsvd3     [40]u8
+	nguid     [16]u8
+	eui64     [8]u8
+	lbaf_list [16]NVMELbaf
+	rsvd4     [192]u8
+	vs        [3712]u8
 }
 
 struct NVMEController {
 pub mut:
 	pci_bar pci.PCIBar
 
-	regs &NVMERegisters
+	regs          &NVMERegisters
 	controller_id &NVMEControllerID
 
-	queue_entries u64
-	max_page_size u64
-	min_page_size u64
-	page_size u64
+	queue_entries      u64
+	max_page_size      u64
+	min_page_size      u64
+	page_size          u64
 	max_transfer_shift u64
-	max_prps u64
-	strides u64
-	qid_bitmap bitmap.GenericBitmap
+	max_prps           u64
+	strides            u64
+	qid_bitmap         bitmap.GenericBitmap
 
-	admin_queue &NVMEQueuePair
+	admin_queue    &NVMEQueuePair
 	namespace_list []&NVMENamespace
 }
 
 struct NVMEQueuePair {
 pub mut:
-	qid u64
+	qid       u64
 	entry_cnt u64
-	sq_head u64
-	sq_tail u64
-	cq_head u64
-	cq_tail u64
-	phase bool
-	vector u64
-	irq u64
-	admin bool
-	l klock.Lock
+	sq_head   u64
+	sq_tail   u64
+	cq_head   u64
+	cq_tail   u64
+	phase     bool
+	vector    u64
+	irq       u64
+	admin     bool
+	l         klock.Lock
 
 	parent_controller &NVMEController
 
-	submission_queue &NVMECommand
-	completion_queue &NVMECompletion
+	submission_queue    &NVMECommand
+	completion_queue    &NVMECompletion
 	submission_doorbell &u32
 	completion_doorbell &u32
 
@@ -319,18 +319,18 @@ pub mut:
 
 struct NVMENamespace {
 pub mut:
-	stat	 stat.Stat
+	stat     stat.Stat
 	refcount int
-	l		 klock.Lock
-	event	 eventstruct.Event
-	status	 int
+	l        klock.Lock
+	event    eventstruct.Event
+	status   int
 	can_mmap bool
 
 	max_prps u64
-	nsid u64
+	nsid     u64
 
 	parent_controller &NVMEController
-	identity &NVMENamespaceID
+	identity          &NVMENamespaceID
 }
 
 __global (
@@ -410,20 +410,22 @@ fn (mut dev NVMENamespace) mmap(page u64, flags int) voidptr {
 	return 0
 }
 
-pub fn (mut namespace NVMENamespace) initialise(mut parent_controller &NVMEController, nsid u64) int {
-	unsafe { namespace.parent_controller = parent_controller }
+pub fn (mut namespace NVMENamespace) initialise(mut parent_controller NVMEController, nsid u64) int {
+	unsafe {
+		namespace.parent_controller = parent_controller
+	}
 	namespace.nsid = nsid
-	namespace.identity = &NVMENamespaceID(u64(memory.pmm_alloc(lib.div_roundup(sizeof(NVMENamespaceID), page_size))) + higher_half)
+	namespace.identity = &NVMENamespaceID(
+		u64(memory.pmm_alloc(lib.div_roundup(sizeof(NVMENamespaceID), page_size))) + higher_half)
 
-	mut new_command := &NVMECommand { }
+	mut new_command := &NVMECommand{}
 
 	unsafe {
-		new_command.opcode = opcode_identify
+		new_command.opcode = nvme.opcode_identify
 		new_command.private.identify.cns = 0
 		new_command.private.identify.nsid = u32(nsid)
 		new_command.private.identify.prp1 = u64(namespace.identity) - higher_half
 	}
-
 	if parent_controller.admin_queue.send_cmd_and_wait(mut new_command, -1) == 0xffff {
 		print('nvme: nsid ${nsid:x} : unable to read namespace identity\n')
 		return -1
@@ -439,7 +441,7 @@ pub fn (mut namespace NVMENamespace) initialise(mut parent_controller &NVMEContr
 	return 0
 }
 
-fn calculate_max_prps(mut c &NVMEController, identity &NVMENamespaceID) u64 {
+fn calculate_max_prps(mut c NVMEController, identity &NVMENamespaceID) u64 {
 	lba_shift := identity.lbaf_list[identity.flbas & 0xf].ds
 
 	shift := 12 + (c.regs.cap >> 48 & 0xf)
@@ -453,7 +455,7 @@ fn calculate_max_prps(mut c &NVMEController, identity &NVMENamespaceID) u64 {
 	return (u64(max_lbas) * (1 << u64(lba_shift))) / 0x1000
 }
 
-pub fn (mut pair NVMEQueuePair) initialise(mut parent_controller &NVMEController, vector u64, irq u64, admin bool) int {
+pub fn (mut pair NVMEQueuePair) initialise(mut parent_controller NVMEController, vector u64, irq u64, admin bool) int {
 	qid := parent_controller.qid_bitmap.alloc() or {
 		print('nvme: no available qid\n')
 		return -1
@@ -470,8 +472,12 @@ pub fn (mut pair NVMEQueuePair) initialise(mut parent_controller &NVMEController
 	pair.admin = admin
 	pair.entry_cnt = parent_controller.queue_entries
 
-	pair.submission_queue = &NVMECommand(u64(memory.pmm_alloc(lib.div_roundup(pair.entry_cnt * sizeof(NVMECommand), page_size))) + higher_half)
-	pair.completion_queue = &NVMECompletion(u64(memory.pmm_alloc(lib.div_roundup(pair.entry_cnt * sizeof(NVMECompletion), page_size))) + higher_half)
+	pair.submission_queue = &NVMECommand(
+		u64(memory.pmm_alloc(lib.div_roundup(pair.entry_cnt * sizeof(NVMECommand), page_size))) +
+		higher_half)
+	pair.completion_queue = &NVMECompletion(
+		u64(memory.pmm_alloc(lib.div_roundup(pair.entry_cnt * sizeof(NVMECompletion), page_size))) +
+		higher_half)
 
 	submission_offset := page_size + 2 * qid * (4 << parent_controller.strides)
 	pair.submission_doorbell = &u32(u64(parent_controller.regs) + submission_offset)
@@ -485,33 +491,31 @@ pub fn (mut pair NVMEQueuePair) initialise(mut parent_controller &NVMEController
 		return 0
 	}
 
-	mut create_cq_command := &NVMECommand { }
+	mut create_cq_command := &NVMECommand{}
 
 	unsafe {
-		create_cq_command.opcode = opcode_create_cq
+		create_cq_command.opcode = nvme.opcode_create_cq
 		create_cq_command.private.create_cq.prp1 = u64(pair.completion_queue) - higher_half
 		create_cq_command.private.create_cq.cqid = u16(qid)
 		create_cq_command.private.create_cq.qsize = u16(pair.entry_cnt - 1)
 		create_cq_command.private.create_cq.irq_vector = u16(irq)
 		create_cq_command.private.create_cq.cq_flags = (1 << 0) | (1 << 1)
 	}
-
 	if parent_controller.admin_queue.send_cmd_and_wait(mut create_cq_command, -1) == 0xffff {
 		print('nvme: unable to create completion queue\n')
 		return -1
 	}
 
-	mut create_sq_command := &NVMECommand { }
+	mut create_sq_command := &NVMECommand{}
 
 	unsafe {
-		create_sq_command.opcode = opcode_create_sq
+		create_sq_command.opcode = nvme.opcode_create_sq
 		create_sq_command.private.create_sq.prp1 = u64(pair.submission_queue) - higher_half
 		create_sq_command.private.create_sq.cqid = u16(qid)
 		create_sq_command.private.create_sq.sqid = u16(qid)
 		create_sq_command.private.create_sq.qsize = u16(pair.entry_cnt - 1)
 		create_sq_command.private.create_sq.sq_flags = (1 << 0) | (1 << 1)
 	}
-
 	if parent_controller.admin_queue.send_cmd_and_wait(mut create_sq_command, -1) == 0xffff {
 		print('nvme: unable to create submission queue\n')
 		return -1
@@ -522,7 +526,7 @@ pub fn (mut pair NVMEQueuePair) initialise(mut parent_controller &NVMEController
 	return 0
 }
 
-pub fn (mut pair NVMEQueuePair) send_cmd(mut submission &NVMECommand, cid int) int {
+pub fn (mut pair NVMEQueuePair) send_cmd(mut submission NVMECommand, cid int) int {
 	mut command_cid := cid
 
 	if cid == -1 {
@@ -537,7 +541,6 @@ pub fn (mut pair NVMEQueuePair) send_cmd(mut submission &NVMECommand, cid int) i
 	unsafe {
 		pair.submission_queue[pair.sq_tail] = submission
 	}
-
 	pair.sq_tail++
 
 	if pair.sq_tail == pair.entry_cnt {
@@ -559,7 +562,7 @@ pub fn (mut pair NVMEQueuePair) send_cmd_and_wait(mut submission NVMECommand, ci
 	}
 
 	mut events := [&int_events[pair.vector]]
-	event.await(mut events, true) or { }
+	event.await(mut events, true) or {}
 
 	mut completion_entry := unsafe { pair.completion_queue[pair.cq_head] }
 
@@ -578,15 +581,15 @@ pub fn (mut pair NVMEQueuePair) send_cmd_and_wait(mut submission NVMECommand, ci
 
 	pair.cid_bitmap.free_entry(u64(cid))
 
-	kio.mmout( unsafe { &u64(pair.submission_doorbell) }, pair.cq_head)
+	kio.mmout(unsafe { &u64(pair.submission_doorbell) }, pair.cq_head)
 
 	pair.l.release()
 
 	return completion_entry.status
 }
 
-pub fn(mut ns NVMENamespace) rw_lba(buffer voidptr, start u64, cnt u64, rw bool) int {
-	mut new_command := NVMECommand { }
+pub fn (mut ns NVMENamespace) rw_lba(buffer voidptr, start u64, cnt u64, rw bool) int {
+	mut new_command := NVMECommand{}
 
 	mut queue_pair := &NVMEQueuePair(cpulocal.current().nvme_io_queue_pair)
 
@@ -595,7 +598,9 @@ pub fn(mut ns NVMENamespace) rw_lba(buffer voidptr, start u64, cnt u64, rw bool)
 		return -1
 	}
 
-	mut prp_list := &u64(u64(memory.pmm_alloc(lib.div_roundup(ns.max_prps * queue_pair.entry_cnt * sizeof(u64), page_size))) + higher_half)
+	mut prp_list := &u64(
+		u64(memory.pmm_alloc(lib.div_roundup(ns.max_prps * queue_pair.entry_cnt * sizeof(u64), page_size))) +
+		higher_half)
 
 	if (cnt * ns.stat.blksize) > page_size {
 		if (cnt * ns.stat.blksize) > (page_size * 2) {
@@ -607,12 +612,19 @@ pub fn(mut ns NVMENamespace) rw_lba(buffer voidptr, start u64, cnt u64, rw bool)
 			}
 
 			for i := u64(0); i < prp_cnt; i++ {
-				unsafe { prp_list[i + cid * ns.max_prps] = (u64(buffer) - higher_half) + page_size + i * page_size }
+				unsafe {
+					prp_list[i + cid * ns.max_prps] = (u64(buffer) - higher_half) + page_size +
+						i * page_size
+				}
 			}
 
-			unsafe { new_command.private.rw.prp2 = u64(&prp_list[cid * ns.max_prps]) - higher_half }
+			unsafe {
+				new_command.private.rw.prp2 = u64(&prp_list[cid * ns.max_prps]) - higher_half
+			}
 		} else {
-			unsafe { new_command.private.rw.prp2 = u64(buffer) + page_size - higher_half }
+			unsafe {
+				new_command.private.rw.prp2 = u64(buffer) + page_size - higher_half
+			}
 		}
 	}
 
@@ -630,7 +642,6 @@ pub fn(mut ns NVMENamespace) rw_lba(buffer voidptr, start u64, cnt u64, rw bool)
 		new_command.private.rw.length = u16(cnt - 1)
 		new_command.private.rw.prp1 = u64(buffer) - higher_half
 	}
-
 	if queue_pair.send_cmd_and_wait(mut new_command, int(cid)) == 0xffff {
 		print('nvme: rw fail\n')
 		return -1
@@ -640,16 +651,16 @@ pub fn(mut ns NVMENamespace) rw_lba(buffer voidptr, start u64, cnt u64, rw bool)
 }
 
 fn (mut c NVMEController) get_controller_id() int {
-	c.controller_id = &NVMEControllerID(u64(memory.pmm_alloc(lib.div_roundup(sizeof(NVMEControllerID), page_size))) + higher_half)
+	c.controller_id = &NVMEControllerID(
+		u64(memory.pmm_alloc(lib.div_roundup(sizeof(NVMEControllerID), page_size))) + higher_half)
 
-	mut new_command := &NVMECommand { }
+	mut new_command := &NVMECommand{}
 
 	unsafe {
-		new_command.opcode = opcode_identify
+		new_command.opcode = nvme.opcode_identify
 		new_command.private.identify.cns = 1
 		new_command.private.identify.prp1 = u64(c.controller_id) - higher_half
 	}
-
 	if c.admin_queue.send_cmd_and_wait(mut new_command, -1) == 0xffff {
 		print('nvme: unable to read controller id\n')
 		return -1
@@ -674,7 +685,7 @@ pub fn (mut c NVMEController) initialise(pci_device &pci.PCIDevice) int {
 	minor_version := (c.regs.vs >> 8) & 0xff
 	tertiary_version := c.regs.vs & 0xff
 
-	print('nvme: Version Detected [${major_version}:${minor_version}:${tertiary_version}]\n')
+	print('nvme: Version Detected [$major_version:$minor_version:$tertiary_version]\n')
 
 	if (u64(c.regs.cap) & (u64(1) << 37)) == 0 {
 		print('nvme: NVME command set not supported\n')
@@ -688,7 +699,7 @@ pub fn (mut c NVMEController) initialise(pci_device &pci.PCIDevice) int {
 		c.regs.cc = c.regs.cc & ~(1 << 0) // disable controller
 	}
 
-	for c.regs.csts & (1 << 0) != 0 { }
+	for c.regs.csts & (1 << 0) != 0 {}
 
 	mut vect := byte(0)
 
@@ -712,14 +723,15 @@ pub fn (mut c NVMEController) initialise(pci_device &pci.PCIDevice) int {
 
 	c.qid_bitmap.initialise(0xffff)
 
-	c.admin_queue = &NVMEQueuePair {	parent_controller: 0,
-										submission_queue: 0,
-										completion_queue: 0,
-										completion_doorbell: 0,
-										submission_doorbell: 0
-								   }
+	c.admin_queue = &NVMEQueuePair{
+		parent_controller: 0
+		submission_queue: 0
+		completion_queue: 0
+		completion_doorbell: 0
+		submission_doorbell: 0
+	}
 
-	if c.admin_queue.initialise(mut c, vect, 0, true) != 0	{
+	if c.admin_queue.initialise(mut c, vect, 0, true) != 0 {
 		print('nvme: failed to create an admin queue\n')
 		return -1
 	}
@@ -728,13 +740,12 @@ pub fn (mut c NVMEController) initialise(pci_device &pci.PCIDevice) int {
 	c.regs.asq = u64(c.admin_queue.submission_queue) - higher_half
 	c.regs.acq = u64(c.admin_queue.completion_queue) - higher_half
 
-	c.regs.cc =		(0 << 4) | // nvme command set
-					(0 << 11) | // ams = round robin
-					(0 << 14) | // no shutdown notifications
-					(6 << 16) | // io submission queue size 16 bytes
-					(4 << 20) | // io completion queue size 64 bytes
-					(1 << 0) // enable
-
+	c.regs.cc = (0 << 4) | // nvme command set
+	(0 << 11) | // ams = round robin
+	(0 << 14) | // no shutdown notifications
+	(6 << 16) | // io submission queue size 16 bytes
+	(4 << 20) | // io completion queue size 64 bytes
+	(1 << 0) // enable
 	for {
 		if c.regs.csts & (1 << 0) != 0 {
 			break
@@ -752,18 +763,18 @@ pub fn (mut c NVMEController) initialise(pci_device &pci.PCIDevice) int {
 	}
 
 	print('nvme: vendor ID: ${c.controller_id.vid:x}\n')
-	print('nvme: subsystem vendor ID: ${c.controller_id.ssvid}\n')
+	print('nvme: subsystem vendor ID: $c.controller_id.ssvid\n')
 
-	nsid_list := &u32(u64(memory.pmm_alloc(lib.div_roundup(c.controller_id.nn * 4, page_size))) + higher_half)
+	nsid_list := &u32(u64(memory.pmm_alloc(lib.div_roundup(c.controller_id.nn * 4, page_size))) +
+		higher_half)
 
-	mut new_command := &NVMECommand { }
+	mut new_command := &NVMECommand{}
 
 	unsafe {
-		new_command.opcode = opcode_identify
+		new_command.opcode = nvme.opcode_identify
 		new_command.private.identify.cns = 2
 		new_command.private.identify.prp1 = u64(nsid_list) - higher_half
 	}
-
 	if c.admin_queue.send_cmd_and_wait(mut new_command, -1) == 0xffff {
 		print('nvme: unable to read nsid list\n')
 		return -1
@@ -772,12 +783,13 @@ pub fn (mut c NVMEController) initialise(pci_device &pci.PCIDevice) int {
 	mut irq_count := u64(0)
 
 	for mut cpu_local in cpu_locals {
-		mut new_io_queue := &NVMEQueuePair {	parent_controller: 0,
-												submission_queue: 0,
-												completion_queue: 0,
-												submission_doorbell: 0,
-												completion_doorbell: 0
-										   }
+		mut new_io_queue := &NVMEQueuePair{
+			parent_controller: 0
+			submission_queue: 0
+			completion_queue: 0
+			submission_doorbell: 0
+			completion_doorbell: 0
+		}
 
 		if pci_device.msix_support == true {
 			vect = idt.allocate_vector()
@@ -792,9 +804,10 @@ pub fn (mut c NVMEController) initialise(pci_device &pci.PCIDevice) int {
 
 	for i := u64(0); i < c.controller_id.nn; i++ {
 		if unsafe { nsid_list[i] != 0 } {
-			mut new_namespace := &NVMENamespace {	parent_controller: 0,
-													identity: 0
-												}
+			mut new_namespace := &NVMENamespace{
+				parent_controller: 0
+				identity: 0
+			}
 
 			if new_namespace.initialise(mut c, unsafe { nsid_list[i] }) != 0 {
 				print('nvme: fatel error\n')
@@ -806,7 +819,7 @@ pub fn (mut c NVMEController) initialise(pci_device &pci.PCIDevice) int {
 			print('nvme: lba size: ${new_namespace.stat.blksize:x}\n')
 			print('nvme: max prps: ${new_namespace.max_prps:x}\n')
 
-			fs.devtmpfs_add_device(new_namespace, 'nvme${controller_list.len}n${i}')
+			fs.devtmpfs_add_device(new_namespace, 'nvme${controller_list.len}n$i')
 			partition.scan_partitions(mut new_namespace, 'nvme${controller_list.len}n${i}p')
 
 			c.namespace_list << new_namespace
@@ -818,11 +831,13 @@ pub fn (mut c NVMEController) initialise(pci_device &pci.PCIDevice) int {
 
 pub fn initialise() {
 	for device in scanned_devices {
-		if device.class == nvme_class && device.subclass == nvme_subclass && device.prog_if == nvme_progif {
-			mut nvme_device := &NVMEController {	regs: 0,
-													controller_id: 0,
-													admin_queue: 0
-											   }
+		if device.class == nvme.nvme_class && device.subclass == nvme.nvme_subclass
+			&& device.prog_if == nvme.nvme_progif {
+			mut nvme_device := &NVMEController{
+				regs: 0
+				controller_id: 0
+				admin_queue: 0
+			}
 
 			if nvme_device.initialise(device) != -1 {
 				controller_list << nvme_device

--- a/kernel/modules/dev/random/random.v
+++ b/kernel/modules/dev/random/random.v
@@ -10,8 +10,8 @@ import x86.cpu
 
 __global (
 	ur_initialized = false
-	ur_rdrand = false
-	ur_rdseed = false
+	ur_rdrand      = false
+	ur_rdseed      = false
 )
 
 struct URandom {
@@ -30,7 +30,7 @@ mut:
 
 [inline]
 fn rotl32(a u32, shift u32) u32 {
-	return ((a) << (shift)) | ((a) >> (32 - (shift)))
+	return (a << shift) | (a >> (32 - shift))
 }
 
 [inline]
@@ -137,11 +137,11 @@ fn (mut this URandom) listen(handle voidptr, backlog int) ? {
 
 fn (mut this URandom) reseed() {
 	if ur_rdseed {
-		for i in 0..this.key.len {
+		for i in 0 .. this.key.len {
 			this.key[i] ^= cpu.rdseed32()
 		}
 	} else if ur_rdrand {
-		for i in 0..this.key.len {
+		for i in 0 .. this.key.len {
 			this.key[i] ^= cpu.rdrand32()
 		}
 	}

--- a/kernel/modules/dev/streams/streams.v
+++ b/kernel/modules/dev/streams/streams.v
@@ -11,7 +11,6 @@ import errno
 // ***************
 // ** /dev/null **
 // ***************
-
 struct DevNull {
 mut:
 	stat     stat.Stat
@@ -68,7 +67,6 @@ fn init_null() {
 // ***************
 // ** /dev/zero **
 // ***************
-
 struct DevZero {
 mut:
 	stat     stat.Stat
@@ -128,7 +126,6 @@ fn init_zero() {
 // ***************
 // ** /dev/full **
 // ***************
-
 struct DevFull {
 mut:
 	stat     stat.Stat

--- a/kernel/modules/errno/errno.v
+++ b/kernel/modules/errno/errno.v
@@ -3,88 +3,169 @@ module errno
 import proc
 
 pub const edom = 1
+
 pub const eilseq = 2
+
 pub const erange = 3
 
 pub const e2big = 1001
+
 pub const eacces = 1002
+
 pub const eaddrinuse = 1003
+
 pub const eaddrnotavail = 1004
+
 pub const eafnosupport = 1005
+
 pub const eagain = 1006
+
 pub const ealready = 1007
+
 pub const ebadf = 1008
+
 pub const ebadmsg = 1009
+
 pub const ebusy = 1010
+
 pub const ecanceled = 1011
+
 pub const echild = 1012
+
 pub const econnaborted = 1013
+
 pub const econnrefused = 1014
+
 pub const econnreset = 1015
+
 pub const edeadlk = 1016
+
 pub const edestaddrreq = 1017
+
 pub const edquot = 1018
+
 pub const eexist = 1019
+
 pub const efault = 1020
+
 pub const efbig = 1021
+
 pub const ehostunreach = 1022
+
 pub const eidrm = 1023
+
 pub const einprogress = 1024
+
 pub const eintr = 1025
+
 pub const einval = 1026
+
 pub const eio = 1027
+
 pub const eisconn = 1028
+
 pub const eisdir = 1029
+
 pub const eloop = 1030
+
 pub const emfile = 1031
+
 pub const emlink = 1032
+
 pub const emsgsize = 1034
+
 pub const emultihop = 1035
+
 pub const enametoolong = 1036
+
 pub const enetdown = 1037
+
 pub const enetreset = 1038
+
 pub const enetunreach = 1039
+
 pub const enfile = 1040
+
 pub const enobufs = 1041
+
 pub const enodev = 1042
+
 pub const enoent = 1043
+
 pub const enoexec = 1044
+
 pub const enolck = 1045
+
 pub const enolink = 1046
+
 pub const enomem = 1047
+
 pub const enomsg = 1048
+
 pub const enoprotoopt = 1049
+
 pub const enospc = 1050
+
 pub const enosys = 1051
+
 pub const enotconn = 1052
+
 pub const enotdir = 1053
+
 pub const enotempty = 1054
+
 pub const enotrecoverable = 1055
+
 pub const enotsock = 1056
+
 pub const enotsup = 1057
+
 pub const enotty = 1058
+
 pub const enxio = 1059
+
 pub const eopnotsupp = 1060
+
 pub const eoverflow = 1061
+
 pub const eownerdead = 1062
+
 pub const eperm = 1063
+
 pub const epipe = 1064
+
 pub const eproto = 1065
+
 pub const eprotonosupport = 1066
+
 pub const eprototype = 1067
+
 pub const erofs = 1068
+
 pub const espipe = 1069
+
 pub const esrch = 1070
+
 pub const estale = 1071
+
 pub const etimedout = 1072
+
 pub const etxtbsy = 1073
+
 pub const ewouldblock = eagain
+
 pub const exdev = 1075
+
 pub const enodata = 1076
+
 pub const etime = 1077
+
 pub const enokey = 1078
+
 pub const eshutdown = 1079
+
 pub const ehostdown = 1080
+
 pub const ebadfd = 1081
 
 pub fn get() u64 {

--- a/kernel/modules/event/event.v
+++ b/kernel/modules/event/event.v
@@ -2,7 +2,7 @@ module event
 
 import proc
 import sched
-import eventstruct
+import event.eventstruct
 import x86.cpu
 import x86.cpu.local as cpulocal
 import katomic
@@ -54,7 +54,9 @@ fn unlock_events(mut events []&eventstruct.Event) {
 pub fn await(mut events []&eventstruct.Event, block bool) ?u64 {
 	mut thread := proc.current_thread()
 
-	asm volatile amd64 { cli }
+	asm volatile amd64 {
+		cli
+	}
 
 	lock_events(mut events)
 
@@ -87,13 +89,17 @@ pub fn await(mut events []&eventstruct.Event, block bool) ?u64 {
 	return thread.which_event
 }
 
-pub fn trigger(mut event &eventstruct.Event, drop bool) u64 {
+pub fn trigger(mut event eventstruct.Event, drop bool) u64 {
 	ints := cpu.interrupt_state()
 
-	asm volatile amd64 { cli }
+	asm volatile amd64 {
+		cli
+	}
 	defer {
 		if ints == true {
-			asm volatile amd64 { sti }
+			asm volatile amd64 {
+				sti
+			}
 		}
 	}
 
@@ -125,7 +131,9 @@ pub fn trigger(mut event &eventstruct.Event, drop bool) u64 {
 }
 
 pub fn pthread_exit(ret voidptr) {
-	asm volatile amd64 { cli }
+	asm volatile amd64 {
+		cli
+	}
 
 	mut cpu_local := cpulocal.current()
 

--- a/kernel/modules/fs/devtmpfs.v
+++ b/kernel/modules/fs/devtmpfs.v
@@ -37,8 +37,8 @@ fn (mut this DevTmpFSResource) mmap(page u64, flags int) voidptr {
 	copy_page := memory.pmm_alloc(1)
 
 	unsafe {
-		C.memcpy(voidptr(u64(copy_page) + higher_half),
-				 &this.storage[page * page_size], page_size)
+		C.memcpy(voidptr(u64(copy_page) + higher_half), &this.storage[page * page_size],
+			page_size)
 	}
 
 	return copy_page
@@ -134,9 +134,9 @@ fn (mut this DevTmpFSResource) listen(handle voidptr, backlog int) ? {
 struct DevTmpFS {}
 
 __global (
-	devtmpfs_dev_id u64
+	devtmpfs_dev_id        u64
 	devtmpfs_inode_counter u64
-	devtmpfs_root &VFSNode
+	devtmpfs_root          &VFSNode
 )
 
 fn (this DevTmpFS) instantiate() &FileSystem {
@@ -157,7 +157,6 @@ fn (mut this DevTmpFS) mount(parent &VFSNode, name string, source &VFSNode) ?&VF
 	return devtmpfs_root
 }
 
-
 // TODO	should it be maybe `mut parent`? doesn't `create_node` mutate `parent` in `unsafe`(passing it to `mut` field)?
 fn (mut this DevTmpFS) create(parent &VFSNode, name string, mode int) &VFSNode {
 	mut new_node := create_node(this, parent, name, stat.isdir(mode))
@@ -169,7 +168,7 @@ fn (mut this DevTmpFS) create(parent &VFSNode, name string, mode int) &VFSNode {
 
 	if stat.isreg(mode) {
 		new_resource.capacity = 4096
-		new_resource.storage  = memory.malloc(new_resource.capacity)
+		new_resource.storage = memory.malloc(new_resource.capacity)
 	}
 
 	new_resource.stat.size = 0
@@ -218,5 +217,7 @@ pub fn devtmpfs_add_device(device &resource.Resource, name string) {
 	new_node.resource.stat.ino = devtmpfs_inode_counter++
 	new_node.resource.stat.nlink = 1
 
-	unsafe { devtmpfs_root.children[name] = new_node }
+	unsafe {
+		devtmpfs_root.children[name] = new_node
+	}
 }

--- a/kernel/modules/fs/inotify.v
+++ b/kernel/modules/fs/inotify.v
@@ -1,7 +1,6 @@
 module fs
 
 // This is a stub
-
 import resource
 import stat
 import klock
@@ -57,7 +56,9 @@ pub fn syscall_inotify_init(_ voidptr, flags int) (u64, u64) {
 		C.printf(c'\e[32mstrace\e[m: returning\n')
 	}
 
-	mut inotify := &INotify{refcount: 1}
+	mut inotify := &INotify{
+		refcount: 1
+	}
 
 	fdnum := file.fdnum_create_from_resource(voidptr(0), mut inotify, 0, 0, false) or {
 		return -1, errno.get()

--- a/kernel/modules/fs/tmpfs.v
+++ b/kernel/modules/fs/tmpfs.v
@@ -37,8 +37,8 @@ fn (mut this TmpFSResource) mmap(page u64, flags int) voidptr {
 	copy_page := memory.pmm_alloc(1)
 
 	unsafe {
-		C.memcpy(voidptr(u64(copy_page) + higher_half),
-				 &this.storage[page * page_size], page_size)
+		C.memcpy(voidptr(u64(copy_page) + higher_half), &this.storage[page * page_size],
+			page_size)
 	}
 
 	return copy_page
@@ -139,7 +139,7 @@ fn (mut this TmpFSResource) listen(handle voidptr, backlog int) ? {
 
 struct TmpFS {
 pub mut:
-	dev_id u64
+	dev_id        u64
 	inode_counter u64
 }
 
@@ -165,7 +165,7 @@ fn (mut this TmpFS) create(parent &VFSNode, name string, mode int) &VFSNode {
 
 	if stat.isreg(mode) {
 		new_resource.capacity = 4096
-		new_resource.storage  = memory.malloc(new_resource.capacity)
+		new_resource.storage = memory.malloc(new_resource.capacity)
 	}
 
 	new_resource.stat.size = 0

--- a/kernel/modules/futex/futex.v
+++ b/kernel/modules/futex/futex.v
@@ -9,7 +9,7 @@ import katomic
 
 __global (
 	futex_lock klock.Lock
-	futexes map[u64]&eventstruct.Event
+	futexes    map[u64]&eventstruct.Event
 )
 
 pub fn initialise() {
@@ -27,9 +27,7 @@ pub fn syscall_futex_wait(_ voidptr, ptr &int, expected int) (u64, u64) {
 	}
 
 	mut e := &eventstruct.Event(0)
-	phys := proc.current_thread().process.pagemap.virt2phys(u64(ptr)) or {
-		return -1, errno.get()
-	}
+	phys := proc.current_thread().process.pagemap.virt2phys(u64(ptr)) or { return -1, errno.get() }
 
 	futex_lock.acquire()
 
@@ -43,9 +41,7 @@ pub fn syscall_futex_wait(_ voidptr, ptr &int, expected int) (u64, u64) {
 	futex_lock.release()
 
 	mut events := [e]
-	event.await(mut events, true) or {
-		return -1, errno.eintr
-	}
+	event.await(mut events, true) or { return -1, errno.eintr }
 
 	return 0, 0
 }
@@ -59,9 +55,7 @@ pub fn syscall_futex_wake(_ voidptr, ptr &int) (u64, u64) {
 	// Ensure this page is not lazily mapped
 	katomic.load(unsafe { ptr[0] })
 
-	phys := proc.current_thread().process.pagemap.virt2phys(u64(ptr)) or {
-		return -1, errno.get()
-	}
+	phys := proc.current_thread().process.pagemap.virt2phys(u64(ptr)) or { return -1, errno.get() }
 
 	futex_lock.acquire()
 	defer {

--- a/kernel/modules/ioctl/ioctl.v
+++ b/kernel/modules/ioctl/ioctl.v
@@ -1,16 +1,21 @@
 module ioctl
 
 pub const tcgets = 0x5401
+
 pub const tcsets = 0x5402
+
 pub const tcsetsw = 0x5403
+
 pub const tcsetsf = 0x5404
+
 pub const tiocsctty = 0x540e
+
 pub const tiocgwinsz = 0x5413
 
 pub struct WinSize {
 pub mut:
-	ws_row u16
-	ws_col u16
+	ws_row    u16
+	ws_col    u16
 	ws_xpixel u16
 	ws_ypixel u16
 }

--- a/kernel/modules/katomic/katomic.v
+++ b/kernel/modules/katomic/katomic.v
@@ -2,27 +2,31 @@ module katomic
 
 pub fn bts<T>(var &T, bit byte) bool {
 	mut ret := false
-	unsafe { asm volatile amd64 {
-		lock
-		bts var, bit
-		; +m (var[0]) as var
-		  =@ccc (ret)
-		; r (u16(bit)) as bit
-		; memory
-	} }
+	unsafe {
+		asm volatile amd64 {
+			lock
+			bts var, bit
+			; +m (var[0]) as var
+			  =@ccc (ret)
+			; r (u16(bit)) as bit
+			; memory
+		}
+	}
 	return ret
 }
 
 pub fn btr<T>(var &T, bit byte) bool {
 	mut ret := false
-	unsafe { asm volatile amd64 {
-		lock
-		btr var, bit
-		; +m (var[0]) as var
-		  =@ccc (ret)
-		; r (u16(bit)) as bit
-		; memory
-	} }
+	unsafe {
+		asm volatile amd64 {
+			lock
+			btr var, bit
+			; +m (var[0]) as var
+			  =@ccc (ret)
+			; r (u16(bit)) as bit
+			; memory
+		}
+	}
 	return ret
 }
 
@@ -30,66 +34,72 @@ pub fn cas<T>(_here &T, _ifthis T, writethis T) bool {
 	mut ret := false
 	mut here := unsafe { _here }
 	mut ifthis := _ifthis
-	unsafe { asm volatile amd64 {
-		lock
-		cmpxchg here, writethis
-		; +a (ifthis)
-		  +m (here[0]) as here
-		  =@ccz (ret)
-		; r (writethis)
-		; memory
-	} }
+	unsafe {
+		asm volatile amd64 {
+			lock
+			cmpxchg here, writethis
+			; +a (ifthis)
+			  +m (here[0]) as here
+			  =@ccz (ret)
+			; r (writethis)
+			; memory
+		}
+	}
 	return ret
 }
 
 pub fn inc<T>(var &T) T {
 	mut diff := T(1)
-	unsafe { asm volatile amd64 {
-		lock
-		xadd var, diff
-		; +m (var[0]) as var
-		  +r (diff)
-		;
-		; memory
-	} }
+	unsafe {
+		asm volatile amd64 {
+			lock
+			xadd var, diff
+			; +m (var[0]) as var
+			  +r (diff)
+			; ; memory
+		}
+	}
 	return diff
 }
 
 pub fn dec<T>(var &T) bool {
 	mut ret := false
 	mut diff := T(-1)
-	unsafe { asm volatile amd64 {
-		lock
-		xadd var, diff
-		; +m (var[0]) as var
-		  +r (diff)
-		  =@ccnz (ret)
-		;
-		; memory
-	} }
+	unsafe {
+		asm volatile amd64 {
+			lock
+			xadd var, diff
+			; +m (var[0]) as var
+			  +r (diff)
+			  =@ccnz (ret)
+			; ; memory
+		}
+	}
 	return ret
 }
 
 pub fn store<T>(var &T, value T) {
-	unsafe { asm volatile amd64 {
-		lock
-		xchg var, value
-		; +m (var[0]) as var
-		  +r (value)
-		;
-		; memory
-	} }
+	unsafe {
+		asm volatile amd64 {
+			lock
+			xchg var, value
+			; +m (var[0]) as var
+			  +r (value)
+			; ; memory
+		}
+	}
 }
 
 pub fn load<T>(var &T) T {
 	mut ret := T(0)
-	unsafe { asm volatile amd64 {
-		lock
-		xadd var, ret
-		; +m (var[0]) as var
-		  +r (ret)
-		;
-		; memory
-	} }
+	unsafe {
+		asm volatile amd64 {
+			lock
+			xadd var, ret
+			; +m (var[0]) as var
+			  +r (ret)
+			; ; memory
+		}
+	}
 	return ret
 }

--- a/kernel/modules/klock/klock.v
+++ b/kernel/modules/klock/klock.v
@@ -5,7 +5,7 @@ import trace
 
 pub struct Lock {
 pub mut:
-	l bool
+	l      bool
 	caller u64
 }
 
@@ -19,7 +19,10 @@ pub fn (mut l Lock) acquire() {
 			l.caller = caller
 			return
 		}
-		asm volatile amd64 { pause ;;; memory }
+		asm volatile amd64 {
+			pause
+			; ; ; memory
+		}
 	}
 
 	C.printf_panic(c'Lock address:   0x%llx\n', voidptr(l))

--- a/kernel/modules/kprint/kprint.v
+++ b/kernel/modules/kprint/kprint.v
@@ -20,7 +20,6 @@ pub fn syscall_kprint(_ voidptr, message charptr) {
 				serial.out(message[i])
 			}
 		}
-
 		kprint_lock.release()
 	}
 }

--- a/kernel/modules/lib/math.v
+++ b/kernel/modules/lib/math.v
@@ -12,7 +12,7 @@ pub fn align_down(value u64, alignment u64) u64 {
 	return (value / alignment) * alignment
 }
 
-pub fn power(base u64, exp u64) u64 { 
+pub fn power(base u64, exp u64) u64 {
 	mut result := u64(1)
 	mut tmp_base := base
 	mut tmp_exp := exp

--- a/kernel/modules/lib/panic.v
+++ b/kernel/modules/lib/panic.v
@@ -27,14 +27,14 @@ pub fn kpanic(gpr_state &cpulocal.GPRState, message charptr) {
 		C.printf_panic(c'CS:RIP=%04llx:%016llx\n', gpr_state.cs, gpr_state.rip)
 		C.printf_panic(c'SS:RSP=%04llx:%016llx\n', gpr_state.ss, gpr_state.rsp)
 		C.printf_panic(c'RFLAGS=%08llx       CR2=%016llx\n', gpr_state.rflags, cpu.read_cr2())
-		C.printf_panic(c'RAX=%016llx  RBX=%016llx  RCX=%016llx  RDX=%016llx\n',
-				 gpr_state.rax, gpr_state.rbx, gpr_state.rcx, gpr_state.rdx)
-		C.printf_panic(c'RSI=%016llx  RDI=%016llx  RBP=%016llx  RSP=%016llx\n',
-				 gpr_state.rsi, gpr_state.rdi, gpr_state.rbp, gpr_state.rsp)
-		C.printf_panic(c'R08=%016llx  R09=%016llx  R10=%016llx  R11=%016llx\n',
-				 gpr_state.r8, gpr_state.r9, gpr_state.r10, gpr_state.r11)
-		C.printf_panic(c'R12=%016llx  R13=%016llx  R14=%016llx  R15=%016llx\n',
-				 gpr_state.r12, gpr_state.r13, gpr_state.r14, gpr_state.r15)
+		C.printf_panic(c'RAX=%016llx  RBX=%016llx  RCX=%016llx  RDX=%016llx\n', gpr_state.rax,
+			gpr_state.rbx, gpr_state.rcx, gpr_state.rdx)
+		C.printf_panic(c'RSI=%016llx  RDI=%016llx  RBP=%016llx  RSP=%016llx\n', gpr_state.rsi,
+			gpr_state.rdi, gpr_state.rbp, gpr_state.rsp)
+		C.printf_panic(c'R08=%016llx  R09=%016llx  R10=%016llx  R11=%016llx\n', gpr_state.r8,
+			gpr_state.r9, gpr_state.r10, gpr_state.r11)
+		C.printf_panic(c'R12=%016llx  R13=%016llx  R14=%016llx  R15=%016llx\n', gpr_state.r12,
+			gpr_state.r13, gpr_state.r14, gpr_state.r15)
 	}
 
 	C.printf_panic(c'Stacktrace:\n')

--- a/kernel/modules/lib/stubs/file.v
+++ b/kernel/modules/lib/stubs/file.v
@@ -8,7 +8,7 @@ struct C.__mlibc_file_base {}
 type FILE = C.__mlibc_file_base
 
 __global (
-	stdin = &FILE(voidptr(0))
+	stdin  = &FILE(voidptr(0))
 	stdout = &FILE(voidptr(0))
 	stderr = &FILE(voidptr(0))
 )

--- a/kernel/modules/lib/stubs/misc.v
+++ b/kernel/modules/lib/stubs/misc.v
@@ -7,7 +7,6 @@ pub fn ctype_tolower_loc() &&int {
 	lib.kpanic(voidptr(0), c'__ctype_tolower_loc is a stub')
 }
 
-
 [export: '__ctype_toupper_loc']
 pub fn ctype_toupper_loc() &&int {
 	lib.kpanic(voidptr(0), c'__ctype_toupper_loc is a stub')
@@ -20,6 +19,6 @@ pub fn kexit(code int) {
 }
 
 [export: 'qsort']
-pub fn qsort(ptr voidptr, count u64, size u64, comp fn(const_a &C.void, const_b &C.void) int) {
+pub fn qsort(ptr voidptr, count u64, size u64, comp fn (const_a &C.void, const_b &C.void) int) {
 	lib.kpanic(voidptr(0), c'qsort is a stub')
 }

--- a/kernel/modules/lib/stubs/pthread.v
+++ b/kernel/modules/lib/stubs/pthread.v
@@ -6,10 +6,11 @@ import event
 import proc
 
 struct C.__mlibc_thread_data {}
+
 struct C.__mlibc_threadattr {}
 
 [export: 'pthread_create']
-pub fn pthread_create(thread &&C.__mlibc_thread_data, const_attr &C.__mlibc_threadattr, start_routine fn(voidptr) voidptr, arg voidptr) int {
+pub fn pthread_create(thread &&C.__mlibc_thread_data, const_attr &C.__mlibc_threadattr, start_routine fn (voidptr) voidptr, arg voidptr) int {
 	if voidptr(const_attr) != voidptr(0) {
 		lib.kpanic(voidptr(0), c'pthread_create() called with non-NULL attr')
 	}
@@ -18,7 +19,6 @@ pub fn pthread_create(thread &&C.__mlibc_thread_data, const_attr &C.__mlibc_thre
 		mut ptr := &voidptr(thread)
 		*ptr = sched.new_kernel_thread(voidptr(start_routine), arg, true)
 	}
-
 	return 0
 }
 

--- a/kernel/modules/lib/stubs/string.v
+++ b/kernel/modules/lib/stubs/string.v
@@ -2,11 +2,7 @@ module stubs
 
 [export: 'toupper']
 pub fn toupper(c int) int {
-	return if c >= int(`a`) && c <= int(`z`) {
-		c - 0x20
-	} else { 
-		c
-	}
+	return if c >= int(`a`) && c <= int(`z`) { c - 0x20 } else { c }
 }
 
 [export: 'memcpy']
@@ -19,7 +15,6 @@ pub fn memcpy(dest voidptr, const_src voidptr, size u64) voidptr {
 			destm[i] = srcm[i]
 		}
 	}
-
 	return dest
 }
 
@@ -32,7 +27,6 @@ pub fn memset(dest voidptr, c int, size u64) voidptr {
 			destm[i] = byte(c)
 		}
 	}
-
 	return dest
 }
 
@@ -45,10 +39,8 @@ pub fn memset64(dest voidptr, c int, size u64) voidptr {
 			destm[i] = u64(c)
 		}
 	}
-
 	return dest
 }
-
 
 [export: 'memmove']
 pub fn memmove(dest &C.void, const_src &C.void, size u64) &C.void {
@@ -82,7 +74,6 @@ pub fn memcmp(const_s1 &C.void, const_s2 &C.void, size u64) int {
 			}
 		}
 	}
-
 	return 0
 }
 
@@ -93,7 +84,7 @@ pub fn strcpy(dest &C.char, const_src &C.char) &C.char {
 	unsafe {
 		mut destm := &byte(voidptr(dest))
 		srcm := &byte(voidptr(const_src))
-		
+
 		for {
 			if srcm[i] != 0 {
 				destm[i] = srcm[i]
@@ -116,7 +107,7 @@ pub fn strncpy(dest &C.char, const_src &C.char, n u64) &C.char {
 	unsafe {
 		mut destm := &byte(voidptr(dest))
 		srcm := &byte(voidptr(const_src))
-		
+
 		for {
 			if i >= n {
 				return dest
@@ -145,7 +136,7 @@ pub fn strcmp(const_s1 &C.char, const_s2 &C.char) int {
 		mut i := u64(0)
 		s1 := &byte(const_s1)
 		s2 := &byte(const_s2)
-		
+
 		for {
 			c1 := s1[i]
 			c2 := s2[i]
@@ -161,7 +152,6 @@ pub fn strcmp(const_s1 &C.char, const_s2 &C.char) int {
 			i++
 		}
 	}
-
 	return 0
 }
 
@@ -184,7 +174,6 @@ pub fn strncmp(const_s1 &C.char, const_s2 &C.char, size u64) int {
 			}
 		}
 	}
-
 	return 0
 }
 
@@ -202,6 +191,5 @@ pub fn strlen(const_ptr &C.char) u64 {
 			i++
 		}
 	}
-
 	return i
 }

--- a/kernel/modules/memory/virtual.v
+++ b/kernel/modules/memory/virtual.v
@@ -5,9 +5,9 @@ import stivale2
 import klock
 
 __global (
-	page_size = u64(0x1000)
-	higher_half = u64(0xffff800000000000)
-	kernel_pagemap Pagemap
+	page_size       = u64(0x1000)
+	higher_half     = u64(0xffff800000000000)
+	kernel_pagemap  Pagemap
 	vmm_initialised = bool(false)
 )
 
@@ -23,13 +23,19 @@ pub fn new_pagemap() &Pagemap {
 	if top_level == 0 {
 		panic('new_pagemap() allocation failure')
 	}
+
 	// Import higher half from kernel pagemap
 	mut p1 := &u64(u64(top_level) + higher_half)
 	p2 := &u64(u64(kernel_pagemap.top_level) + higher_half)
 	for i := u64(256); i < 512; i++ {
-		unsafe { p1[i] = p2[i] }
+		unsafe {
+			p1[i] = p2[i]
+		}
 	}
-	return &Pagemap{top_level: top_level, mmap_ranges: []voidptr{}}
+	return &Pagemap{
+		top_level: top_level
+		mmap_ranges: []voidptr{}
+	}
 }
 
 pub fn (pagemap &Pagemap) virt2pte(virt u64, allocate bool) ?&u64 {
@@ -39,23 +45,15 @@ pub fn (pagemap &Pagemap) virt2pte(virt u64, allocate bool) ?&u64 {
 	pml1_entry := (virt & (u64(0x1ff) << 12)) >> 12
 
 	pml4 := pagemap.top_level
-	pml3 := get_next_level(pml4, pml4_entry, allocate) or {
-		return none
-	}
-	pml2 := get_next_level(pml3, pml3_entry, allocate) or {
-		return none
-	}
-	pml1 := get_next_level(pml2, pml2_entry, allocate) or {
-		return none
-	}
+	pml3 := get_next_level(pml4, pml4_entry, allocate) or { return none }
+	pml2 := get_next_level(pml3, pml3_entry, allocate) or { return none }
+	pml1 := get_next_level(pml2, pml2_entry, allocate) or { return none }
 
 	return unsafe { &u64(u64(&pml1[pml1_entry]) + higher_half) }
 }
 
 pub fn (pagemap &Pagemap) virt2phys(virt u64) ?u64 {
-	pte_p := pagemap.virt2pte(virt, false) or {
-		return none
-	}
+	pte_p := pagemap.virt2pte(virt, false) or { return none }
 	unsafe {
 		if pte_p[0] & 1 == 0 {
 			return none
@@ -101,11 +99,11 @@ fn get_next_level(current_level &u64, index u64, allocate bool) ?&u64 {
 }
 
 pub fn (mut pagemap Pagemap) unmap_page(virt u64) ? {
-	pte_p := pagemap.virt2pte(virt, false) or {
-		return error('')
-	}
+	pte_p := pagemap.virt2pte(virt, false) or { return error('') }
 
-	unsafe { pte_p[0] = 0 }
+	unsafe {
+		pte_p[0] = 0
+	}
 }
 
 pub fn (mut pagemap Pagemap) map_page(virt u64, phys u64, flags u64) ? {
@@ -120,15 +118,9 @@ pub fn (mut pagemap Pagemap) map_page(virt u64, phys u64, flags u64) ? {
 	pml1_entry := (virt & (u64(0x1ff) << 12)) >> 12
 
 	pml4 := pagemap.top_level
-	pml3 := get_next_level(pml4, pml4_entry, true) or {
-		return error('')
-	}
-	pml2 := get_next_level(pml3, pml3_entry, true) or {
-		return error('')
-	}
-	mut pml1 := get_next_level(pml2, pml2_entry, true) or {
-		return error('')
-	}
+	pml3 := get_next_level(pml4, pml4_entry, true) or { return error('') }
+	pml2 := get_next_level(pml3, pml3_entry, true) or { return error('') }
+	mut pml1 := get_next_level(pml2, pml2_entry, true) or { return error('') }
 
 	unsafe {
 		entry := &u64(u64(pml1) + higher_half + pml1_entry * 8)
@@ -147,18 +139,12 @@ pub fn vmm_init(memmap &stivale2.MemmapTag) {
 	// shared.
 	for i := u64(256); i < 512; i++ {
 		// get_next_level will allocate the PML3s for us.
-		get_next_level(kernel_pagemap.top_level, i, true) or {
-			panic('pmm init failure')
-		}
+		get_next_level(kernel_pagemap.top_level, i, true) or { panic('pmm init failure') }
 	}
 
 	for i := u64(0x1000); i < 0x100000000; i += page_size {
-		kernel_pagemap.map_page(i, i, 0x03) or {
-			panic('pmm init failure')
-		}
-		kernel_pagemap.map_page(i + higher_half, i, 0x03) or {
-			panic('pmm init failure')
-		}
+		kernel_pagemap.map_page(i, i, 0x03) or { panic('pmm init failure') }
+		kernel_pagemap.map_page(i + higher_half, i, 0x03) or { panic('pmm init failure') }
 	}
 	for i := u64(0); i < 0x80000000; i += page_size {
 		kernel_pagemap.map_page(i + u64(0xffffffff80000000), i, 0x03) or {
@@ -176,12 +162,8 @@ pub fn vmm_init(memmap &stivale2.MemmapTag) {
 			if j < u64(0x100000000) {
 				continue
 			}
-			kernel_pagemap.map_page(j, j, 0x03) or {
-				panic('pmm init failure')
-			}
-			kernel_pagemap.map_page(j + higher_half, j, 0x03) or {
-				panic('pmm init failure')
-			}
+			kernel_pagemap.map_page(j, j, 0x03) or { panic('pmm init failure') }
+			kernel_pagemap.map_page(j + higher_half, j, 0x03) or { panic('pmm init failure') }
 		}
 	}
 

--- a/kernel/modules/pci/device.v
+++ b/kernel/modules/pci/device.v
@@ -5,32 +5,32 @@ import bitmap
 
 pub struct PCIDevice {
 pub:
-	bus byte
-	slot byte
+	bus      byte
+	slot     byte
 	function byte
-	parent i64
+	parent   i64
 pub mut:
-	device_id u16
-	vendor_id u16
-	revision_id u16
-	class byte
-	subclass byte
-	prog_if byte
-	multifunction bool
-	irq_pin byte
-	msi_offset u16
-	msix_offset u16
-	msi_support bool
-	msix_support bool
+	device_id         u16
+	vendor_id         u16
+	revision_id       u16
+	class             byte
+	subclass          byte
+	prog_if           byte
+	multifunction     bool
+	irq_pin           byte
+	msi_offset        u16
+	msix_offset       u16
+	msi_support       bool
+	msix_support      bool
 	msix_table_bitmap bitmap.GenericBitmap
-	msix_table_size u16
+	msix_table_size   u16
 }
 
 pub struct PCIBar {
 pub:
-	base u64
-	size u64
-	is_mmio bool
+	base            u64
+	size            u64
+	is_mmio         bool
 	is_prefetchable bool
 }
 
@@ -117,7 +117,6 @@ pub fn (dev &PCIDevice) set_msi(vector byte) {
 
 	message_control |= 1 // enable=1
 	message_control &= ~(0b111 << 4) // mme=0
-
 	dev.write<u16>(dev.msi_offset + 2, message_control)
 }
 
@@ -147,13 +146,11 @@ pub fn (dev &PCIDevice) set_msix(vector byte) bool {
 	kio.mmout(&u32(bar_base), address) // address low
 	kio.mmout(&u32(bar_base + 4), u32(0)) // address high
 	kio.mmout(&u32(bar_base + 8), data) // data
-	kio.mmout(&u32(bar_base + 12), u32(0)) // vector control 
-
+	kio.mmout(&u32(bar_base + 12), u32(0)) // vector control
 	mut message_control := dev.read<u16>(dev.msix_offset + 2)
 
 	message_control |= (1 << 15) // enable=1
 	message_control &= ~(1 << 14) // mask=0
-
 	dev.write<u16>(dev.msix_offset + 2, message_control)
 
 	return true
@@ -166,7 +163,6 @@ pub fn (dev &PCIDevice) enable_bus_mastering() {
 }
 
 fn (dev &PCIDevice) get_address(offset u32) {
-	address := (dev.bus << 16) | (dev.slot << 11) | (dev.function << 8)
-		| (offset & ~(u32(3))) | 0x80000000
+	address := (dev.bus << 16) | (dev.slot << 11) | (dev.function << 8) | (offset & ~(u32(3))) | 0x80000000
 	kio.port_out<u32>(0xcf8, address)
 }

--- a/kernel/modules/pci/scan.v
+++ b/kernel/modules/pci/scan.v
@@ -5,22 +5,24 @@ __global (
 )
 
 const max_function = 8
+
 const max_device = 32
+
 const max_bus = 256
 
 pub fn initialise() {
 	print('pci: Building device scan\n')
 	mut root_bus := PCIDevice{}
-	configc  := root_bus.read<u32>(0xc)
+	configc := root_bus.read<u32>(0xc)
 
 	if (configc & 0x800000) == 0 {
 		check_bus(0, -1)
 	} else {
-		for function := byte(0); function < max_function; function++ {
+		for function := byte(0); function < pci.max_function; function++ {
 			host_bridge := PCIDevice{
-				bus: 0,
-				slot: 0,
-				function: function,
+				bus: 0
+				slot: 0
+				function: function
 				parent: 0
 			}
 			config0 := host_bridge.read<u32>(0)
@@ -34,8 +36,8 @@ pub fn initialise() {
 }
 
 fn check_bus(bus byte, parent i64) {
-	for dev := byte(0); dev < max_device; dev++ {
-		for func := byte(0); func < max_function; func++ {
+	for dev := byte(0); dev < pci.max_device; dev++ {
+		for func := byte(0); func < pci.max_function; func++ {
 			check_function(bus, dev, func, parent)
 		}
 	}
@@ -43,9 +45,9 @@ fn check_bus(bus byte, parent i64) {
 
 fn check_function(bus byte, slot byte, function byte, parent i64) {
 	mut device := &PCIDevice{
-		bus: bus,
-		slot: slot,
-		function: function,
+		bus: bus
+		slot: slot
+		function: function
 		parent: parent
 	}
 	device.read_info()
@@ -65,7 +67,7 @@ fn check_function(bus byte, slot byte, function byte, parent i64) {
 		if (status & (1 << 4)) != 0 { // parse capabilities list
 			mut off := device.read<byte>(0x34)
 
-			for off > 0 { 
+			for off > 0 {
 				id := device.read<byte>(off)
 
 				match id {
@@ -82,9 +84,7 @@ fn check_function(bus byte, slot byte, function byte, parent i64) {
 						device.msix_table_size = message_control & 0x7FF
 						device.msix_table_bitmap.initialise(device.msix_table_size)
 					}
-					else {
-						
-					}
+					else {}
 				}
 
 				off = device.read<byte>(off + 1)
@@ -112,9 +112,7 @@ pub fn get_device_by_vendor(vendor_id u16, device_id u16, index u32) ?&PCIDevice
 pub fn get_device_by_coordinates(bus byte, slot byte, function byte, index u32) ?&PCIDevice {
 	mut count := 0
 	for device in scanned_devices {
-		if device.bus == bus
-		&& device.slot == slot
-		&& device.function == function {
+		if device.bus == bus && device.slot == slot && device.function == function {
 			if count == index {
 				return unsafe { device }
 			} else {
@@ -128,9 +126,7 @@ pub fn get_device_by_coordinates(bus byte, slot byte, function byte, index u32) 
 pub fn get_device_by_class(class byte, subclass byte, progif byte, index u32) ?&PCIDevice {
 	mut count := 0
 	for device in scanned_devices {
-		if device.class == class
-		&& device.subclass == subclass
-		&& device.prog_if == progif {
+		if device.class == class && device.subclass == subclass && device.prog_if == progif {
 			if count == index {
 				return unsafe { device }
 			} else {

--- a/kernel/modules/pipe/pipe.v
+++ b/kernel/modules/pipe/pipe.v
@@ -10,7 +10,6 @@ import file
 import katomic
 
 // A pipe is a circular buffer
-
 pub const pipe_buf = 4096
 
 pub struct Pipe {
@@ -33,8 +32,8 @@ pub fn initialise() {}
 
 pub fn create() ?&Pipe {
 	mut pipe := &Pipe{
-		data: unsafe { C.malloc(pipe_buf) }
-		capacity: pipe_buf
+		data: unsafe { C.malloc(pipe.pipe_buf) }
+		capacity: pipe.pipe_buf
 	}
 	pipe.stat.mode = stat.ifpipe
 
@@ -47,9 +46,7 @@ pub fn syscall_pipe(_ voidptr, pipefds &int, flags int) (u64, u64) {
 		C.printf(c'\e[32mstrace\e[m: returning\n')
 	}
 
-	mut new_pipe := create() or {
-		return -1, errno.get()
-	}
+	mut new_pipe := create() or { return -1, errno.get() }
 
 	rd_fd := file.fdnum_create_from_resource(voidptr(0), mut new_pipe, flags, 0, false) or {
 		return -1, errno.get()
@@ -63,7 +60,6 @@ pub fn syscall_pipe(_ voidptr, pipefds &int, flags int) (u64, u64) {
 		pipefds[0] = rd_fd
 		pipefds[1] = wr_fd
 	}
-
 	return 0, 0
 }
 

--- a/kernel/modules/proc/proc.v
+++ b/kernel/modules/proc/proc.v
@@ -10,68 +10,67 @@ pub const max_fds = 256
 
 pub struct Process {
 pub mut:
-	pid int
-	ppid int
-	pagemap &memory.Pagemap
-	thread_stack_top u64
-	threads []&Thread
-	fds_lock klock.Lock
-	fds [max_fds]voidptr
-	children []&Process
+	pid                      int
+	ppid                     int
+	pagemap                  &memory.Pagemap
+	thread_stack_top         u64
+	threads                  []&Thread
+	fds_lock                 klock.Lock
+	fds                      [max_fds]voidptr
+	children                 []&Process
 	mmap_anon_non_fixed_base u64
-	current_directory voidptr
-	event eventstruct.Event
-	status int
+	current_directory        voidptr
+	event                    eventstruct.Event
+	status                   int
 }
 
 pub struct SigAction {
 pub mut:
 	sa_sigaction voidptr
-	sa_mask u64
-	sa_flags int
+	sa_mask      u64
+	sa_flags     int
 }
 
 pub struct Thread {
 pub mut:
 	// Fixed members, DO NOT MOVE
-	running_on u64
-	self voidptr
-	errno u64
+	running_on   u64
+	self         voidptr
+	errno        u64
 	kernel_stack u64
-	user_stack u64
-	syscall_num u64
-
+	user_stack   u64
+	syscall_num  u64
 	// Movable members
-	is_in_queue bool
-	l klock.Lock
-	process &Process
-	gpr_state cpulocal.GPRState
-	kernel_gs_base u64
-	gs_base u64
-	fs_base u64
-	pf_stack u64
-	cr3 u64
-	fpu_storage voidptr
-	yield_await klock.Lock
-	timeslice u64
-	which_event u64
-	exit_value voidptr
-	exited eventstruct.Event
-	sigentry u64
-	sigactions [256]SigAction
-	pending_signals u64
-	masked_signals u64
+	is_in_queue        bool
+	l                  klock.Lock
+	process            &Process
+	gpr_state          cpulocal.GPRState
+	kernel_gs_base     u64
+	gs_base            u64
+	fs_base            u64
+	pf_stack           u64
+	cr3                u64
+	fpu_storage        voidptr
+	yield_await        klock.Lock
+	timeslice          u64
+	which_event        u64
+	exit_value         voidptr
+	exited             eventstruct.Event
+	sigentry           u64
+	sigactions         [256]SigAction
+	pending_signals    u64
+	masked_signals     u64
 	enqueued_by_signal bool
-	stacks []voidptr
-	signalfds_lock klock.Lock
-	signalfds []voidptr
+	stacks             []voidptr
+	signalfds_lock     klock.Lock
+	signalfds          []voidptr
 }
 
 pub fn current_thread() &Thread {
 	mut ret := &Thread(0)
 
 	asm volatile amd64 {
-		mov ret, gs:[8] // get self
+		mov ret, [8] // get self
 		; =r (ret)
 	}
 

--- a/kernel/modules/resource/resource.v
+++ b/kernel/modules/resource/resource.v
@@ -7,27 +7,42 @@ import errno
 import event.eventstruct
 
 pub const o_accmode = 0x0007
-pub const o_exec    = 1
-pub const o_rdonly  = 2
-pub const o_rdwr    = 3
-pub const o_search  = 4
-pub const o_wronly  = 5
 
-pub const o_append    = 0x0008
-pub const o_creat     = 0x0010
+pub const o_exec = 1
+
+pub const o_rdonly = 2
+
+pub const o_rdwr = 3
+
+pub const o_search = 4
+
+pub const o_wronly = 5
+
+pub const o_append = 0x0008
+
+pub const o_creat = 0x0010
+
 pub const o_directory = 0x0020
-pub const o_excl      = 0x0040
-pub const o_noctty    = 0x0080
-pub const o_nofollow  = 0x0100
-pub const o_trunc     = 0x0200
-pub const o_nonblock  = 0x0400
-pub const o_dsync     = 0x0800
-pub const o_rsync     = 0x1000
-pub const o_sync      = 0x2000
-pub const o_cloexec   = 0x4000
 
-pub const file_creation_flags_mask = o_creat | o_directory | o_excl | o_noctty |
-									 o_nofollow | o_trunc
+pub const o_excl = 0x0040
+
+pub const o_noctty = 0x0080
+
+pub const o_nofollow = 0x0100
+
+pub const o_trunc = 0x0200
+
+pub const o_nonblock = 0x0400
+
+pub const o_dsync = 0x0800
+
+pub const o_rsync = 0x1000
+
+pub const o_sync = 0x2000
+
+pub const o_cloexec = 0x4000
+
+pub const file_creation_flags_mask = o_creat | o_directory | o_excl | o_noctty | o_nofollow | o_trunc
 
 pub const file_descriptor_flags_mask = o_cloexec
 
@@ -35,13 +50,12 @@ pub const file_status_flags_mask = ~(file_creation_flags_mask | file_descriptor_
 
 interface Resource {
 mut:
-	stat     stat.Stat
+	stat stat.Stat
 	refcount int
-	l        klock.Lock
-	event    eventstruct.Event
-	status   int
+	l klock.Lock
+	event eventstruct.Event
+	status int
 	can_mmap bool
-
 	grow(handle voidptr, new_size u64) ?
 	read(handle voidptr, buf voidptr, loc u64, count u64) ?i64
 	write(handle voidptr, buf voidptr, loc u64, count u64) ?i64

--- a/kernel/modules/socket/netlink/netlink.v
+++ b/kernel/modules/socket/netlink/netlink.v
@@ -7,15 +7,19 @@ import errno
 import socket.public as sock_pub
 
 pub const netlink_route = 0
+
 pub const netlink_usersock = 2
+
 pub const netlink_firewall = 3
+
 pub const netlink_ip6_fw = 13
+
 pub const netlink_kobject_uevent = 15
 
 struct SockaddrNL {
 	nl_family u32
-	nl_pad u16
-	nl_pid u32
+	nl_pad    u16
+	nl_pid    u32
 	nl_groups u32
 }
 
@@ -28,9 +32,9 @@ mut:
 	can_mmap bool
 	event    eventstruct.Event
 
-	name SockaddrNL
+	name      SockaddrNL
 	listening bool
-	backlog []&NetlinkSocket
+	backlog   []&NetlinkSocket
 }
 
 fn (mut this NetlinkSocket) mmap(page u64, flags int) voidptr {
@@ -74,5 +78,7 @@ fn (mut this NetlinkSocket) listen(handle voidptr, backlog int) ? {
 }
 
 pub fn create(@type int, protocol int) ?&NetlinkSocket {
-	return &NetlinkSocket{refcount: 1}
+	return &NetlinkSocket{
+		refcount: 1
+	}
 }

--- a/kernel/modules/socket/public/public.v
+++ b/kernel/modules/socket/public/public.v
@@ -1,11 +1,17 @@
 module public
 
 pub const af_inet = 1
+
 pub const af_inet6 = 2
+
 pub const af_unix = 3
+
 pub const af_local = 3
+
 pub const af_unspec = 4
+
 pub const af_netlink = 5
 
 pub const sock_nonblock = 0x10000
+
 pub const sock_cloexec = 0x20000

--- a/kernel/modules/socket/socket.v
+++ b/kernel/modules/socket/socket.v
@@ -3,9 +3,7 @@ module socket
 import resource
 import file
 import errno
-
 import socket.public as sock_pub
-
 import socket.unix as sock_unix
 import socket.netlink as sock_netlink
 
@@ -17,7 +15,8 @@ fn socketpair_create(domain int, @type int, protocol int) ?(&resource.Resource, 
 			socket0, socket1 := sock_unix.create_pair(@type) ?
 			return &resource.Resource(*socket0), &resource.Resource(*socket1)
 		}
-		/*sock_pub.af_netlink {
+		/*
+		sock_pub.af_netlink {
 			socket0, socket1 := sock_netlink.create_pair(@type, protocol) ?
 			return socket0, socket1
 		}*/
@@ -48,7 +47,8 @@ fn socket_create(domain int, @type int, protocol int) ?&resource.Resource {
 }
 
 pub fn syscall_socketpair(_ voidptr, domain int, @type int, protocol int, ret &int) (u64, u64) {
-	C.printf(c'\n\e[32mstrace\e[m: socketpair(%d, 0x%x, %d, 0x%llx)\n', domain, @type, protocol, voidptr(ret))
+	C.printf(c'\n\e[32mstrace\e[m: socketpair(%d, 0x%x, %d, 0x%llx)\n', domain, @type,
+		protocol, voidptr(ret))
 	defer {
 		C.printf(c'\e[32mstrace\e[m: returning\n')
 	}
@@ -71,7 +71,6 @@ pub fn syscall_socketpair(_ voidptr, domain int, @type int, protocol int, ret &i
 			return -1, errno.get()
 		}
 	}
-
 	return 0, 0
 }
 
@@ -81,9 +80,7 @@ pub fn syscall_socket(_ voidptr, domain int, @type int, protocol int) (u64, u64)
 		C.printf(c'\e[32mstrace\e[m: returning\n')
 	}
 
-	mut socket := socket_create(domain, @type, protocol) or {
-		return -1, errno.get()
-	}
+	mut socket := socket_create(domain, @type, protocol) or { return -1, errno.get() }
 
 	mut flags := int(0)
 	if @type & sock_pub.sock_cloexec != 0 {
@@ -103,16 +100,12 @@ pub fn syscall_bind(_ voidptr, fdnum int, _addr voidptr, addrlen u64) (u64, u64)
 		C.printf(c'\e[32mstrace\e[m: returning\n')
 	}
 
-	mut fd := file.fd_from_fdnum(voidptr(0), fdnum) or {
-		return -1, errno.get()
-	}
+	mut fd := file.fd_from_fdnum(voidptr(0), fdnum) or { return -1, errno.get() }
 	defer {
 		fd.unref()
 	}
 
-	fd.handle.resource.bind(fd.handle, _addr, addrlen) or {
-		return -1, errno.get()
-	}
+	fd.handle.resource.bind(fd.handle, _addr, addrlen) or { return -1, errno.get() }
 
 	return 0, 0
 }
@@ -123,16 +116,12 @@ pub fn syscall_listen(_ voidptr, fdnum int, backlog int) (u64, u64) {
 		C.printf(c'\e[32mstrace\e[m: returning\n')
 	}
 
-	mut fd := file.fd_from_fdnum(voidptr(0), fdnum) or {
-		return -1, errno.get()
-	}
+	mut fd := file.fd_from_fdnum(voidptr(0), fdnum) or { return -1, errno.get() }
 	defer {
 		fd.unref()
 	}
 
-	fd.handle.resource.listen(fd.handle, backlog) or {
-		return -1, errno.get()
-	}
+	fd.handle.resource.listen(fd.handle, backlog) or { return -1, errno.get() }
 
 	return 0, 0
 }

--- a/kernel/modules/socket/unix/unix.v
+++ b/kernel/modules/socket/unix/unix.v
@@ -22,9 +22,9 @@ mut:
 	can_mmap bool
 	event    eventstruct.Event
 
-	name SockaddrUn
+	name      SockaddrUn
 	listening bool
-	backlog []&UnixSocket
+	backlog   []&UnixSocket
 }
 
 fn (mut this UnixSocket) mmap(page u64, flags int) voidptr {
@@ -78,11 +78,17 @@ fn (mut this UnixSocket) listen(handle voidptr, backlog int) ? {
 }
 
 pub fn create(@type int) ?&UnixSocket {
-	return &UnixSocket{refcount: 1}
+	return &UnixSocket{
+		refcount: 1
+	}
 }
 
 pub fn create_pair(@type int) ?(&UnixSocket, &UnixSocket) {
-	mut a := &UnixSocket{refcount: 1}
-	mut b := &UnixSocket{refcount: 1}
+	mut a := &UnixSocket{
+		refcount: 1
+	}
+	mut b := &UnixSocket{
+		refcount: 1
+	}
 	return a, b
 }

--- a/kernel/modules/stat/stat.v
+++ b/kernel/modules/stat/stat.v
@@ -6,23 +6,51 @@ pub mut:
 	tv_nsec i64
 }
 
-pub const ifmt   = 0xf000
-pub const ifblk  = 0x6000
-pub const ifchr  = 0x2000
-pub const ififo  = 0x1000
-pub const ifreg  = 0x8000
-pub const ifdir  = 0x4000
-pub const iflnk  = 0xa000
+pub const ifmt = 0xf000
+
+pub const ifblk = 0x6000
+
+pub const ifchr = 0x2000
+
+pub const ififo = 0x1000
+
+pub const ifreg = 0x8000
+
+pub const ifdir = 0x4000
+
+pub const iflnk = 0xa000
+
 pub const ifsock = 0xc000
+
 pub const ifpipe = 0x3000
 
-pub fn isblk(mode int) bool { return (mode & ifmt) == ifblk }
-pub fn ischr(mode int) bool { return (mode & ifmt) == ifchr }
-pub fn isifo(mode int) bool { return (mode & ifmt) == ififo }
-pub fn isreg(mode int) bool { return (mode & ifmt) == ifreg }
-pub fn isdir(mode int) bool { return (mode & ifmt) == ifdir }
-pub fn islnk(mode int) bool { return (mode & ifmt) == iflnk }
-pub fn issock(mode int) bool { return (mode & ifmt) == ifsock }
+pub fn isblk(mode int) bool {
+	return (mode & stat.ifmt) == stat.ifblk
+}
+
+pub fn ischr(mode int) bool {
+	return (mode & stat.ifmt) == stat.ifchr
+}
+
+pub fn isifo(mode int) bool {
+	return (mode & stat.ifmt) == stat.ififo
+}
+
+pub fn isreg(mode int) bool {
+	return (mode & stat.ifmt) == stat.ifreg
+}
+
+pub fn isdir(mode int) bool {
+	return (mode & stat.ifmt) == stat.ifdir
+}
+
+pub fn islnk(mode int) bool {
+	return (mode & stat.ifmt) == stat.iflnk
+}
+
+pub fn issock(mode int) bool {
+	return (mode & stat.ifmt) == stat.ifsock
+}
 
 pub struct Stat {
 pub mut:
@@ -42,13 +70,21 @@ pub mut:
 }
 
 pub const dt_unknown = 0
+
 pub const dt_fifo = 1
+
 pub const dt_chr = 2
+
 pub const dt_dir = 4
+
 pub const dt_blk = 6
+
 pub const dt_reg = 8
+
 pub const dt_lnk = 10
+
 pub const dt_sock = 12
+
 pub const dt_wht = 14
 
 pub struct Dirent {

--- a/kernel/modules/stivale2/stivale2.v
+++ b/kernel/modules/stivale2/stivale2.v
@@ -4,10 +4,15 @@ import klock
 import x86.cpu
 
 pub const framebuffer_id = 0x506461d2950408fa
+
 pub const memmap_id = 0x2187f79e8612de07
+
 pub const terminal_id = 0xc2b3f4c3233b0974
+
 pub const rsdp_id = 0x9e1786930a375e78
+
 pub const modules_id = 0x4b6fe466aade04ce
+
 pub const smp_id = 0x34d1d96339647025
 
 [packed]
@@ -102,7 +107,8 @@ struct MemmapTag {
 pub mut:
 	tag         Tag
 	entry_count u64
-	entries     MemmapEntry // This is a var length array at the end.
+	entries     MemmapEntry
+	// This is a var length array at the end.
 }
 
 [packed]
@@ -147,11 +153,11 @@ pub fn get_tag(stivale2_struct &Struct, id u64) ?voidptr {
 
 __global (
 	terminal_print_lock klock.Lock
-	terminal_print_ptr = voidptr(0)
-	terminal_rows = u16(0)
-	terminal_cols = u16(0)
-	framebuffer_width = u16(0)
-	framebuffer_height = u16(0)
+	terminal_print_ptr  = voidptr(0)
+	terminal_rows       = u16(0)
+	terminal_cols       = u16(0)
+	framebuffer_width   = u16(0)
+	framebuffer_height  = u16(0)
 )
 
 pub fn terminal_init(stivale2_struct &Struct) {

--- a/kernel/modules/syscall/syscall.v
+++ b/kernel/modules/syscall/syscall.v
@@ -4,7 +4,9 @@ import x86.cpu.local as cpulocal
 import userland
 
 fn leave(context &cpulocal.GPRState) {
-	asm volatile amd64 { cli }
+	asm volatile amd64 {
+		cli
+	}
 
 	userland.dispatch_a_signal(context)
 }
@@ -12,21 +14,15 @@ fn leave(context &cpulocal.GPRState) {
 [_naked]
 fn syscall_entry() {
 	asm volatile amd64 {
-		swapgs
-
-		// Save user stack
-		mov gs:[32], rsp
-		// Switch to kernel stack
-		mov rsp, gs:[24]
-
+		swapgs // Save user stack
+		mov [32], rsp // Switch to kernel stack
+		mov rsp, [24]
 		push 0x3b
-		push gs:[32]
+		push [32]
 		push r11
 		push 0x43
 		push rcx
-
 		push 0
-
 		push r15
 		push r14
 		push r13
@@ -46,25 +42,18 @@ fn syscall_entry() {
 		push rax
 		mov eax, ds
 		push rax
-
-		sti
-
-		// syscall num
-		mov gs:[40], rdi
-
+		sti // syscall num
+		mov [40], rdi
 		xor rbp, rbp
 		mov rbx, rdi
 		mov rcx, r10
 		mov rdi, rsp
 		lea rax, [rip + syscall_table]
 		call [rax + rbx * 8 + 0]
-
 		mov [rsp + 16], rax
 		mov [rsp + 40], rdx
-
 		mov rdi, rsp
 		call syscall__leave
-
 		pop rax
 		mov ds, eax
 		pop rax
@@ -83,17 +72,10 @@ fn syscall_entry() {
 		pop r12
 		pop r13
 		pop r14
-		pop r15
-
-		// Restore user stack
-		mov rsp, gs:[32]
-
+		pop r15 // Restore user stack
+		mov rsp, [32]
 		swapgs
-
 		rex.w sysret
-
-		;
-		;
-		; memory
+		; ; ; memory
 	}
 }

--- a/kernel/modules/termios/termios.v
+++ b/kernel/modules/termios/termios.v
@@ -1,27 +1,47 @@
 module termios
 
 pub const echo = 0x0001
+
 pub const echoe = 0x0002
+
 pub const echok = 0x0004
+
 pub const echonl = 0x0008
+
 pub const icanon = 0x0010
+
 pub const iexten = 0x0020
+
 pub const isig = 0x0040
+
 pub const noflsh = 0x0080
+
 pub const tostop = 0x0100
+
 pub const echoprt = 0x0200
 
 pub const nccs = 11
+
 pub const veof = 0
+
 pub const veol = 1
+
 pub const verase = 2
+
 pub const vintr = 3
+
 pub const vkill = 4
+
 pub const vmin = 5
+
 pub const vquit = 6
+
 pub const vstart = 7
+
 pub const vstop = 8
+
 pub const vsusp = 9
+
 pub const vtime = 10
 
 pub struct Termios {
@@ -30,7 +50,7 @@ pub mut:
 	c_oflag u32
 	c_cflag u32
 	c_lflag u32
-	c_cc [nccs]u32
-	ibaud u32
-	obaud u32
+	c_cc    [nccs]u32
+	ibaud   u32
+	obaud   u32
 }

--- a/kernel/modules/trace/trace.v
+++ b/kernel/modules/trace/trace.v
@@ -15,7 +15,7 @@ pub fn address(addr u64) ?(u64, &Symbol) {
 
 	symbol_table := C.get_symbol_table()
 
-	for i := u64(0); ; i++ {
+	for i := u64(0); true; i++ {
 		if unsafe { symbol_table[i].address } == 0xffffffffffffffff {
 			return none
 		}
@@ -32,9 +32,7 @@ pub fn address(addr u64) ?(u64, &Symbol) {
 }
 
 pub fn address_print(addr u64) ? {
-	off, sym := address(addr) or {
-		return error('')
-	}
+	off, sym := address(addr) or { return error('') }
 	C.printf_panic(c'  [0x%llx] <%s+0x%llx>\n', addr, sym.name, off)
 }
 
@@ -45,7 +43,7 @@ pub fn stacktrace(_base_ptr u64) {
 		asm volatile amd64 {
 			mov base_ptr, rbp
 			; =g (base_ptr)
-			;; memory
+			; ; memory
 		}
 	}
 
@@ -60,9 +58,7 @@ pub fn stacktrace(_base_ptr u64) {
 			if ret_addr == 0 || old_bp == 0 {
 				break
 			}
-			address_print(ret_addr) or {
-				break
-			}
+			address_print(ret_addr) or { break }
 			base_ptr = old_bp
 		}
 	}

--- a/kernel/modules/userland/signalfd.v
+++ b/kernel/modules/userland/signalfd.v
@@ -9,24 +9,24 @@ import file
 import errno
 
 struct SFDSiginfo {
-	ssi_signo u32
-	ssi_errno i32
-	ssi_code i32
-	ssi_pid u32
-	ssi_uid u32
-	ssi_fd i32
-	ssi_tid u32
-	ssi_band u32
-	ssi_overrun u32
-	ssi_trapno u32
-	ssi_status i32
-	ssi_int i32
-	ssi_ptr u64
-	ssi_utime u64
-	ssi_stime u64
-	ssi_addr u64
+	ssi_signo    u32
+	ssi_errno    i32
+	ssi_code     i32
+	ssi_pid      u32
+	ssi_uid      u32
+	ssi_fd       i32
+	ssi_tid      u32
+	ssi_band     u32
+	ssi_overrun  u32
+	ssi_trapno   u32
+	ssi_status   i32
+	ssi_int      i32
+	ssi_ptr      u64
+	ssi_utime    u64
+	ssi_stime    u64
+	ssi_addr     u64
 	ssi_addr_lsb u16
-	pad [46]u8
+	pad          [46]u8
 }
 
 struct SignalFD {
@@ -38,7 +38,7 @@ pub mut:
 	can_mmap bool
 	event    eventstruct.Event
 
-	mask u64
+	mask  u64
 	queue []&SFDSiginfo
 }
 
@@ -91,7 +91,9 @@ pub fn syscall_signalfd(_ voidptr, fdnum int, mask u64, flags int) (u64, u64) {
 	}
 
 	if fdnum == -1 {
-		signalfd = &SignalFD{refcount: 1}
+		signalfd = &SignalFD{
+			refcount: 1
+		}
 
 		newfd = file.fdnum_create_from_resource(voidptr(0), mut signalfd, flags, 0, false) or {
 			return -1, errno.get()
@@ -99,9 +101,7 @@ pub fn syscall_signalfd(_ voidptr, fdnum int, mask u64, flags int) (u64, u64) {
 
 		thread.signalfds << voidptr(signalfd)
 	} else {
-		mut fd := file.fd_from_fdnum(voidptr(0), fdnum) or {
-			return -1, errno.get()
-		}
+		mut fd := file.fd_from_fdnum(voidptr(0), fdnum) or { return -1, errno.get() }
 
 		signalfd = unsafe { &SignalFD(fd.handle.resource) }
 

--- a/kernel/modules/x86/cpu/cpu.v
+++ b/kernel/modules/x86/cpu/cpu.v
@@ -1,6 +1,6 @@
 module cpu
 
-import msr
+import x86.msr
 
 pub fn interrupt_state() bool {
 	mut f := u64(0)
@@ -15,9 +15,15 @@ pub fn interrupt_state() bool {
 pub fn interrupt_toggle(state bool) bool {
 	ret := interrupt_state()
 	if state == false {
-		asm volatile amd64 { cli ;;; memory }
+		asm volatile amd64 {
+			cli
+			; ; ; memory
+		}
 	} else {
-		asm volatile amd64 { sti ;;; memory }
+		asm volatile amd64 {
+			sti
+			; ; ; memory
+		}
 	}
 	return ret
 }
@@ -71,8 +77,7 @@ pub fn read_cr0() u64 {
 	asm volatile amd64 {
 		mov ret, cr0
 		; =r (ret)
-		;
-		; memory
+		; ; memory
 	}
 	return ret
 }
@@ -80,8 +85,7 @@ pub fn read_cr0() u64 {
 pub fn write_cr0(value u64) {
 	asm volatile amd64 {
 		mov cr0, value
-		;
-		; r (value)
+		; ; r (value)
 		; memory
 	}
 }
@@ -91,8 +95,7 @@ pub fn read_cr2() u64 {
 	asm volatile amd64 {
 		mov ret, cr2
 		; =r (ret)
-		;
-		; memory
+		; ; memory
 	}
 	return ret
 }
@@ -100,8 +103,7 @@ pub fn read_cr2() u64 {
 pub fn write_cr2(value u64) {
 	asm volatile amd64 {
 		mov cr2, value
-		;
-		; r (value)
+		; ; r (value)
 		; memory
 	}
 }
@@ -111,8 +113,7 @@ pub fn read_cr3() u64 {
 	asm volatile amd64 {
 		mov ret, cr3
 		; =r (ret)
-		;
-		; memory
+		; ; memory
 	}
 	return ret
 }
@@ -120,8 +121,7 @@ pub fn read_cr3() u64 {
 pub fn write_cr3(value u64) {
 	asm volatile amd64 {
 		mov cr3, value
-		;
-		; r (value)
+		; ; r (value)
 		; memory
 	}
 }
@@ -131,8 +131,7 @@ pub fn read_cr4() u64 {
 	asm volatile amd64 {
 		mov ret, cr4
 		; =r (ret)
-		;
-		; memory
+		; ; memory
 	}
 	return ret
 }
@@ -140,8 +139,7 @@ pub fn read_cr4() u64 {
 pub fn write_cr4(value u64) {
 	asm volatile amd64 {
 		mov cr4, value
-		;
-		; r (value)
+		; ; r (value)
 		; memory
 	}
 }
@@ -151,8 +149,7 @@ pub fn wrxcr(reg u32, value u64) {
 	d := u32(value >> 32)
 	asm volatile amd64 {
 		xsetbv
-		;
-		; a (a)
+		; ; a (a)
 		  d (d)
 		  c (reg)
 		; memory
@@ -204,8 +201,7 @@ pub fn rdseed32() u32 {
 fn xsave(region voidptr) {
 	asm volatile amd64 {
 		xsave [region]
-		;
-		; r (region)
+		; ; r (region)
 		  a (0xffffffff)
 		  d (0xffffffff)
 		; memory
@@ -215,8 +211,7 @@ fn xsave(region voidptr) {
 fn xrstor(region voidptr) {
 	asm volatile amd64 {
 		xrstor [region]
-		;
-		; r (region)
+		; ; r (region)
 		  a (0xffffffff)
 		  d (0xffffffff)
 		; memory
@@ -226,8 +221,7 @@ fn xrstor(region voidptr) {
 fn fxsave(region voidptr) {
 	asm volatile amd64 {
 		fxsave [region]
-		;
-		; r (region)
+		; ; r (region)
 		; memory
 	}
 }
@@ -235,14 +229,15 @@ fn fxsave(region voidptr) {
 fn fxrstor(region voidptr) {
 	asm volatile amd64 {
 		fxrstor [region]
-		;
-		; r (region)
+		; ; r (region)
 		; memory
 	}
 }
 
 pub const cpuid_xsave = u32(1 << 26)
+
 pub const cpuid_avx = u32(1 << 28)
+
 pub const cpuid_avx512 = u32(1 << 16)
 
 pub fn cpuid(leaf u32, subleaf u32) (bool, u32, u32, u32, u32) {

--- a/kernel/modules/x86/cpu/local/local.v
+++ b/kernel/modules/x86/cpu/local/local.v
@@ -58,7 +58,7 @@ pub mut:
 	tss                  TSS
 	lapic_id             u32
 	lapic_timer_freq     u64
-	online				 u64
+	online               u64
 	is_idle              bool
 	nvme_io_queue_pair   voidptr
 	last_run_queue_index int
@@ -80,7 +80,7 @@ pub fn current() &Local {
 
 	mut cpu_number := u64(0)
 	asm volatile amd64 {
-		mov cpu_number, gs:[0]
+		mov cpu_number, [0]
 		; =r (cpu_number)
 	}
 	return cpu_locals[cpu_number]

--- a/kernel/modules/x86/gdt/gdt.v
+++ b/kernel/modules/x86/gdt/gdt.v
@@ -21,11 +21,11 @@ struct GDTEntry {
 __global (
 	kernel_code_seg = u16(0x28)
 	kernel_data_seg = u16(0x30)
-	user_code_seg = u16(0x43)
-	user_data_seg = u16(0x3b)
+	user_code_seg   = u16(0x43)
+	user_data_seg   = u16(0x3b)
 	gdt_pointer     GDTPointer
 	gdt_entries     [11]GDTEntry
-	gdt_lock klock.Lock
+	gdt_lock        klock.Lock
 )
 
 pub fn initialise() {
@@ -144,8 +144,7 @@ pub fn reload() {
 		mov ss, dseg
 		mov fs, udseg
 		mov gs, udseg
-		;
-		; m (gdt_pointer) as ptr
+		; ; m (gdt_pointer) as ptr
 		  rm (u64(kernel_code_seg)) as cseg
 		  rm (u32(kernel_data_seg)) as dseg
 		  rm (u32(user_data_seg)) as udseg
@@ -173,8 +172,7 @@ pub fn load_tss(addr voidptr) {
 
 	asm volatile amd64 {
 		ltr offset
-		;
-		; rm (u16(0x48)) as offset
+		; ; rm (u16(0x48)) as offset
 		; memory
 	}
 

--- a/kernel/modules/x86/idt/idt.v
+++ b/kernel/modules/x86/idt/idt.v
@@ -21,10 +21,10 @@ pub mut:
 }
 
 __global (
-	idt_pointer IDTPointer
-	idt_entries [256]IDTEntry
+	idt_pointer     IDTPointer
+	idt_entries     [256]IDTEntry
 	idt_free_vector = byte(32)
-	idt_lock klock.Lock
+	idt_lock        klock.Lock
 )
 
 pub fn allocate_vector() byte {
@@ -39,7 +39,7 @@ pub fn allocate_vector() byte {
 
 __global (
 	interrupt_thunks [256]voidptr
-	interrupt_table [256]voidptr
+	interrupt_table  [256]voidptr
 )
 
 #include <symbols.h>
@@ -73,7 +73,6 @@ fn prepare_interrupt_thunks() {
 				14 { 2 }
 				17 { 2 }
 				30 { 2 }
-
 				else { 0 }
 			}
 
@@ -96,8 +95,7 @@ pub fn reload() {
 
 	asm volatile amd64 {
 		lidt ptr
-		;
-		; m (idt_pointer) as ptr
+		; ; m (idt_pointer) as ptr
 		; memory
 	}
 }

--- a/kernel/modules/x86/kio/kio.v
+++ b/kernel/modules/x86/kio/kio.v
@@ -14,8 +14,7 @@ pub fn port_in<T>(port u16) T {
 pub fn port_out<T>(port u16, value T) {
 	asm volatile amd64 {
 		out port, value
-		;
-		; a (value)
+		; ; a (value)
 		  Nd (port)
 		; memory
 	}
@@ -35,8 +34,7 @@ pub fn mmin<T>(addr &T) T {
 pub fn mmout<T>(addr &T, value T) {
 	asm volatile amd64 {
 		mov [addr], value
-		;
-		; r (addr)
+		; ; r (addr)
 		  r (value)
 		; memory
 	}

--- a/kernel/modules/x86/msr/msr.v
+++ b/kernel/modules/x86/msr/msr.v
@@ -18,8 +18,7 @@ pub fn wrmsr(msr u32, value u64) {
 	edx := value >> 32
 	asm volatile amd64 {
 		wrmsr
-		;
-		; a (eax)
+		; ; a (eax)
 		  d (edx)
 		  c (msr)
 		; memory

--- a/kernel/modules/x86/smp/smp.v
+++ b/kernel/modules/x86/smp/smp.v
@@ -3,8 +3,8 @@ module smp
 import stivale2
 import memory
 import katomic
-import cpu.local as cpulocal
-import cpu.initialisation as cpuinit
+import x86.cpu.local as cpulocal
+import x86.cpu.initialisation as cpuinit
 
 __global (
 	bsp_lapic_id = u32(0)
@@ -12,7 +12,7 @@ __global (
 
 pub fn initialise(smp_tag &stivale2.SMPTag) {
 	println('smp: BSP LAPIC ID:    ${smp_tag.bsp_lapic_id:x}')
-	println('smp: Total CPU count: ${smp_tag.cpu_count}')
+	println('smp: Total CPU count: $smp_tag.cpu_count')
 
 	smp_info_array := unsafe { &stivale2.SMPInfo(&smp_tag.smp_info) }
 


### PR DESCRIPTION
I ran `v fmt -w .` over the Vinix kernel.
(Due to a V/fmt bug I needed to manually adjust the output by removing two `.`s)