### PR TITLE
Add lingemu and Bochs booting from makefile.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -40,7 +40,10 @@ ovmf:
 .PHONY: run-uefi
 run-uefi: ovmf
 	qemu-system-x86_64 -enable-kvm -cpu host $(QEMUFLAGS) -smp 4 -bios ovmf/OVMF.fd
-
+run-bochs: vinix.iso
+        bochs -f bochsrc
+run-lingemu: vinix.iso 
+        lingemu runvirt -m 8192 --diskcontroller type=ahci,name=ahcibus1 --disk vinix.iso,disktype=cdrom,controller=ahcibus1
 .PHONY: run
 run: vinix.iso
 	qemu-system-x86_64 $(QEMUFLAGS) -no-shutdown -no-reboot -d int -smp 1

--- a/bochsrc
+++ b/bochsrc
@@ -1,0 +1,6 @@
+ata0-slave: type=cdrom, path=vinix.iso, status=inserted
+boot: cdrom
+com1: enabled=1
+memory: guest=1024, host=1024
+clock: sync=none, time0=utc
+cpuid: level=6, fsgsbase=true


### PR DESCRIPTION
This PR adds support for booting from Lingemu virtualizer and Bochs emulator from Makefile. 

This is useful for those that may  want to test on those platforms.