### PR TITLE
v: support new contraint of v with usafe {} block

### DIFF
--- a/kernel/modules/fs/devtmpfs.v
+++ b/kernel/modules/fs/devtmpfs.v
@@ -155,7 +155,7 @@ fn (mut this DevTmpFS) mount(parent &VFSNode, name string, source &VFSNode) ?&VF
 	if devtmpfs_dev_id == 0 {
 		devtmpfs_dev_id = resource.create_dev_id()
 	}
-	if devtmpfs_root == 0 {
+	if unsafe { devtmpfs_root == 0 } {
 		// XXX this will break if devtmpfs is mounted more than once
 		devtmpfs_root = this.create(parent, name, 0o644 | stat.ifdir)
 	}

--- a/kernel/modules/fs/vfs.v
+++ b/kernel/modules/fs/vfs.v
@@ -84,15 +84,15 @@ pub fn initialise() {
 }
 
 fn reduce_node(node &VFSNode, follow_symlinks bool) &VFSNode {
-	if node.redir != 0 {
+	if unsafe { node.redir != 0 } {
 		return reduce_node(node.redir, follow_symlinks)
 	}
-	if node.mountpoint != 0 {
+	if unsafe { node.mountpoint != 0 } {
 		return reduce_node(node.mountpoint, follow_symlinks)
 	}
 	if node.symlink_target.len != 0 && follow_symlinks == true {
 		_, next_node, _ := path2node(node.parent, node.symlink_target)
-		if next_node == 0 {
+		if unsafe { next_node == 0 } {
 			return 0
 		}
 		return reduce_node(next_node, follow_symlinks)
@@ -314,7 +314,7 @@ pub fn pathname(node &VFSNode) string {
 pub fn symlink(parent &VFSNode, dest string, target string) ?&VFSNode {
 	mut parent_of_tgt_node, mut target_node, basename := path2node(parent, target)
 
-	if target_node != 0 || parent_of_tgt_node == 0 {
+	if unsafe { target_node != 0 } || parent_of_tgt_node == 0 {
 		errno.set(errno.eexist)
 		return none
 	}
@@ -354,12 +354,12 @@ pub fn create(parent &VFSNode, name string, mode int) ?&VFSNode {
 pub fn internal_create(parent &VFSNode, name string, mode int) ?&VFSNode {
 	mut parent_of_tgt_node, mut target_node, basename := path2node(parent, name)
 
-	if target_node != 0 {
+	if unsafe { target_node != 0 } {
 		errno.set(errno.eexist)
 		return none
 	}
 
-	if parent_of_tgt_node == 0 {
+	if unsafe { parent_of_tgt_node == 0 } {
 		errno.set(errno.enoent)
 		return none
 	}
@@ -420,11 +420,11 @@ pub fn syscall_mkdirat(_ voidptr, dirfd int, _path charptr, mode int) (u64, u64)
 
 	mut parent_of_tgt_node, mut target_node, basename := path2node(parent, path)
 
-	if parent_of_tgt_node == 0 {
+	if unsafe { parent_of_tgt_node == 0 } {
 		return -1, errno.enoent
 	}
 
-	if target_node != 0 {
+	if unsafe { target_node != 0 } {
 		return -1, errno.eexist
 	}
 
@@ -496,7 +496,7 @@ pub fn syscall_openat(_ voidptr, dirfd int, _path charptr, flags int, mode int) 
 		}
 	}
 
-	if node == 0 {
+	if unsafe { node == 0 } {
 		return -1, errno.get()
 	}
 

--- a/kernel/modules/sched/sched.v
+++ b/kernel/modules/sched/sched.v
@@ -51,7 +51,7 @@ fn get_next_thread(orig_i int) int {
 
 		mut thread := scheduler_running_queue[index]
 
-		if thread != 0 {
+		if unsafe { thread != 0 } {
 			if katomic.load(thread.running_on) == cpu_number || thread.l.test_and_acquire() == true {
 				return index
 			}
@@ -80,7 +80,7 @@ fn scheduler_isr(_ u32, gpr_state &cpulocal.GPRState) {
 
 	new_index := get_next_thread(cpu_local.last_run_queue_index)
 
-	if current_thread != 0 {
+	if unsafe { current_thread != 0 } {
 		current_thread.yield_await.release()
 
 		if new_index == cpu_local.last_run_queue_index {
@@ -534,7 +534,7 @@ pub fn new_process(old_process &proc.Process, pagemap &memory.Pagemap) ?&proc.Pr
 	new_process.threads = []&proc.Thread{}
 	new_process.children = []&proc.Process{}
 
-	if old_process != 0 {
+	if unsafe { old_process != 0 } {
 		new_process.ppid = old_process.pid
 		new_process.pagemap = mmap.fork_pagemap(old_process.pagemap) or { return none }
 		new_process.thread_stack_top = old_process.thread_stack_top


### PR DESCRIPTION
This should be cover all the unsafe comparisons due the compiler error added by the following PR https://github.com/vlang/v/pull/14462

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>