### PR TITLE
all: change `thread` to `t`, when used as the name of function parameters, or as a local variable name

### DIFF
--- a/kernel/modules/event/event.v
+++ b/kernel/modules/event/event.v
@@ -38,7 +38,7 @@ fn attach_listeners(mut events []&eventstruct.Event, mut t proc.Thread) {
 
 		mut listener := &e.listeners[e.listeners_i]
 
-		listener.t = voidptr(t)
+		listener.thrd = voidptr(t)
 		listener.which = i
 
 		e.listeners_i++
@@ -59,7 +59,7 @@ fn detach_listeners(mut t proc.Thread) {
 		for j := u64(0); j < e.listeners_i; j++ {
 			mut listener := &e.listeners[j]
 
-			if listener.t != voidptr(t) {
+			if listener.thrd != voidptr(t) {
 				continue
 			}
 
@@ -166,7 +166,7 @@ pub fn trigger(mut e eventstruct.Event, drop bool) u64 {
 	}
 
 	for i := u64(0); i < e.listeners_i; i++ {
-		mut t := unsafe { &proc.Thread(e.listeners[i].t) }
+		mut t := unsafe { &proc.Thread(e.listeners[i].thrd) }
 
 		t.which_event = e.listeners[i].which
 

--- a/kernel/modules/event/event.v
+++ b/kernel/modules/event/event.v
@@ -26,8 +26,8 @@ fn check_for_pending(mut events []&eventstruct.Event) ?u64 {
 	return none
 }
 
-fn attach_listeners(mut events []&eventstruct.Event, mut thread proc.Thread) {
-	thread.attached_events_i = 0
+fn attach_listeners(mut events []&eventstruct.Event, mut t proc.Thread) {
+	t.attached_events_i = 0
 
 	for i := u64(0); i < events.len; i++ {
 		mut e := events[i]
@@ -38,28 +38,28 @@ fn attach_listeners(mut events []&eventstruct.Event, mut thread proc.Thread) {
 
 		mut listener := &e.listeners[e.listeners_i]
 
-		listener.thread = voidptr(thread)
+		listener.t = voidptr(t)
 		listener.which = i
 
 		e.listeners_i++
 
-		if thread.attached_events_i == proc.max_events {
+		if t.attached_events_i == proc.max_events {
 			panic('listening on too many events')
 		}
 
-		thread.attached_events[thread.attached_events_i] = e
-		thread.attached_events_i++
+		t.attached_events[t.attached_events_i] = e
+		t.attached_events_i++
 	}
 }
 
-fn detach_listeners(mut thread proc.Thread) {
-	for i := u64(0); i < thread.attached_events_i; i++ {
-		mut e := thread.attached_events[i]
+fn detach_listeners(mut t proc.Thread) {
+	for i := u64(0); i < t.attached_events_i; i++ {
+		mut e := t.attached_events[i]
 
 		for j := u64(0); j < e.listeners_i; j++ {
 			mut listener := &e.listeners[j]
 
-			if listener.thread != voidptr(thread) {
+			if listener.t != voidptr(t) {
 				continue
 			}
 
@@ -70,7 +70,7 @@ fn detach_listeners(mut thread proc.Thread) {
 		}
 	}
 
-	thread.attached_events_i = 0
+	t.attached_events_i = 0
 }
 
 fn lock_events(mut events []&eventstruct.Event) {
@@ -86,7 +86,7 @@ fn unlock_events(mut events []&eventstruct.Event) {
 }
 
 pub fn await(mut events []&eventstruct.Event, block bool) ?u64 {
-	mut thread := proc.current_thread()
+	mut t := proc.current_thread()
 
 	asm volatile amd64 {
 		cli
@@ -111,20 +111,20 @@ pub fn await(mut events []&eventstruct.Event, block bool) ?u64 {
 
 	katomic.inc(waiting_event_count)
 
-	attach_listeners(mut events, mut thread)
+	attach_listeners(mut events, mut t)
 	defer {
 		asm volatile amd64 {
 			cli
 		}
 		lock_events(mut events)
-		detach_listeners(mut thread)
+		detach_listeners(mut t)
 		unlock_events(mut events)
 		asm volatile amd64 {
 			sti
 		}
 	}
 
-	sched.dequeue_thread(thread)
+	sched.dequeue_thread(t)
 
 	unlock_events(mut events)
 
@@ -132,11 +132,11 @@ pub fn await(mut events []&eventstruct.Event, block bool) ?u64 {
 
 	katomic.dec(waiting_event_count)
 
-	if thread.enqueued_by_signal {
+	if t.enqueued_by_signal {
 		return none
 	}
 
-	return thread.which_event
+	return t.which_event
 }
 
 pub fn trigger(mut e eventstruct.Event, drop bool) u64 {
@@ -166,11 +166,11 @@ pub fn trigger(mut e eventstruct.Event, drop bool) u64 {
 	}
 
 	for i := u64(0); i < e.listeners_i; i++ {
-		mut thread := unsafe { &proc.Thread(e.listeners[i].thread) }
+		mut t := unsafe { &proc.Thread(e.listeners[i].t) }
 
-		thread.which_event = e.listeners[i].which
+		t.which_event = e.listeners[i].which
 
-		sched.enqueue_thread(thread, false)
+		sched.enqueue_thread(t, false)
 	}
 
 	ret := e.listeners_i
@@ -200,10 +200,10 @@ pub fn pthread_exit(ret voidptr) {
 	sched.yield(false)
 }
 
-pub fn pthread_wait(thread &proc.Thread) voidptr {
-	mut events := [&thread.exited]
+pub fn pthread_wait(t &proc.Thread) voidptr {
+	mut events := [&t.exited]
 	await(mut events, true) or {}
-	exit_value := thread.exit_value
-	unsafe { free(thread) }
+	exit_value := t.exit_value
+	unsafe { free(t) }
 	return exit_value
 }

--- a/kernel/modules/event/eventstruct/eventstruct.v
+++ b/kernel/modules/event/eventstruct/eventstruct.v
@@ -10,7 +10,7 @@ pub const max_listeners = 32
 
 pub struct EventListener {
 pub mut:
-	thread voidptr
+	thrd voidptr
 	which  u64
 }
 

--- a/kernel/modules/file/epoll.v
+++ b/kernel/modules/file/epoll.v
@@ -180,14 +180,14 @@ pub fn syscall_epoll_pwait(_ voidptr, epfdnum int, ret_events &EPollEvent, maxev
 		return errno.err, errno.einval
 	}
 
-	mut thread := proc.current_thread()
+	mut t := proc.current_thread()
 
-	oldmask := thread.masked_signals
+	oldmask := t.masked_signals
 	if voidptr(sigmask) != unsafe { nil } {
-		thread.masked_signals = unsafe { *sigmask }
+		t.masked_signals = unsafe { *sigmask }
 	}
 	defer {
-		thread.masked_signals = oldmask
+		t.masked_signals = oldmask
 	}
 
 	mut fdlist := []&FD{}

--- a/kernel/modules/file/file.v
+++ b/kernel/modules/file/file.v
@@ -63,8 +63,8 @@ pub const (
 )
 
 pub fn syscall_ppoll(_ voidptr, fds &PollFD, nfds u64, tmo_p &time.TimeSpec, sigmask &u64) (u64, u64) {
-	mut thread := proc.current_thread()
-	mut process := thread.process
+	mut t := proc.current_thread()
+	mut process := t.process
 
 	C.printf(c'\n\e[32m%s\e[m: ppoll(0x%llx, %llu, 0x%llx, 0x%llx)\n', process.name.str,
 		voidptr(fds), nfds, voidptr(tmo_p), voidptr(sigmask))
@@ -76,12 +76,12 @@ pub fn syscall_ppoll(_ voidptr, fds &PollFD, nfds u64, tmo_p &time.TimeSpec, sig
 		return 0, 0
 	}
 
-	oldmask := thread.masked_signals
+	oldmask := t.masked_signals
 	if voidptr(sigmask) != unsafe { nil } {
-		thread.masked_signals = unsafe { sigmask[0] }
+		t.masked_signals = unsafe { sigmask[0] }
 	}
 	defer {
-		thread.masked_signals = oldmask
+		t.masked_signals = oldmask
 	}
 
 	mut fdlist := []&FD{}
@@ -371,8 +371,8 @@ pub fn fdnum_dup(_old_process &proc.Process, oldfdnum int, _new_process &proc.Pr
 }
 
 pub fn syscall_dup3(_ voidptr, oldfdnum int, newfdnum int, flags int) (u64, u64) {
-	mut thread := proc.current_thread()
-	mut process := thread.process
+	mut t := proc.current_thread()
+	mut process := t.process
 
 	C.printf(c'\n\e[32m%s\e[m: dup3(%d, %d, %d)\n', process.name.str, oldfdnum, newfdnum,
 		flags)
@@ -387,8 +387,8 @@ pub fn syscall_dup3(_ voidptr, oldfdnum int, newfdnum int, flags int) (u64, u64)
 }
 
 pub fn syscall_fcntl(_ voidptr, fdnum int, cmd int, arg u64) (u64, u64) {
-	mut thread := proc.current_thread()
-	mut process := thread.process
+	mut t := proc.current_thread()
+	mut process := t.process
 
 	C.printf(c'\n\e[32m%s\e[m: fcntl(%d, %d, %lld)\n', process.name.str, fdnum, cmd, arg)
 	defer {

--- a/kernel/modules/lib/stubs/pthread.v
+++ b/kernel/modules/lib/stubs/pthread.v
@@ -14,27 +14,27 @@ struct C.__thread_data {}
 struct C.__threadattr {}
 
 [export: 'pthread_create']
-pub fn pthread_create(thread &&C.__thread_data, attr &C.__threadattr, start_routine fn (voidptr) voidptr, arg voidptr) int {
+pub fn pthread_create(t &&C.__thread_data, attr &C.__threadattr, start_routine fn (voidptr) voidptr, arg voidptr) int {
 	if voidptr(attr) != voidptr(0) {
 		lib.kpanic(voidptr(0), c'pthread_create() called with non-NULL attr')
 	}
 
 	unsafe {
-		mut ptr := &voidptr(thread)
+		mut ptr := &voidptr(t)
 		*ptr = sched.new_kernel_thread(voidptr(start_routine), arg, true)
 	}
 	return 0
 }
 
 [export: 'pthread_detach']
-pub fn pthread_detach(thread &C.__thread_data) int {
+pub fn pthread_detach(t &C.__thread_data) int {
 	return 0
 }
 
 [export: 'pthread_join']
-pub fn pthread_join(thread &C.__thread_data, mut retval voidptr) int {
+pub fn pthread_join(t &C.__thread_data, mut retval voidptr) int {
 	unsafe {
-		*retval = event.pthread_wait(&proc.Thread(thread))
+		*retval = event.pthread_wait(&proc.Thread(t))
 	}
 	return 0
 }

--- a/kernel/modules/sched/sched.v
+++ b/kernel/modules/sched/sched.v
@@ -51,7 +51,7 @@ fn get_next_thread(orig_i int) int {
 
 		mut thread_run := scheduler_running_queue[index]
 
-		if unsafe { t != 0 } {
+		if unsafe { thread_run != 0 } {
 			if katomic.load(thread_run.running_on) == cpu_number || thread_run.l.test_and_acquire() == true {
 				return index
 			}

--- a/kernel/modules/sched/sched.v
+++ b/kernel/modules/sched/sched.v
@@ -49,10 +49,10 @@ fn get_next_thread(orig_i int) int {
 			index = 0
 		}
 
-		mut thread_run := scheduler_running_queue[index]
+		mut t := scheduler_running_queue[index]
 
-		if unsafe { thread_run != 0 } {
-			if katomic.load(thread_run.running_on) == cpu_number || thread_run.l.test_and_acquire() == true {
+		if unsafe { t != 0 } {
+			if katomic.load(t.running_on) == cpu_number || t.l.test_and_acquire() == true {
 				return index
 			}
 		}

--- a/kernel/modules/sched/sched.v
+++ b/kernel/modules/sched/sched.v
@@ -49,10 +49,10 @@ fn get_next_thread(orig_i int) int {
 			index = 0
 		}
 
-		mut thread := scheduler_running_queue[index]
+		mut thread_run := scheduler_running_queue[index]
 
-		if unsafe { thread != 0 } {
-			if katomic.load(thread.running_on) == cpu_number || thread.l.test_and_acquire() == true {
+		if unsafe { t != 0 } {
+			if katomic.load(thread_run.running_on) == cpu_number || thread_run.l.test_and_acquire() == true {
 				return index
 			}
 		}
@@ -177,17 +177,17 @@ fn scheduler_isr(_ u32, gpr_state &cpulocal.GPRState) {
 }
 
 pub fn enqueue_thread(_thread &proc.Thread, by_signal bool) bool {
-	mut thread := unsafe { _thread }
+	mut t := unsafe { _thread }
 
-	if thread.is_in_queue == true {
+	if t.is_in_queue == true {
 		return true
 	}
 
-	katomic.store(thread.enqueued_by_signal, by_signal)
+	katomic.store(t.enqueued_by_signal, by_signal)
 
 	for i := u64(0); i < scheduler_running_queue.len; i++ {
-		if katomic.cas(voidptr(&scheduler_running_queue[i]), u64(0), u64(thread)) {
-			thread.is_in_queue = true
+		if katomic.cas(voidptr(&scheduler_running_queue[i]), u64(0), u64(t)) {
+			t.is_in_queue = true
 
 			// Check if any CPU is idle and wake it up
 			for cpu in cpu_locals {
@@ -205,15 +205,15 @@ pub fn enqueue_thread(_thread &proc.Thread, by_signal bool) bool {
 }
 
 pub fn dequeue_thread(_thread &proc.Thread) bool {
-	mut thread := unsafe { _thread }
+	mut t := unsafe { _thread }
 
-	if thread.is_in_queue == false {
+	if t.is_in_queue == false {
 		return true
 	}
 
 	for i := u64(0); i < scheduler_running_queue.len; i++ {
-		if katomic.cas(voidptr(&scheduler_running_queue[i]), u64(thread), u64(0)) {
-			thread.is_in_queue = false
+		if katomic.cas(voidptr(&scheduler_running_queue[i]), u64(t), u64(0)) {
+			t.is_in_queue = false
 			return true
 		}
 	}
@@ -223,15 +223,15 @@ pub fn dequeue_thread(_thread &proc.Thread) bool {
 
 // Like dequeue_thread(), but it stops it immediately
 pub fn intercept_thread(_thread &proc.Thread) ? {
-	mut thread := unsafe { _thread }
+	mut t := unsafe { _thread }
 
-	if voidptr(thread) == voidptr(proc.current_thread()) {
+	if voidptr(t) == voidptr(proc.current_thread()) {
 		return none
 	}
 
-	dequeue_thread(thread)
+	dequeue_thread(t)
 
-	running_on := thread.running_on
+	running_on := t.running_on
 
 	if running_on == u64(-1) {
 		return
@@ -239,8 +239,8 @@ pub fn intercept_thread(_thread &proc.Thread) ? {
 
 	apic.lapic_send_ipi(u8(cpu_locals[running_on].lapic_id), scheduler_vector)
 
-	thread.l.acquire()
-	thread.l.release()
+	t.l.acquire()
+	t.l.release()
 }
 
 pub fn yield(save_ctx bool) {
@@ -292,14 +292,14 @@ pub fn dequeue_and_die() {
 	asm volatile amd64 {
 		cli
 	}
-	mut thread := proc.current_thread()
-	dequeue_thread(thread)
-	for ptr in thread.stacks {
+	mut t := proc.current_thread()
+	dequeue_thread(t)
+	for ptr in t.stacks {
 		memory.pmm_free(ptr, sched.stack_size / page_size)
 	}
 	unsafe {
-		thread.stacks.free()
-		free(thread)
+		t.stacks.free()
+		free(t)
 	}
 	yield(false)
 	for {}
@@ -324,7 +324,7 @@ pub fn new_kernel_thread(pc voidptr, arg voidptr, autoenqueue bool) &proc.Thread
 		rsp: stack
 	}
 
-	mut thread := &proc.Thread{
+	mut t := &proc.Thread{
 		process: kernel_process
 		cr3: u64(kernel_process.pagemap.top_level)
 		gpr_state: gpr_state
@@ -335,14 +335,14 @@ pub fn new_kernel_thread(pc voidptr, arg voidptr, autoenqueue bool) &proc.Thread
 			higher_half)
 	}
 
-	thread.self = voidptr(thread)
-	thread.gs_base = u64(voidptr(thread))
+	t.self = voidptr(t)
+	t.gs_base = u64(voidptr(t))
 
 	if autoenqueue == true {
-		enqueue_thread(thread, false)
+		enqueue_thread(t, false)
 	}
 
-	return thread
+	return t
 }
 
 pub fn syscall_new_thread(_ voidptr, pc voidptr, arg voidptr, stack u64, fs u64) (u64, u64) {
@@ -409,7 +409,7 @@ pub fn new_user_thread(_process &proc.Process, want_elf bool, pc voidptr, arg vo
 		rsp: u64(stack_vma)
 	}
 
-	mut thread := &proc.Thread{
+	mut t := &proc.Thread{
 		process: process
 		cr3: u64(process.pagemap.top_level)
 		gpr_state: gpr_state
@@ -422,12 +422,12 @@ pub fn new_user_thread(_process &proc.Process, want_elf bool, pc voidptr, arg vo
 			higher_half)
 	}
 
-	thread.self = voidptr(thread)
-	thread.gs_base = u64(0)
-	thread.fs_base = u64(0)
+	t.self = voidptr(t)
+	t.gs_base = u64(0)
+	t.fs_base = u64(0)
 
 	// Set up FPU control word and MXCSR as defined in the sysv ABI
-	fpu_restore(thread.fpu_storage)
+	fpu_restore(t.fpu_storage)
 
 	default_fcw := u16(0b1100111111)
 
@@ -445,10 +445,10 @@ pub fn new_user_thread(_process &proc.Process, want_elf bool, pc voidptr, arg vo
 		; memory
 	}
 
-	fpu_save(thread.fpu_storage)
+	fpu_save(t.fpu_storage)
 
 	// Set all sigactions to default
-	for mut sa in thread.sigactions {
+	for mut sa in t.sigactions {
 		sa.sa_sigaction = voidptr(-2)
 	}
 
@@ -511,18 +511,18 @@ pub fn new_user_thread(_process &proc.Process, want_elf bool, pc voidptr, arg vo
 			stack[-1] = u64(argv.len)
 			stack = &stack[-1]
 
-			thread.gpr_state.rsp -= u64(stack_top) - u64(stack)
+			t.gpr_state.rsp -= u64(stack_top) - u64(stack)
 		}
 	}
 
 	if autoenqueue == true {
-		enqueue_thread(thread, false)
+		enqueue_thread(t, false)
 	}
 
-	thread.tid = process.threads.len
-	process.threads << thread
+	t.tid = process.threads.len
+	process.threads << t
 
-	return thread
+	return t
 }
 
 pub fn new_process(old_process &proc.Process, pagemap &memory.Pagemap) ?&proc.Process {


### PR DESCRIPTION
Needed for https://github.com/vlang/v/pull/19174