### PR TITLE
Fix doomgeneric patch DG_SleepMs

### DIFF
--- a/patches/doomgeneric/0001-Vinix-specific-changes.patch
+++ b/patches/doomgeneric/0001-Vinix-specific-changes.patch
@@ -261,7 +261,7 @@ index 0000000..ba84c2d
 +  handleKeyInput();
 +}
 +
-+void DG_SleepMs(uint32_t ms) { usleep(ms * 1000000); }
++void DG_SleepMs(uint32_t ms) { usleep(ms * 1000); }
 +
 +uint32_t DG_GetTicksMs() {
 +  struct timeval tp;


### PR DESCRIPTION
This PR fixes the conversion from milliseconds to microseconds in the DG_SleepMs function of the doomgeneric patch.