### PR TITLE
refactor: rename vars and params to prevent module name shadowing

### DIFF
--- a/kernel/main.v
+++ b/kernel/main.v
@@ -94,7 +94,7 @@ pub fn kmain() {
 	serial.early_initialise()
 
 	// We're alive
-	kprint.kprint(c'Welcome to Vinix\n\n')
+	kprint.kwrite(c'Welcome to Vinix\n\n')
 
 	// a dummy call to avoid V warning about an unused `stubs` module
 	_ := stubs.toupper(0)

--- a/kernel/modules/bitmap/bitmap.v
+++ b/kernel/modules/bitmap/bitmap.v
@@ -13,23 +13,23 @@ mut:
 	entry_cnt  u64
 }
 
-pub fn (mut bitmap GenericBitmap) initialise(entry_cnt u64) {
-	bitmap.entry_cnt = entry_cnt
-	bitmap.raw_bitmap = memory.calloc(lib.div_roundup(entry_cnt, u64(8)), 1)
+pub fn (mut bmp GenericBitmap) initialise(entry_cnt u64) {
+	bmp.entry_cnt = entry_cnt
+	bmp.raw_bitmap = memory.calloc(lib.div_roundup(entry_cnt, u64(8)), 1)
 }
 
-pub fn (bitmap GenericBitmap) alloc() ?u64 {
-	for i := u64(0); i < bitmap.entry_cnt; i++ {
-		if lib.bittest(bitmap.raw_bitmap, i) == false {
-			lib.bitset(bitmap.raw_bitmap, i)
+pub fn (bmp GenericBitmap) alloc() ?u64 {
+	for i := u64(0); i < bmp.entry_cnt; i++ {
+		if lib.bittest(bmp.raw_bitmap, i) == false {
+			lib.bitset(bmp.raw_bitmap, i)
 			return i
 		}
 	}
 	return none
 }
 
-pub fn (bitmap GenericBitmap) free_entry(index u64) {
-	if index < bitmap.entry_cnt {
-		lib.bitreset(bitmap.raw_bitmap, index)
+pub fn (bmp GenericBitmap) free_entry(index u64) {
+	if index < bmp.entry_cnt {
+		lib.bitreset(bmp.raw_bitmap, index)
 	}
 }

--- a/kernel/modules/errno/errno.v
+++ b/kernel/modules/errno/errno.v
@@ -178,6 +178,6 @@ pub fn get() u64 {
 	return proc.current_thread().errno
 }
 
-pub fn set(errno u64) {
-	proc.current_thread().errno = errno
+pub fn set(err_no u64) {
+	proc.current_thread().errno = err_no
 }

--- a/kernel/modules/fs/vfs.v
+++ b/kernel/modules/fs/vfs.v
@@ -266,9 +266,9 @@ pub fn mount(parent &VFSNode, source string, target string, filesystem string) ?
 		return none
 	}
 
-	mut fs := filesystems[filesystem].instantiate()
+	mut f_sys := filesystems[filesystem].instantiate()
 
-	mut mount_node := fs.mount(parent_of_tgt_node, basename, source_node)?
+	mut mount_node := f_sys.mount(parent_of_tgt_node, basename, source_node)?
 
 	target_node.mountpoint = mount_node
 

--- a/kernel/modules/kprint/kprint.v
+++ b/kernel/modules/kprint/kprint.v
@@ -29,7 +29,7 @@ pub fn syscall_kprint(_ voidptr, message charptr) {
 	}
 }
 
-pub fn kprint(message charptr) {
+pub fn kwrite(message charptr) {
 	msglen := unsafe { u64(C.strlen(message)) }
 
 	kprint_lock.acquire()

--- a/kernel/modules/lib/stubs/file.v
+++ b/kernel/modules/lib/stubs/file.v
@@ -53,7 +53,7 @@ pub fn write(fd int, buf &C.void, count u64) i64 {
 		lib.kpanic(voidptr(0), c'write to fd != 1 && fd != 2 is a stub')
 	}
 
-	kprint.kprint(charptr(buf))
+	kprint.kwrite(charptr(buf))
 
 	return i64(count)
 }

--- a/kernel/modules/pipe/pipe.v
+++ b/kernel/modules/pipe/pipe.v
@@ -36,13 +36,13 @@ pub mut:
 pub fn initialise() {}
 
 pub fn create() ?&Pipe {
-	mut pipe := &Pipe{
+	mut p := &Pipe{
 		data: unsafe { C.malloc(pipe.pipe_buf) }
 		capacity: pipe.pipe_buf
 	}
-	pipe.stat.mode = stat.ifpipe
+	p.stat.mode = stat.ifpipe
 
-	return pipe
+	return p
 }
 
 pub fn syscall_pipe(_ voidptr, pipefds &int, flags int) (u64, u64) {

--- a/kernel/modules/socket/socket.v
+++ b/kernel/modules/socket/socket.v
@@ -84,7 +84,7 @@ pub fn syscall_socket(_ voidptr, domain int, @type int, protocol int) (u64, u64)
 		C.printf(c'\e[32m%s\e[m: returning\n', process.name.str)
 	}
 
-	mut socket := socket_create(domain, @type, protocol) or { return errno.err, errno.get() }
+	mut sock := socket_create(domain, @type, protocol) or { return errno.err, errno.get() }
 
 	mut flags := int(0)
 	if @type & sock_pub.sock_cloexec != 0 {
@@ -94,7 +94,7 @@ pub fn syscall_socket(_ voidptr, domain int, @type int, protocol int) (u64, u64)
 		flags |= resource.o_nonblock
 	}
 
-	ret := file.fdnum_create_from_resource(voidptr(0), mut socket, flags, 0, false) or {
+	ret := file.fdnum_create_from_resource(voidptr(0), mut sock, flags, 0, false) or {
 		return errno.err, errno.get()
 	}
 
@@ -117,15 +117,15 @@ pub fn syscall_accept(_ voidptr, fdnum int) (u64, u64) {
 
 	res := fd.handle.resource
 
-	mut socket := &sock_pub.Socket(voidptr(0))
+	mut sock := &sock_pub.Socket(voidptr(0))
 
 	if res is sock_unix.UnixSocket {
-		socket = res
+		sock = res
 	} else {
 		return errno.err, errno.einval
 	}
 
-	mut connection_socket := socket.accept(fd.handle) or {
+	mut connection_socket := sock.accept(fd.handle) or {
 		return errno.err, errno.get()
 	}
 
@@ -152,15 +152,15 @@ pub fn syscall_bind(_ voidptr, fdnum int, _addr voidptr, addrlen u64) (u64, u64)
 
 	res := fd.handle.resource
 
-	mut socket := &sock_pub.Socket(voidptr(0))
+	mut sock := &sock_pub.Socket(voidptr(0))
 
 	if res is sock_unix.UnixSocket {
-		socket = res
+		sock = res
 	} else {
 		return errno.err, errno.einval
 	}
 
-	socket.bind(fd.handle, _addr, addrlen) or { return errno.err, errno.get() }
+	sock.bind(fd.handle, _addr, addrlen) or { return errno.err, errno.get() }
 
 	return 0, 0
 }
@@ -181,15 +181,15 @@ pub fn syscall_listen(_ voidptr, fdnum int, backlog int) (u64, u64) {
 
 	res := fd.handle.resource
 
-	mut socket := &sock_pub.Socket(voidptr(0))
+	mut sock := &sock_pub.Socket(voidptr(0))
 
 	if res is sock_unix.UnixSocket {
-		socket = res
+		sock = res
 	} else {
 		return errno.err, errno.einval
 	}
 
-	socket.listen(fd.handle, backlog) or { return errno.err, errno.get() }
+	sock.listen(fd.handle, backlog) or { return errno.err, errno.get() }
 
 	return 0, 0
 }
@@ -210,15 +210,15 @@ pub fn syscall_recvmsg(_ voidptr, fdnum int, msg &sock_pub.MsgHdr, flags int) (u
 
 	res := fd.handle.resource
 
-	mut socket := &sock_pub.Socket(voidptr(0))
+	mut sock := &sock_pub.Socket(voidptr(0))
 
 	if res is sock_unix.UnixSocket {
-		socket = res
+		sock = res
 	} else {
 		return errno.err, errno.einval
 	}
 
-	ret := socket.recvmsg(fd.handle, msg, flags) or { return errno.err, errno.get() }
+	ret := sock.recvmsg(fd.handle, msg, flags) or { return errno.err, errno.get() }
 
 	return ret, 0
 }
@@ -239,15 +239,15 @@ pub fn syscall_connect(_ voidptr, fdnum int, _addr voidptr, addrlen u64) (u64, u
 
 	res := fd.handle.resource
 
-	mut socket := &sock_pub.Socket(voidptr(0))
+	mut sock := &sock_pub.Socket(voidptr(0))
 
 	if res is sock_unix.UnixSocket {
-		socket = res
+		sock = res
 	} else {
 		return errno.err, errno.einval
 	}
 
-	socket.connect(fd.handle, _addr, addrlen) or { return errno.err, errno.get() }
+	sock.connect(fd.handle, _addr, addrlen) or { return errno.err, errno.get() }
 
 	return 0, 0
 }
@@ -268,15 +268,15 @@ pub fn syscall_getpeername(_ voidptr, fdnum int, _addr voidptr, addrlen &u64) (u
 
 	res := fd.handle.resource
 
-	mut socket := &sock_pub.Socket(voidptr(0))
+	mut sock := &sock_pub.Socket(voidptr(0))
 
 	if res is sock_unix.UnixSocket {
-		socket = res
+		sock = res
 	} else {
 		return errno.err, errno.einval
 	}
 
-	socket.peername(fd.handle, _addr, addrlen) or { return errno.err, errno.get() }
+	sock.peername(fd.handle, _addr, addrlen) or { return errno.err, errno.get() }
 
 	return 0, 0
 }


### PR DESCRIPTION
Ensures the kernel keeps compiling, related to: https://github.com/vlang/v/pull/18118

