### PR TITLE
fix makefile formatting

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -41,9 +41,9 @@ ovmf:
 run-uefi: ovmf
 	qemu-system-x86_64 -enable-kvm -cpu host $(QEMUFLAGS) -smp 4 -bios ovmf/OVMF.fd
 run-bochs: vinix.iso
-        bochs -f bochsrc
+	bochs -f bochsrc
 run-lingemu: vinix.iso 
-        lingemu runvirt -m 8192 --diskcontroller type=ahci,name=ahcibus1 --disk vinix.iso,disktype=cdrom,controller=ahcibus1
+	lingemu runvirt -m 8192 --diskcontroller type=ahci,name=ahcibus1 --disk vinix.iso,disktype=cdrom,controller=ahcibus1
 .PHONY: run
 run: vinix.iso
 	qemu-system-x86_64 $(QEMUFLAGS) -no-shutdown -no-reboot -d int -smp 1


### PR DESCRIPTION
I couldn't make the project with GNU Make 4.3 on archlinux
`GNUmakefile:44: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.`
`GNUmakefile:46: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.`