### PR TITLE
build: pin jinx version

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ debug:
 	JINX_CONFIG_FILE=jinx-config-debug $(MAKE) all
 
 jinx:
-	curl -o jinx https://raw.githubusercontent.com/mintsuki/jinx/trunk/jinx
+	curl -o jinx https://raw.githubusercontent.com/mintsuki/jinx/eb8976414b2902bec55e61552cd525db7a036256/jinx
 	chmod +x jinx
 
 .PHONY: distro-full


### PR DESCRIPTION
The PR wants to pin jinx to a version that is save to work with vinix.

It might be good to pin a working version to prevent error potential instead of using the latest head commit. I'm submitting this after I came across some smaller problems when testing some commits in the jinx history.

Well different than expected I can't bootstrap it. With the latest jinx commit it's a curl error, with earlier versions I run into permission errors later in the process. 