### PR TITLE
Update build requirement commands to include bsdtar, or libarchive package

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,17 +60,17 @@ to test it.
 
 ### Build prerequisites for Ubuntu, Debian, and derivatives
 ```bash
-sudo apt install -y make curl git mercurial libarchive-tools xorriso qemu-system-x86
+sudo apt install -y make curl git mercurial libarchive-tools xorriso qemu-system-x86 bsdtar
 ```
 
 ### Build prerequisites for Arch Linux and derivatives
 ```bash
-sudo pacman -S --needed make curl git mercurial libarchive xorriso qemu
+sudo pacman -S --needed make curl git mercurial libarchive xorriso qemu bsdtar
 ```
 
 ### Build prerequisites for Red Hat Linux and derivatives
 ```bash
-sudo yum install -y make curl git mercurial libarchive xorriso qemu
+sudo yum install -y make curl git mercurial libarchive xorriso qemu bsdtar
 ```
 
 ### Building the distro

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ to test it.
 
 ### Build prerequisites for Ubuntu, Debian, and derivatives
 ```bash
-sudo apt install -y make curl git mercurial libarchive-tools xorriso qemu-system-x86 bsdtar
+sudo apt install -y make curl git mercurial libarchive-tools xorriso qemu-system-x86 libarchive-tools
 ```
 
 ### Build prerequisites for Arch Linux and derivatives
 ```bash
-sudo pacman -S --needed make curl git mercurial libarchive xorriso qemu bsdtar
+sudo pacman -S --needed make curl git mercurial libarchive xorriso qemu libarchive
 ```
 
 ### Build prerequisites for Red Hat Linux and derivatives


### PR DESCRIPTION
Hello Vinix community!

Thought it would be worth it to update the build req commands as while the README.md does mention `bsdtar` as a requirement, it is missing in the given command examples.