### PR TITLE
misc: run `v fmt -w .`

### DIFF
--- a/init/main.v
+++ b/init/main.v
@@ -5,6 +5,7 @@
 module main
 
 import os
+
 #include <unistd.h>
 
 fn C.sethostname(name charptr, len u64) int

--- a/kernel/main.v
+++ b/kernel/main.v
@@ -36,8 +36,8 @@ import socket
 import time
 import limine
 
-@[cinit]
 @[_linker_section: '.requests']
+@[cinit]
 __global (
 	volatile limine_base_revision = limine.LimineBaseRevision{
 		revision: 2
@@ -76,8 +76,8 @@ fn kmain_thread() {
 		ahci.initialise()
 	}
 
-	userland.start_program(false, vfs_root, '/sbin/init', ['/sbin/init'], [],
-	'/dev/console', '/dev/console', '/dev/console') or { panic('Could not start init process') }
+	userland.start_program(false, vfs_root, '/sbin/init', ['/sbin/init'], [], '/dev/console',
+		'/dev/console', '/dev/console') or { panic('Could not start init process') }
 
 	sched.dequeue_and_die()
 }

--- a/kernel/modules/acpi/acpi.v
+++ b/kernel/modules/acpi/acpi.v
@@ -44,8 +44,8 @@ fn use_xsdt() bool {
 	return rsdp.revision >= 2 && rsdp.xsdt_addr != 0
 }
 
-@[cinit]
 @[_linker_section: '.requests']
+@[cinit]
 __global (
 	volatile rsdp_req = limine.LimineRSDPRequest{
 		response: unsafe { nil }

--- a/kernel/modules/acpi/madt.v
+++ b/kernel/modules/acpi/madt.v
@@ -32,10 +32,10 @@ pub:
 @[packed]
 struct MADTLocalX2Apic {
 pub:
-	header MADTHeader
-	reserved [2]u8
-	x2apic_id u32
-	flags u32
+	header       MADTHeader
+	reserved     [2]u8
+	x2apic_id    u32
+	flags        u32
 	processor_id u32
 }
 
@@ -69,12 +69,12 @@ pub:
 }
 
 __global (
-	madt             &MADT
-	madt_local_apics []&MADTLocalApic
+	madt               &MADT
+	madt_local_apics   []&MADTLocalApic
 	madt_local_x2apics []&MADTLocalX2Apic
-	madt_io_apics    []&MADTIoApic
-	madt_isos        []&MADTISO
-	madt_nmis        []&MADTNMI
+	madt_io_apics      []&MADTIoApic
+	madt_isos          []&MADTISO
+	madt_nmis          []&MADTNMI
 )
 
 fn madt_init() {

--- a/kernel/modules/dev/ata/ata.v
+++ b/kernel/modules/dev/ata/ata.v
@@ -78,9 +78,9 @@ pub fn initialise() {
 	mut index := 0
 	for i in 0 .. ata.ata_ports.len {
 		drive := init_ata_drive(i, mut dev) or { continue }
-		name := 'ata$index'
+		name := 'ata${index}'
 		fs.devtmpfs_add_device(drive, name)
-		print('ata: Port $i initialised as $name ($drive.stat.size bytes)\n')
+		print('ata: Port ${i} initialised as ${name} (${drive.stat.size} bytes)\n')
 		index += 1
 	}
 }
@@ -90,7 +90,7 @@ fn init_ata_drive(port_index int, mut pci_device pci.PCIDevice) ?&ATADrive {
 
 	// Fetch the IO ports and comm addresses of the drive.
 	port := u16(ata.ata_ports[port_index])
-	mut bar4 := u16(pci_device.read<u32>(0x20))
+	mut bar4 := u16(pci_device.read[u32](0x20))
 	if bar4 & 1 != 0 {
 		bar4 &= 0xfffffffc
 	}
@@ -118,21 +118,21 @@ fn init_ata_drive(port_index int, mut pci_device pci.PCIDevice) ?&ATADrive {
 
 	// Identify the drive.
 	val := if dev.is_master { 0xa0 } else { 0xb0 }
-	kio.port_out<u8>(dev.device_port, u8(val))
-	kio.port_out<u8>(dev.sector_count_port, 0)
-	kio.port_out<u8>(dev.lba_low_port, 0)
-	kio.port_out<u8>(dev.lba_mid_port, 0)
-	kio.port_out<u8>(dev.lba_hi_port, 0)
-	kio.port_out<u8>(dev.cmd_port, 0xec)
+	kio.port_out[u8](dev.device_port, u8(val))
+	kio.port_out[u8](dev.sector_count_port, 0)
+	kio.port_out[u8](dev.lba_low_port, 0)
+	kio.port_out[u8](dev.lba_mid_port, 0)
+	kio.port_out[u8](dev.lba_hi_port, 0)
+	kio.port_out[u8](dev.cmd_port, 0xec)
 
-	if kio.port_in<u8>(dev.cmd_port) == 0 {
-		print('ata: Port $port_index is not connected\n')
+	if kio.port_in[u8](dev.cmd_port) == 0 {
+		print('ata: Port ${port_index} is not connected\n')
 		return none
 	} else {
 		mut timeout := 0
-		for kio.port_in<u8>(dev.cmd_port) & 0b10000000 != 0 {
+		for kio.port_in[u8](dev.cmd_port) & 0b10000000 != 0 {
 			if timeout == 100000 {
-				print('ata: Port $port_index is not answering\n')
+				print('ata: Port ${port_index} is not answering\n')
 				return none
 			}
 			timeout += 1
@@ -140,23 +140,23 @@ fn init_ata_drive(port_index int, mut pci_device pci.PCIDevice) ?&ATADrive {
 	}
 
 	// Check for non-standard ATAPI.
-	if kio.port_in<u8>(dev.lba_mid_port) != 0 || kio.port_in<u8>(dev.lba_hi_port) != 0 {
-		print('ata: Port $port_index is non-standard ATAPI\n')
+	if kio.port_in[u8](dev.lba_mid_port) != 0 || kio.port_in[u8](dev.lba_hi_port) != 0 {
+		print('ata: Port ${port_index} is non-standard ATAPI\n')
 		return none
 	}
 
 	mut timeout := 0
 	for {
-		status := kio.port_in<u8>(dev.cmd_port)
+		status := kio.port_in[u8](dev.cmd_port)
 		if status & 0b00000001 != 0 {
-			print('ata: Port $port_index errored out\n')
+			print('ata: Port ${port_index} errored out\n')
 			return none
 		}
 		if status & 0b00001000 != 0 {
 			break
 		}
 		if timeout == 100000 {
-			print('ata: Port $port_index hanged\n')
+			print('ata: Port ${port_index} hanged\n')
 			return none
 		}
 	}
@@ -164,11 +164,11 @@ fn init_ata_drive(port_index int, mut pci_device pci.PCIDevice) ?&ATADrive {
 	// Storing identify info.
 	mut identify := [256]u16{}
 	for i in 0 .. identify.len {
-		identify[i] = kio.port_in<u16>(dev.data_port)
+		identify[i] = kio.port_in[u16](dev.data_port)
 	}
 
 	// Wacky PCI things
-	mut cmd_register := pci_device.read<u32>(0x4)
+	mut cmd_register := pci_device.read[u32](0x4)
 	if cmd_register & (1 << 2) == 0 {
 		cmd_register |= 1 << 2
 		pci_device.write(0x4, cmd_register)
@@ -182,7 +182,7 @@ fn init_ata_drive(port_index int, mut pci_device pci.PCIDevice) ?&ATADrive {
 	dev.stat.mode = 0o644 | stat.ifblk
 	dev.prdt_phys = u32(u64(memory.pmm_alloc(1)))
 	dev.prdt = &PRDT(dev.prdt_phys + higher_half)
-	dev.prdt.buffer_phys = u32(u64(memory.pmm_alloc(lib.div_roundup<u64>(ata.ata_bytes_per_prdt,
+	dev.prdt.buffer_phys = u32(u64(memory.pmm_alloc(lib.div_roundup[u64](ata.ata_bytes_per_prdt,
 		page_size))))
 	dev.prdt.transfer_size = ata.ata_bytes_per_prdt
 	dev.prdt.mark_end = 0x8000
@@ -212,13 +212,13 @@ fn (mut dev ATADrive) read(handle voidptr, buffer voidptr, loc u64, count u64) ?
 
 	for i := u64(0); i < sector_count; i += ata.ata_sectors_per_prdt {
 		sector_loc := sector_start + i
-		kio.port_out<u8>(dev.bmr_command, 0)
-		kio.port_out<u32>(dev.bmr_prdt, dev.prdt_phys)
-		bmr_status := kio.port_in<u8>(dev.bmr_status)
-		kio.port_out<u8>(dev.bmr_status, bmr_status | 0x4 | 0x2)
+		kio.port_out[u8](dev.bmr_command, 0)
+		kio.port_out[u32](dev.bmr_prdt, dev.prdt_phys)
+		bmr_status := kio.port_in[u8](dev.bmr_status)
+		kio.port_out[u8](dev.bmr_status, bmr_status | 0x4 | 0x2)
 
 		val := if dev.is_master { 0x40 } else { 0x50 }
-		kio.port_out<u8>(dev.device_port, u8(val))
+		kio.port_out[u8](dev.device_port, u8(val))
 
 		actual_count := if i + ata.ata_sectors_per_prdt > sector_count {
 			sector_count % ata.ata_sectors_per_prdt
@@ -226,29 +226,29 @@ fn (mut dev ATADrive) read(handle voidptr, buffer voidptr, loc u64, count u64) ?
 			ata.ata_sectors_per_prdt
 		}
 
-		kio.port_out<u8>(dev.sector_count_port, u8(actual_count >> 8))
-		kio.port_out<u8>(dev.lba_low_port, u8((sector_loc & 0x000000FF000000) >> 24))
-		kio.port_out<u8>(dev.lba_mid_port, u8((sector_loc & 0x0000FF00000000) >> 32))
-		kio.port_out<u8>(dev.lba_hi_port, u8((sector_loc & 0x00FF0000000000) >> 40))
-		kio.port_out<u8>(dev.sector_count_port, u8(actual_count & 0xff))
-		kio.port_out<u8>(dev.lba_low_port, u8(sector_loc & 0x000000000000FF))
-		kio.port_out<u8>(dev.lba_mid_port, u8((sector_loc & 0x0000000000FF00) >> 8))
-		kio.port_out<u8>(dev.lba_hi_port, u8((sector_loc & 0x00000000FF0000) >> 16))
+		kio.port_out[u8](dev.sector_count_port, u8(actual_count >> 8))
+		kio.port_out[u8](dev.lba_low_port, u8((sector_loc & 0x000000FF000000) >> 24))
+		kio.port_out[u8](dev.lba_mid_port, u8((sector_loc & 0x0000FF00000000) >> 32))
+		kio.port_out[u8](dev.lba_hi_port, u8((sector_loc & 0x00FF0000000000) >> 40))
+		kio.port_out[u8](dev.sector_count_port, u8(actual_count & 0xff))
+		kio.port_out[u8](dev.lba_low_port, u8(sector_loc & 0x000000000000FF))
+		kio.port_out[u8](dev.lba_mid_port, u8((sector_loc & 0x0000000000FF00) >> 8))
+		kio.port_out[u8](dev.lba_hi_port, u8((sector_loc & 0x00000000FF0000) >> 16))
 
-		kio.port_out<u8>(dev.cmd_port, 0x25) // READ_DMA command
-		kio.port_out<u8>(dev.bmr_command, 0x8 | 0x1)
+		kio.port_out[u8](dev.cmd_port, 0x25) // READ_DMA command
+		kio.port_out[u8](dev.bmr_command, 0x8 | 0x1)
 
 		for {
-			status := kio.port_in<u8>(dev.cmd_port)
+			status := kio.port_in[u8](dev.cmd_port)
 			if status & 0x80 == 0 {
 				break
 			}
 			if status & 0x01 != 0 {
-				print('ata: Error reading sector $sector_loc on drive')
+				print('ata: Error reading sector ${sector_loc} on drive')
 				return none
 			}
 		}
-		kio.port_out<u8>(dev.bmr_command, 0)
+		kio.port_out[u8](dev.bmr_command, 0)
 
 		buffer_final := voidptr(u64(buffer) + i * ata.ata_bytes_per_sector)
 		unsafe { C.memcpy(buffer_final, dev.prdt_cache, actual_count * ata.ata_bytes_per_sector) }
@@ -275,13 +275,13 @@ fn (mut dev ATADrive) write(handle voidptr, buffer voidptr, loc u64, count u64) 
 	for i := u64(0); i < sector_count; i += ata.ata_sectors_per_prdt {
 		sector_loc := sector_start + i
 
-		kio.port_out<u8>(dev.bmr_command, 0)
-		kio.port_out<u32>(dev.bmr_prdt, dev.prdt_phys)
-		bmr_status := kio.port_in<u8>(dev.bmr_status)
-		kio.port_out<u8>(dev.bmr_status, bmr_status | 0x4 | 0x2)
+		kio.port_out[u8](dev.bmr_command, 0)
+		kio.port_out[u32](dev.bmr_prdt, dev.prdt_phys)
+		bmr_status := kio.port_in[u8](dev.bmr_status)
+		kio.port_out[u8](dev.bmr_status, bmr_status | 0x4 | 0x2)
 
 		val := if dev.is_master { 0x40 } else { 0x50 }
-		kio.port_out<u8>(dev.device_port, u8(val))
+		kio.port_out[u8](dev.device_port, u8(val))
 
 		actual_count := if i + ata.ata_sectors_per_prdt > sector_count {
 			sector_count % ata.ata_sectors_per_prdt
@@ -293,39 +293,39 @@ fn (mut dev ATADrive) write(handle voidptr, buffer voidptr, loc u64, count u64) 
 		buffer_final := voidptr(u64(buffer) + i * ata.ata_bytes_per_sector)
 		unsafe { C.memcpy(dev.prdt_cache, buffer_final, actual_count * ata.ata_bytes_per_sector) }
 
-		kio.port_out<u8>(dev.sector_count_port, u8(actual_count >> 8))
-		kio.port_out<u8>(dev.lba_low_port, u8((sector_loc & 0x000000FF000000) >> 24))
-		kio.port_out<u8>(dev.lba_mid_port, u8((sector_loc & 0x0000FF00000000) >> 32))
-		kio.port_out<u8>(dev.lba_hi_port, u8((sector_loc & 0x00FF0000000000) >> 40))
-		kio.port_out<u8>(dev.sector_count_port, u8(actual_count & 0xff))
-		kio.port_out<u8>(dev.lba_low_port, u8(sector_loc & 0x000000000000FF))
-		kio.port_out<u8>(dev.lba_mid_port, u8((sector_loc & 0x0000000000FF00) >> 8))
-		kio.port_out<u8>(dev.lba_hi_port, u8((sector_loc & 0x00000000FF0000) >> 16))
+		kio.port_out[u8](dev.sector_count_port, u8(actual_count >> 8))
+		kio.port_out[u8](dev.lba_low_port, u8((sector_loc & 0x000000FF000000) >> 24))
+		kio.port_out[u8](dev.lba_mid_port, u8((sector_loc & 0x0000FF00000000) >> 32))
+		kio.port_out[u8](dev.lba_hi_port, u8((sector_loc & 0x00FF0000000000) >> 40))
+		kio.port_out[u8](dev.sector_count_port, u8(actual_count & 0xff))
+		kio.port_out[u8](dev.lba_low_port, u8(sector_loc & 0x000000000000FF))
+		kio.port_out[u8](dev.lba_mid_port, u8((sector_loc & 0x0000000000FF00) >> 8))
+		kio.port_out[u8](dev.lba_hi_port, u8((sector_loc & 0x00000000FF0000) >> 16))
 
-		kio.port_out<u8>(dev.cmd_port, 0x35) // WRITE_DMA command
-		kio.port_out<u8>(dev.bmr_command, 0x1)
+		kio.port_out[u8](dev.cmd_port, 0x35) // WRITE_DMA command
+		kio.port_out[u8](dev.bmr_command, 0x1)
 
 		for {
-			status := kio.port_in<u8>(dev.cmd_port)
+			status := kio.port_in[u8](dev.cmd_port)
 			if status & 0x80 == 0 {
 				break
 			}
 			if status & 0x01 != 0 {
-				print('ata: Error reading sector $sector_loc on drive')
+				print('ata: Error reading sector ${sector_loc} on drive')
 				return none
 			}
 		}
-		kio.port_out<u8>(dev.bmr_command, 0)
+		kio.port_out[u8](dev.bmr_command, 0)
 
-		kio.port_out<u8>(dev.device_port, u8(val))
-		kio.port_out<u8>(dev.cmd_port, 0xea) // Cache flush EXT command.
+		kio.port_out[u8](dev.device_port, u8(val))
+		kio.port_out[u8](dev.cmd_port, 0xea) // Cache flush EXT command.
 		for {
-			status := kio.port_in<u8>(dev.cmd_port)
+			status := kio.port_in[u8](dev.cmd_port)
 			if status & 0x80 == 0 {
 				break
 			}
 			if status & 0x01 != 0 {
-				print('ata: Error reading sector $sector_loc on drive')
+				print('ata: Error reading sector ${sector_loc} on drive')
 				return none
 			}
 		}

--- a/kernel/modules/dev/console/console.v
+++ b/kernel/modules/dev/console/console.v
@@ -23,17 +23,17 @@ import proc
 import katomic
 import flanterm as _
 
-const max_scancode        = 0x57
-const capslock            = 0x3a
-const numlock             = 0x45
-const left_alt            = 0x38
-const left_alt_rel        = 0xb8
-const right_shift         = 0x36
-const left_shift          = 0x2a
-const right_shift_rel     = 0xb6
-const left_shift_rel      = 0xaa
-const ctrl                = 0x1d
-const ctrl_rel            = 0x9d
+const max_scancode = 0x57
+const capslock = 0x3a
+const numlock = 0x45
+const left_alt = 0x38
+const left_alt_rel = 0xb8
+const right_shift = 0x36
+const left_shift = 0x2a
+const right_shift_rel = 0xb6
+const left_shift_rel = 0xaa
+const ctrl = 0x1d
+const ctrl_rel = 0x9d
 const console_buffer_size = 1024
 const console_bigbuf_size = 4096
 
@@ -48,9 +48,9 @@ __global (
 	console_ctrl_active            = bool(false)
 	console_alt_active             = bool(false)
 	console_extra_scancodes        = bool(false)
-	console_buffer                 [console_buffer_size]u8
+	console_buffer                 [console.console_buffer_size]u8
 	console_buffer_i               = u64(0)
-	console_bigbuf                 [console_bigbuf_size]u8
+	console_bigbuf                 [console.console_bigbuf_size]u8
 	console_bigbuf_i               = u64(0)
 	console_termios                = &termios.Termios(unsafe { nil })
 	console_decckm                 = false
@@ -739,7 +739,7 @@ fn (mut this Console) read(handle voidptr, void_buf voidptr, loc u64, count u64)
 			for j := u64(0); j < console_bigbuf_i; j++ {
 				console_bigbuf[j] = console_bigbuf[j + 1]
 			}
-			if console_bigbuf_i == 0 && (console_res.status & file.pollin != 0) {
+			if console_bigbuf_i == 0 && console_res.status & file.pollin != 0 {
 				console_res.status &= ~file.pollin
 				event.trigger(mut console_res.event, false)
 			}

--- a/kernel/modules/dev/fbdev/api/driver.v
+++ b/kernel/modules/dev/fbdev/api/driver.v
@@ -6,18 +6,17 @@ module api
 
 pub struct FramebufferInfo {
 pub mut:
-	base voidptr
-	size u64
-	driver &FramebufferDriver
+	base     voidptr
+	size     u64
+	driver   &FramebufferDriver
 	variable FBVarScreenInfo
-	fixed FBFixScreenInfo
+	fixed    FBFixScreenInfo
 }
 
 pub struct FramebufferDriver {
 pub mut:
 	name string
-	init fn() = unsafe { nil }
-
+	init fn () = unsafe { nil }
 	// those below are filled in during registration, must be null.
-	register_device fn(FramebufferInfo)? = unsafe { nil }
+	register_device fn (FramebufferInfo) ? = unsafe { nil }
 }

--- a/kernel/modules/dev/fbdev/fbdev.v
+++ b/kernel/modules/dev/fbdev/fbdev.v
@@ -22,7 +22,7 @@ pub mut:
 	event        eventstruct.Event
 	status       int
 	can_mmap     bool
-	node_lock  	 klock.Lock
+	node_lock    klock.Lock
 	initialized  bool
 	node_created bool
 	info         api.FramebufferInfo
@@ -32,7 +32,7 @@ const fbdev_max_device_count = 32
 
 __global (
 	fbdev_lock  klock.Lock
-	fbdev_nodes [fbdev_max_device_count]FramebufferNode
+	fbdev_nodes [fbdev.fbdev_max_device_count]FramebufferNode
 )
 
 fn (mut this FramebufferNode) mmap(page u64, flags int) voidptr {
@@ -88,7 +88,7 @@ fn (mut this FramebufferNode) ioctl(handle voidptr, request u64, argp voidptr) ?
 			return 0
 		}
 		ioctl.fbioput_vscreeninfo {
-			unsafe { C.memcpy(&this.info.variable, argp,  sizeof(api.FBVarScreenInfo)) }
+			unsafe { C.memcpy(&this.info.variable, argp, sizeof(api.FBVarScreenInfo)) }
 			return 0
 		}
 		ioctl.fbioget_fscreeninfo {
@@ -107,7 +107,7 @@ fn (mut this FramebufferNode) ioctl(handle voidptr, request u64, argp voidptr) ?
 			return none
 		}
 		else {
-			panic('$request')
+			panic('${request}')
 			return resource.default_ioctl(handle, request, argp)
 		}
 	}
@@ -129,7 +129,7 @@ fn (mut this FramebufferNode) grow(handle voidptr, new_size u64) ? {
 }
 
 fn create_device_node(index u64) ? {
-	if index >= fbdev_max_device_count {
+	if index >= fbdev.fbdev_max_device_count {
 		println('device index out of range')
 		return none
 	}
@@ -160,7 +160,7 @@ pub fn register_device(info api.FramebufferInfo) ? {
 		fbdev_lock.release()
 	}
 
-	for index < fbdev_max_device_count {
+	for index < fbdev.fbdev_max_device_count {
 		if fbdev_nodes[index].initialized {
 			index += 1
 			continue
@@ -171,7 +171,7 @@ pub fn register_device(info api.FramebufferInfo) ? {
 		break
 	}
 
-	if index >= fbdev_max_device_count {
+	if index >= fbdev.fbdev_max_device_count {
 		println('too many registered devices')
 		return none
 	}
@@ -189,5 +189,4 @@ pub fn register_driver(driver &api.FramebufferDriver) {
 }
 
 pub fn initialise() {
-
 }

--- a/kernel/modules/dev/fbdev/simple/simple.v
+++ b/kernel/modules/dev/fbdev/simple/simple.v
@@ -98,7 +98,7 @@ fn do_register(config &SimpleFBConfig) {
 	}
 
 	simplefb_driver.register_device(info) or {
-		print('simplefb: failed to register framebuffer device: $err.msg()')
+		print('simplefb: failed to register framebuffer device: ${err.msg()}')
 	}
 }
 

--- a/kernel/modules/dev/mouse/mouse.v
+++ b/kernel/modules/dev/mouse/mouse.v
@@ -15,17 +15,16 @@ import x86.idt
 
 @[inline]
 fn wait(t int) {
-	mut timeout := 100000;
-
+	mut timeout := 100000
 	if t == 0 {
 		for ; timeout != 0; timeout-- {
-			if kio.port_in<u8>(0x64) & (1 << 0) != 0 {
+			if kio.port_in[u8](0x64) & (1 << 0) != 0 {
 				return
 			}
 		}
 	} else {
 		for ; timeout != 0; timeout-- {
-			if kio.port_in<u8>(0x64) & (1 << 1) == 0 {
+			if kio.port_in[u8](0x64) & (1 << 1) == 0 {
 				return
 			}
 		}
@@ -35,15 +34,15 @@ fn wait(t int) {
 @[inline]
 fn write(val u8) {
 	wait(1)
-	kio.port_out<u8>(0x64, 0xd4)
+	kio.port_out[u8](0x64, 0xd4)
 	wait(1)
-	kio.port_out<u8>(0x60, val)
+	kio.port_out[u8](0x60, val)
 }
 
 @[inline]
 fn read() u8 {
 	wait(0)
-	return kio.port_in<u8>(0x60)
+	return kio.port_in[u8](0x60)
 }
 
 struct MousePacket {
@@ -55,12 +54,12 @@ pub mut:
 
 struct Mouse {
 pub mut:
-	stat       stat.Stat
-	refcount   int
-	l          klock.Lock
-	event      eventstruct.Event
-	status     int
-	can_mmap   bool
+	stat     stat.Stat
+	refcount int
+	l        klock.Lock
+	event    eventstruct.Event
+	status   int
+	can_mmap bool
 
 	packet_avl bool
 	packet     MousePacket
@@ -131,7 +130,7 @@ fn (mut this Mouse) grow(handle voidptr, new_size u64) ? {
 }
 
 __global (
-	mouse_res Mouse
+	mouse_res        Mouse
 	ps2_mouse_vector u8
 )
 
@@ -145,11 +144,11 @@ fn handler() {
 		event.await(mut events, true) or {}
 		unsafe { events.free() }
 
-        // we will get some spurious packets at the beginning and they will screw
-        // up the alignment of the handler cycle so just ignore everything in
-        // the first 250 milliseconds after boot
+		// we will get some spurious packets at the beginning and they will screw
+		// up the alignment of the handler cycle so just ignore everything in
+		// the first 250 milliseconds after boot
 		if monotonic_clock.tv_sec == 0 && monotonic_clock.tv_nsec < 250000000 {
-			kio.port_in<u8>(0x60)
+			kio.port_in[u8](0x60)
 		}
 
 		match handler_cycle {
@@ -207,7 +206,7 @@ pub fn initialise() {
 
 	mouse_res.stat.size = 0
 	mouse_res.stat.blocks = 0
-	mouse_res.stat.blksize = 512;
+	mouse_res.stat.blksize = 512
 	mouse_res.stat.rdev = resource.create_dev_id()
 	mouse_res.stat.mode = 0o644 | stat.ifchr
 

--- a/kernel/modules/dev/serial/serial.v
+++ b/kernel/modules/dev/serial/serial.v
@@ -81,23 +81,23 @@ pub fn initialise() {
 // Initialize a port.
 fn initialise_port(port u16) bool {
 	// Check if the port exists by writing a value and checking it back.
-	kio.port_out<u8>(port + 7, 0x55)
-	if kio.port_in<u8>(port + 7) != 0x55 {
+	kio.port_out[u8](port + 7, 0x55)
+	if kio.port_in[u8](port + 7) != 0x55 {
 		return false
 	}
 
 	// Enable data available interrupts and enable DLAB.
-	kio.port_out<u8>(port + 1, 0x01)
-	kio.port_out<u8>(port + 3, 0x80)
+	kio.port_out[u8](port + 1, 0x01)
+	kio.port_out[u8](port + 3, 0x80)
 
 	// Set divisor to low 1 hi 0 (115200 baud)
-	kio.port_out<u8>(port + 0, 0x01)
-	kio.port_out<u8>(port + 1, 0x00)
+	kio.port_out[u8](port + 0, 0x01)
+	kio.port_out[u8](port + 1, 0x00)
 
 	// Enable FIFO and interrupts
-	kio.port_out<u8>(port + 3, 0x03)
-	kio.port_out<u8>(port + 2, 0xc7)
-	kio.port_out<u8>(port + 4, 0x0b)
+	kio.port_out[u8](port + 3, 0x03)
+	kio.port_out[u8](port + 2, 0xc7)
+	kio.port_out[u8](port + 4, 0x0b)
 	return true
 }
 
@@ -106,10 +106,10 @@ pub fn out(value u8) {
 	com1_lock.acquire()
 	if value == `\n` {
 		for !is_transmiter_empty(serial.com1_port) {}
-		kio.port_out<u8>(serial.com1_port, `\r`)
+		kio.port_out[u8](serial.com1_port, `\r`)
 	}
 	for !is_transmiter_empty(serial.com1_port) {}
-	kio.port_out<u8>(serial.com1_port, value)
+	kio.port_out[u8](serial.com1_port, value)
 	com1_lock.release()
 }
 
@@ -117,18 +117,18 @@ pub fn out(value u8) {
 pub fn panic_out(value u8) {
 	if value == `\n` {
 		for !is_transmiter_empty(serial.com1_port) {}
-		kio.port_out<u8>(serial.com1_port, `\r`)
+		kio.port_out[u8](serial.com1_port, `\r`)
 	}
 	for !is_transmiter_empty(serial.com1_port) {}
-	kio.port_out<u8>(serial.com1_port, value)
+	kio.port_out[u8](serial.com1_port, value)
 }
 
 fn is_transmiter_empty(port u16) bool {
-	return kio.port_in<u8>(port + 5) & 0b01000000 != 0
+	return kio.port_in[u8](port + 5) & 0b01000000 != 0
 }
 
 fn is_data_received(port u16) bool {
-	return kio.port_in<u8>(port + 5) & 0b00000001 != 0
+	return kio.port_in[u8](port + 5) & 0b00000001 != 0
 }
 
 // Resource functions for serial COMPort s
@@ -163,7 +163,7 @@ fn (mut this COMPort) read(handle voidptr, void_buf voidptr, loc u64, count u64)
 	}
 	for i := u64(0); i < count; {
 		if is_data_received(this.port) {
-			val := kio.port_in<u8>(this.port)
+			val := kio.port_in[u8](this.port)
 			unsafe {
 				data[i] = val
 			}
@@ -184,7 +184,7 @@ fn (mut this COMPort) write(handle voidptr, buf voidptr, loc u64, count u64) ?i6
 	mut data := &u8(buf)
 	for i in 0 .. count {
 		for !is_transmiter_empty(this.port) {}
-		kio.port_out<u8>(this.port, unsafe { data[i] })
+		kio.port_out[u8](this.port, unsafe { data[i] })
 	}
 	return i64(count)
 }

--- a/kernel/modules/elf/elf.v
+++ b/kernel/modules/elf/elf.v
@@ -17,25 +17,25 @@ pub mut:
 	at_phnum u64
 }
 
-pub const et_dyn      = 0x03
+pub const et_dyn = 0x03
 
-pub const at_entry    = 9
-pub const at_phdr     = 3
-pub const at_phent    = 4
-pub const at_phnum    = 5
+pub const at_entry = 9
+pub const at_phdr = 3
+pub const at_phent = 4
+pub const at_phnum = 5
 
-pub const pt_load     = 0x00000001
-pub const pt_interp   = 0x00000003
-pub const pt_phdr     = 0x00000006
+pub const pt_load = 0x00000001
+pub const pt_interp = 0x00000003
+pub const pt_phdr = 0x00000006
 
-pub const abi_sysv    = 0x00
+pub const abi_sysv = 0x00
 pub const arch_x86_64 = 0x3e
-pub const bits_le     = 0x01
+pub const bits_le = 0x01
 
-pub const ei_class    = 4
-pub const ei_data     = 5
-pub const ei_version  = 6
-pub const ei_osabi    = 7
+pub const ei_class = 4
+pub const ei_data = 5
+pub const ei_version = 6
+pub const ei_osabi = 7
 
 pub struct Header {
 pub mut:
@@ -103,7 +103,7 @@ pub fn load(_pagemap &memory.Pagemap, _res &resource.Resource, base u64) !(Auxva
 	}
 
 	mut slide := u64(0)
-	if header.@type == et_dyn {
+	if header.@type == elf.et_dyn {
 		slide = 0x400000
 	}
 
@@ -119,7 +119,9 @@ pub fn load(_pagemap &memory.Pagemap, _res &resource.Resource, base u64) !(Auxva
 	for i := u64(0); i < header.ph_num; i++ {
 		mut phdr := &ProgramHdr{}
 
-		res.read(0, phdr, header.phoff + (sizeof(ProgramHdr) * i), sizeof(ProgramHdr)) or { return error('') }
+		res.read(0, phdr, header.phoff + (sizeof(ProgramHdr) * i), sizeof(ProgramHdr)) or {
+			return error('')
+		}
 
 		match phdr.p_type {
 			elf.pt_interp {

--- a/kernel/modules/event/eventstruct/eventstruct.v
+++ b/kernel/modules/event/eventstruct/eventstruct.v
@@ -10,8 +10,8 @@ pub const max_listeners = 32
 
 pub struct EventListener {
 pub mut:
-	thrd voidptr
-	which  u64
+	thrd  voidptr
+	which u64
 }
 
 pub struct Event {
@@ -19,5 +19,5 @@ pub mut:
 	@lock       klock.Lock
 	pending     u64
 	listeners_i u64
-	listeners   [max_listeners]EventListener
+	listeners   [eventstruct.max_listeners]EventListener
 }

--- a/kernel/modules/file/file.v
+++ b/kernel/modules/file/file.v
@@ -15,19 +15,19 @@ import event.eventstruct
 import memory.mmap
 import time
 
-pub const f_dupfd         = 0
+pub const f_dupfd = 0
 pub const f_dupfd_cloexec = 1030
-pub const f_getfd         = 1
-pub const f_setfd         = 2
-pub const f_getfl         = 3
-pub const f_setfl         = 4
-pub const f_getlk         = 5
-pub const f_setlk         = 6
-pub const f_setlkw        = 7
-pub const f_getown        = 8
-pub const f_setown        = 9
+pub const f_getfd = 1
+pub const f_setfd = 2
+pub const f_getfl = 3
+pub const f_setfl = 4
+pub const f_getlk = 5
+pub const f_setlk = 6
+pub const f_setlkw = 7
+pub const f_getown = 8
+pub const f_setown = 9
 
-pub const fd_cloexec      = 1
+pub const fd_cloexec = 1
 
 pub struct Handle {
 pub mut:
@@ -49,13 +49,13 @@ mut:
 	revents i16
 }
 
-pub const pollin     = 0x01
-pub const pollout    = 0x04
-pub const pollpri    = 0x02
-pub const pollhup    = 0x10
-pub const pollerr    = 0x08
-pub const pollrdhup  = 0x2000
-pub const pollnval   = 0x20
+pub const pollin = 0x01
+pub const pollout = 0x04
+pub const pollpri = 0x02
+pub const pollhup = 0x10
+pub const pollerr = 0x08
+pub const pollrdhup = 0x2000
+pub const pollnval = 0x20
 pub const pollwrnorm = 0x100
 
 pub fn syscall_ppoll(_ voidptr, fds &PollFD, nfds u64, tmo_p &time.TimeSpec, sigmask &u64) (u64, u64) {
@@ -279,7 +279,7 @@ pub fn fdnum_create_from_fd(_process &proc.Process, fd &FD, oldfd int, specific 
 		}
 		return none
 	} else {
-		fdnum_close(process, oldfd, false) or { }
+		fdnum_close(process, oldfd, false) or {}
 		process.fds[oldfd] = voidptr(fd)
 		return oldfd
 	}

--- a/kernel/modules/flanterm/flanterm.v
+++ b/kernel/modules/flanterm/flanterm.v
@@ -5,17 +5,17 @@ module flanterm
 #include <flanterm-helper.h>
 
 fn C.flanterm_fb_init(_malloc voidptr, _free voidptr,
-				   	  framebuffer &u32, width u64, height u64, pitch u64,
-				   	  red_mask_size u8, red_mask_shift u8,
-				   	  green_mask_size u8, green_mask_shift u8,
-				   	  blue_mask_size u8, blue_mask_shift u8,
-				   	  canvas &u32,
-				   	  ansi_colours &u32, ansi_bright_colours &u32,
-				   	  default_bg &u32, default_fg &u32,
-				   	  default_bg_bright &u32, default_fg_bright &u32,
-				   	  font voidptr, font_width u64, font_height u64, font_spacing u64,
-				   	  font_scale_x u64, font_scale_y u64,
-				   	  margin u64) voidptr
+	framebuffer &u32, width u64, height u64, pitch u64,
+	red_mask_size u8, red_mask_shift u8,
+	green_mask_size u8, green_mask_shift u8,
+	blue_mask_size u8, blue_mask_shift u8,
+	canvas &u32,
+	ansi_colours &u32, ansi_bright_colours &u32,
+	default_bg &u32, default_fg &u32,
+	default_bg_bright &u32, default_fg_bright &u32,
+	font voidptr, font_width u64, font_height u64, font_spacing u64,
+	font_scale_x u64, font_scale_y u64,
+	margin u64) voidptr
 fn C.flanterm_write(voidptr Context, buf charptr, count u64)
 
 fn C.flanterm_get_rows(voidptr Context) u64

--- a/kernel/modules/fs/devtmpfs.v
+++ b/kernel/modules/fs/devtmpfs.v
@@ -242,7 +242,8 @@ fn (mut this DevTmpFS) symlink(parent &VFSNode, dest string, target string) &VFS
 }
 
 pub fn devtmpfs_add_device(device &resource.Resource, name string) {
-	mut new_node := create_node(unsafe { filesystems['devtmpfs'] }, devtmpfs_root, name, false)
+	mut new_node := create_node(unsafe { filesystems['devtmpfs'] }, devtmpfs_root, name,
+		false)
 
 	new_node.resource = unsafe { device }
 	new_node.resource.stat.dev = devtmpfs_dev_id

--- a/kernel/modules/fs/ext2/ext2.v
+++ b/kernel/modules/fs/ext2/ext2.v
@@ -16,93 +16,93 @@ import fs
 @[packed]
 struct EXT2Superblock {
 pub mut:
-	inode_cnt u32
-	block_cnt u32
-	sb_reserved u32
+	inode_cnt          u32
+	block_cnt          u32
+	sb_reserved        u32
 	unallocated_blocks u32
 	unallocated_inodes u32
-	sb_block u32
-	block_size u32
-	frag_size u32
-	blocks_per_group u32
-	frags_per_group u32
-	inodes_per_group u32
-	last_mnt_time u32
-	last_written_time u32
-	mnt_cnt u16
-	mnt_allowed u16
-	signature u16
-	fs_state u16
-	error_response u16
-	version_min u16
-	last_fsck u32
-	forced_fsck u32
-	os_id u32
-	version_maj u32
-	user_id u16
-	group_id u16
+	sb_block           u32
+	block_size         u32
+	frag_size          u32
+	blocks_per_group   u32
+	frags_per_group    u32
+	inodes_per_group   u32
+	last_mnt_time      u32
+	last_written_time  u32
+	mnt_cnt            u16
+	mnt_allowed        u16
+	signature          u16
+	fs_state           u16
+	error_response     u16
+	version_min        u16
+	last_fsck          u32
+	forced_fsck        u32
+	os_id              u32
+	version_maj        u32
+	user_id            u16
+	group_id           u16
 
-	first_inode u32
-	inode_size u16
-	sb_bgd u16
-	opt_features u32
-	req_features u32
+	first_inode            u32
+	inode_size             u16
+	sb_bgd                 u16
+	opt_features           u32
+	req_features           u32
 	non_supported_features u32
-	uuid[2] u64
-	volume_name[2] u64
-	last_mnt_path[8] u64
+	uuid                   [2]u64
+	volume_name            [2]u64
+	last_mnt_path          [8]u64
 }
 
 @[packed]
 struct EXT2BlockGroupDescriptor {
 pub mut:
-	block_addr_bitmap u32
-	block_addr_inode u32
-	inode_table_block u32
+	block_addr_bitmap  u32
+	block_addr_inode   u32
+	inode_table_block  u32
 	unallocated_blocks u16
 	unallocated_inodes u16
-	dir_cnt u16
-	reserved[7] u16
+	dir_cnt            u16
+	reserved           [7]u16
 }
 
 @[packed]
 struct EXT2Inode {
 pub mut:
-	permissions u16
-	user_id u16
-	size32l u32
-	access_time u32
+	permissions   u16
+	user_id       u16
+	size32l       u32
+	access_time   u32
 	creation_time u32
-	mod_time u32
-	del_time u32
-	group_id u16
+	mod_time      u32
+	del_time      u32
+	group_id      u16
 	hard_link_cnt u16
-	sector_cnt u32
-	flags u32
-	oss1 u32
-	blocks[15] u32
-	gen_num u32
-	eab u32
-	size32h u32
-	frag_addr u32
+	sector_cnt    u32
+	flags         u32
+	oss1          u32
+	blocks        [15]u32
+	gen_num       u32
+	eab           u32
+	size32h       u32
+	frag_addr     u32
 }
 
 @[packed]
 struct EXT2DirectoryEntry {
 pub mut:
 	inode_index u32
-	entry_size u16
+	entry_size  u16
 	name_length u8
-	dir_type u8
+	dir_type    u8
 }
 
 struct EXT2Resource {
 pub mut:
-	stat	 stat.Stat
+	stat     stat.Stat
 	refcount int
-	l		 klock.Lock
-	event	 eventstruct.Event
-	status	 int
+	l        klock.Lock
+	event    eventstruct.Event
+	status   int
 	can_mmap bool
 
 	filesystem &EXT2Filesystem
@@ -113,21 +113,17 @@ fn (mut this EXT2Resource) mmap(page u64, flags int) voidptr {
 }
 
 fn (mut this EXT2Resource) read(handle voidptr, buf voidptr, loc u64, count u64) ?i64 {
-	mut current_inode := &EXT2Inode { }
+	mut current_inode := &EXT2Inode{}
 
-	current_inode.read_entry(mut this.filesystem, u32(this.stat.ino)) or {
-		return none
-	}
+	current_inode.read_entry(mut this.filesystem, u32(this.stat.ino)) or { return none }
 
 	return current_inode.read(mut this.filesystem, buf, loc, count)
 }
 
 fn (mut this EXT2Resource) write(handle voidptr, buf voidptr, loc u64, count u64) ?i64 {
-	mut current_inode := &EXT2Inode { }
+	mut current_inode := &EXT2Inode{}
 
-	current_inode.read_entry(mut this.filesystem, u32(this.stat.ino)) or {
-		return none
-	}
+	current_inode.read_entry(mut this.filesystem, u32(this.stat.ino)) or { return none }
 
 	return current_inode.write(mut this.filesystem, buf, u32(this.stat.ino), loc, count)
 }
@@ -143,26 +139,22 @@ fn (mut this EXT2Resource) unref(handle voidptr) ? {
 fn (mut this EXT2Resource) grow(handle voidptr, new_size u64) ? {
 	this.l.acquire()
 
-	mut current_inode := &EXT2Inode { }
+	mut current_inode := &EXT2Inode{}
 
-	current_inode.read_entry(mut this.filesystem, u32(this.stat.ino)) or {
-		return none
-	}
+	current_inode.read_entry(mut this.filesystem, u32(this.stat.ino)) or { return none }
 
-	current_inode.resize(mut this.filesystem, u32(this.stat.ino), 0, new_size) or {
-		return none
-	}
+	current_inode.resize(mut this.filesystem, u32(this.stat.ino), 0, new_size) or { return none }
 
 	this.l.release()
 }
 
 struct EXT2Filesystem {
 pub mut:
-	stat stat.Stat
+	stat     stat.Stat
 	refcount int
-	l klock.Lock
-	event eventstruct.Event
-	status int
+	l        klock.Lock
+	event    eventstruct.Event
+	status   int
 	can_mmap bool
 
 	dev_id u64
@@ -171,28 +163,27 @@ pub mut:
 	root_inode &EXT2Inode
 
 	block_size u64
-	frag_size u64
-	bgd_cnt u64
+	frag_size  u64
+	bgd_cnt    u64
 
 	backing_device &fs.VFSNode
 }
 
 fn (mut this EXT2Filesystem) populate(node &fs.VFSNode) {
-	mut parent := &EXT2Inode {}
-	parent.read_entry(mut this, u32(node.resource.stat.ino)) or {
-		return
-	}
+	mut parent := &EXT2Inode{}
+	parent.read_entry(mut this, u32(node.resource.stat.ino)) or { return }
 
 	buffer := &voidptr(memory.calloc(parent.size32l, 1))
-	parent.read(mut this, buffer, 0, parent.size32l) or {
-		return
-	}
+	parent.read(mut this, buffer, 0, parent.size32l) or { return }
 
 	for i := u32(0); i < parent.size32l; {
 		dir_entry := &EXT2DirectoryEntry(u64(buffer) + i)
-	
+
 		name_buffer := memory.calloc(dir_entry.name_length + 1, 1)
-		unsafe { C.memcpy(name_buffer, voidptr(u64(dir_entry) + sizeof(EXT2DirectoryEntry)), u64(dir_entry.name_length)) }
+		unsafe {
+			C.memcpy(name_buffer, voidptr(u64(dir_entry) + sizeof(EXT2DirectoryEntry)),
+				u64(dir_entry.name_length))
+		}
 		name := unsafe { tos(&char(name_buffer), dir_entry.name_length) }
 
 		if dir_entry.inode_index == 0 {
@@ -200,10 +191,8 @@ fn (mut this EXT2Filesystem) populate(node &fs.VFSNode) {
 			return
 		}
 
-		mut inode := &EXT2Inode {}
-		inode.read_entry(mut this, dir_entry.inode_index) or {
-			return
-		}
+		mut inode := &EXT2Inode{}
+		inode.read_entry(mut this, dir_entry.inode_index) or { return }
 
 		mut mode := u16(0)
 
@@ -215,11 +204,13 @@ fn (mut this EXT2Filesystem) populate(node &fs.VFSNode) {
 			5 { mode |= stat.ififo }
 			6 { mode |= stat.ifsock }
 			7 { mode |= stat.iflnk }
-			else { }
+			else {}
 		}
 
 		mut vfs_node := fs.create_node(this, node, name, stat.isdir(mode))
-		mut resource := &EXT2Resource { filesystem: unsafe { this } }
+		mut resource := &EXT2Resource{
+			filesystem: unsafe { this }
+		}
 
 		resource.stat.mode = 0o644 | mode
 		resource.stat.ino = dir_entry.inode_index
@@ -234,8 +225,9 @@ fn (mut this EXT2Filesystem) populate(node &fs.VFSNode) {
 
 		vfs_node.resource = resource
 
-		unsafe { vfs_node.parent.children[name] = vfs_node }
-
+		unsafe {
+			vfs_node.parent.children[name] = vfs_node
+		}
 		i += dir_entry.entry_size
 	}
 
@@ -243,7 +235,7 @@ fn (mut this EXT2Filesystem) populate(node &fs.VFSNode) {
 }
 
 fn (mut bro EXT2Filesystem) instantiate() &fs.FileSystem {
-	mut this := &EXT2Filesystem {
+	mut this := &EXT2Filesystem{
 		backing_device: bro.backing_device
 		superblock: bro.superblock
 		root_inode: bro.root_inode
@@ -272,7 +264,9 @@ fn (mut bro EXT2Filesystem) instantiate() &fs.FileSystem {
 fn (mut this EXT2Filesystem) symlink(parent &fs.VFSNode, dest string, target string) &fs.VFSNode {
 	mut new_node := fs.create_node(this, parent, target, false)
 
-	mut resource := &EXT2Resource { filesystem: unsafe { this } }
+	mut resource := &EXT2Resource{
+		filesystem: unsafe { this }
+	}
 
 	resource.stat.size = u64(target.len)
 	resource.stat.blocks = 0
@@ -294,7 +288,9 @@ fn (mut this EXT2Filesystem) symlink(parent &fs.VFSNode, dest string, target str
 fn (mut this EXT2Filesystem) create(parent &fs.VFSNode, name string, mode u32) &fs.VFSNode {
 	mut new_node := fs.create_node(this, parent, name, stat.isdir(mode))
 
-	mut resource := &EXT2Resource { filesystem: unsafe { this } }
+	mut resource := &EXT2Resource{
+		filesystem: unsafe { this }
+	}
 
 	resource.stat.size = 0
 	resource.stat.blocks = 0
@@ -307,15 +303,11 @@ fn (mut this EXT2Filesystem) create(parent &fs.VFSNode, name string, mode u32) &
 	resource.stat.ctim = realtime_clock
 	resource.stat.mtim = realtime_clock
 
-	resource.stat.ino = this.allocate_inode() or {
-		return 0
-	}
+	resource.stat.ino = this.allocate_inode() or { return 0 }
 
-	mut parent_inode := &EXT2Inode {}
-	parent_inode.read_entry(mut this, u32(parent.resource.stat.ino)) or {
-		return 0
-	}
-	
+	mut parent_inode := &EXT2Inode{}
+	parent_inode.read_entry(mut this, u32(parent.resource.stat.ino)) or { return 0 }
+
 	mut file_type := 0
 
 	if stat.isreg(mode) {
@@ -334,9 +326,8 @@ fn (mut this EXT2Filesystem) create(parent &fs.VFSNode, name string, mode u32) &
 		file_type = 7
 	}
 
-	this.dir_create_entry(mut parent_inode, u32(parent.resource.stat.ino), u32(resource.stat.ino), file_type, name) or {
-		return 0
-	}
+	this.dir_create_entry(mut parent_inode, u32(parent.resource.stat.ino), u32(resource.stat.ino),
+		file_type, name) or { return 0 }
 
 	new_node.resource = resource
 
@@ -348,7 +339,9 @@ fn (mut this EXT2Filesystem) mount(parent &fs.VFSNode, name string, source &fs.V
 
 	mut target := fs.create_node(this, parent, name, true)
 
-	mut resource := &EXT2Resource { filesystem: unsafe { this } }
+	mut resource := &EXT2Resource{
+		filesystem: unsafe { this }
+	}
 
 	resource.stat.size = this.root_inode.size32l | (u64(this.root_inode.size32h) >> 32)
 	resource.stat.blksize = this.block_size
@@ -372,9 +365,7 @@ fn (mut this EXT2Filesystem) mount(parent &fs.VFSNode, name string, source &fs.V
 
 fn (mut fs EXT2Filesystem) dir_create_entry(mut parent EXT2Inode, parent_inode_index u32, new_inode u32, dir_type u8, name string) ?int {
 	buffer := &voidptr(memory.calloc(parent.size32l, 1))
-	parent.read(mut fs, buffer, 0, parent.size32l) or {
-		return none
-	}
+	parent.read(mut fs, buffer, 0, parent.size32l) or { return none }
 
 	mut found := false
 
@@ -387,16 +378,18 @@ fn (mut fs EXT2Filesystem) dir_create_entry(mut parent EXT2Inode, parent_inode_i
 			dir_entry.name_length = name.len
 			dir_entry.entry_size = u16(parent.size32l - i)
 
-			unsafe { C.memcpy(voidptr(u64(dir_entry) + sizeof(EXT2DirectoryEntry)), name.str, name.len) }
-
-			parent.write(mut fs, buffer, parent_inode_index, 0, parent.size32l) or {
-				return none
+			unsafe {
+				C.memcpy(voidptr(u64(dir_entry) + sizeof(EXT2DirectoryEntry)), name.str,
+					name.len)
 			}
+
+			parent.write(mut fs, buffer, parent_inode_index, 0, parent.size32l) or { return none }
 
 			return 0
 		}
-	
-		expected_size := lib.align_up(sizeof(EXT2DirectoryEntry) + dir_entry.name_length, 4)
+
+		expected_size := lib.align_up(sizeof(EXT2DirectoryEntry) + dir_entry.name_length,
+			4)
 		if dir_entry.entry_size != expected_size {
 			dir_entry.entry_size = u16(expected_size)
 			i += u32(expected_size)
@@ -435,13 +428,10 @@ fn (mut inode EXT2Inode) read(mut fs &EXT2Filesystem, buf voidptr, off u64, cnt 
 			size = fs.block_size - offset
 		}
 
-		disk_block := inode.get_block(mut fs, u32(iblock)) or {
-			return none
-		}
+		disk_block := inode.get_block(mut fs, u32(iblock)) or { return none }
 
-		fs.raw_device_read(voidptr(u64(buf) + headway), disk_block * fs.block_size + offset, size) or {
-			return none
-		}
+		fs.raw_device_read(voidptr(u64(buf) + headway), disk_block * fs.block_size + offset,
+			size) or { return none }
 
 		headway += size
 	}
@@ -453,7 +443,7 @@ fn (mut inode EXT2Inode) resize(mut fs &EXT2Filesystem, inode_index u32, start u
 	sector_size := fs.backing_device.resource.stat.blksize
 
 	if (start + cnt) < (inode.sector_cnt * sector_size) {
-		return 0		
+		return 0
 	}
 
 	iblock_start := lib.div_roundup(inode.sector_cnt * sector_size, fs.block_size)
@@ -464,28 +454,20 @@ fn (mut inode EXT2Inode) resize(mut fs &EXT2Filesystem, inode_index u32, start u
 	}
 
 	for i := iblock_start; i < iblock_end; i++ {
-		disk_block := fs.allocate_block() or {
-			return none
-		}
+		disk_block := fs.allocate_block() or { return none }
 
 		inode.sector_cnt = u32(fs.block_size / sector_size)
 
-		inode.set_block(mut fs, inode_index, u32(i), disk_block) or {
-			return none
-		}
+		inode.set_block(mut fs, inode_index, u32(i), disk_block) or { return none }
 	}
 
-	inode.write_entry(mut fs, inode_index) or {
-		return none
-	}
+	inode.write_entry(mut fs, inode_index) or { return none }
 
 	return 0
 }
 
 fn (mut inode EXT2Inode) write(mut fs &EXT2Filesystem, buf voidptr, inode_index u32, off u64, cnt u64) ?i64 {
-	inode.resize(mut fs, inode_index, off, cnt) or {
-		return none
-	}
+	inode.resize(mut fs, inode_index, off, cnt) or { return none }
 
 	for headway := u64(0); headway < cnt; {
 		iblock := (off + headway) / fs.block_size
@@ -497,13 +479,10 @@ fn (mut inode EXT2Inode) write(mut fs &EXT2Filesystem, buf voidptr, inode_index 
 			size = fs.block_size - offset
 		}
 
-		disk_block := inode.get_block(mut fs, u32(iblock)) or {
-			return none
-		}
+		disk_block := inode.get_block(mut fs, u32(iblock)) or { return none }
 
-		fs.raw_device_write(voidptr(u64(buf) + headway), disk_block * fs.block_size + offset, size) or {
-			return none
-		}
+		fs.raw_device_write(voidptr(u64(buf) + headway), disk_block * fs.block_size + offset,
+			size) or { return none }
 
 		headway += size
 	}
@@ -512,23 +491,16 @@ fn (mut inode EXT2Inode) write(mut fs &EXT2Filesystem, buf voidptr, inode_index 
 }
 
 fn (mut inode EXT2Inode) free_entry(mut fs &EXT2Filesystem, inode_index u32) ?int {
-	for i := u64(0); i < lib.div_roundup(inode.sector_cnt * fs.backing_device.resource.stat.blksize, fs.block_size); i++ {
-		block_index := inode.get_block(mut fs, u32(i)) or {
-			return none
-		}
+	for i := u64(0); i < lib.div_roundup(inode.sector_cnt * fs.backing_device.resource.stat.blksize,
+		fs.block_size); i++ {
+		block_index := inode.get_block(mut fs, u32(i)) or { return none }
 
-		fs.free_block(block_index) or {
-			return none
-		}
+		fs.free_block(block_index) or { return none }
 
-		inode.set_block(mut fs, inode_index, u32(i), 0) or {
-			return none
-		}
+		inode.set_block(mut fs, inode_index, u32(i), 0) or { return none }
 	}
 
-	fs.free_inode(inode_index) or {
-		return none
-	}
+	fs.free_inode(inode_index) or { return none }
 
 	return 0
 }
@@ -559,99 +531,73 @@ fn (mut inode EXT2Inode) set_block(mut fs &EXT2Filesystem, inode_index u32, iblo
 			mut single_indirect_index := u32(0)
 
 			if inode.blocks[14] == 0 {
-				inode.blocks[14] = fs.allocate_block() or {
-					return none
-				}
+				inode.blocks[14] = fs.allocate_block() or { return none }
 
-				inode.write_entry(mut fs, inode_index) or {
-					return none
-				}
+				inode.write_entry(mut fs, inode_index) or { return none }
 			}
 
-			fs.raw_device_read(voidptr(&single_indirect_index), inode.blocks[14] * fs.block_size + double_indirect_index * 4, 4) or {
-				return none
-			}
+			fs.raw_device_read(voidptr(&single_indirect_index), inode.blocks[14] * fs.block_size +
+				double_indirect_index * 4, 4) or { return none }
 
 			if single_indirect_index == 0 {
-				new_block := fs.allocate_block() or {
-					return none
-				}
+				new_block := fs.allocate_block() or { return none }
 
-				fs.raw_device_write(voidptr(&new_block), inode.blocks[14] * fs.block_size + double_indirect_index * 4, 4) or {
-					return none
-				}
+				fs.raw_device_write(voidptr(&new_block), inode.blocks[14] * fs.block_size +
+					double_indirect_index * 4, 4) or { return none }
 
 				single_indirect_index = new_block
 			}
 
-			fs.raw_device_read(voidptr(&indirect_block), double_indirect_index * fs.block_size + single_indirect_index * 4, 4) or {
-				return none
-			}
+			fs.raw_device_read(voidptr(&indirect_block), double_indirect_index * fs.block_size +
+				single_indirect_index * 4, 4) or { return none }
 
 			if indirect_block == 0 {
-				new_block := fs.allocate_block() or {
-					return none
-				}
+				new_block := fs.allocate_block() or { return none }
 
-				fs.raw_device_write(voidptr(&indirect_block), double_indirect_index * fs.block_size + single_indirect_index * 4, 4) or {
-					return none
-				}
+				fs.raw_device_write(voidptr(&indirect_block),
+					double_indirect_index * fs.block_size + single_indirect_index * 4,
+					4) or { return none }
 
 				indirect_block = new_block
 			}
 
-			fs.raw_device_write(voidptr(&disk_block), indirect_block * fs.block_size + indirect_offset * 4, 4) or {
-				return none
-			}
+			fs.raw_device_write(voidptr(&disk_block), indirect_block * fs.block_size +
+				indirect_offset * 4, 4) or { return none }
 
 			return disk_block
 		}
 
 		if inode.blocks[13] == 0 {
-			inode.blocks[13] = fs.allocate_block() or {
-				return none
-			}
+			inode.blocks[13] = fs.allocate_block() or { return none }
 
-			inode.write_entry(mut fs, inode_index) or {
-				return none
-			}
+			inode.write_entry(mut fs, inode_index) or { return none }
 		}
 
-		fs.raw_device_read(voidptr(&indirect_block), inode.blocks[13] * fs.block_size + single_index * 4, 4) or {
-			return none
-		}
+		fs.raw_device_read(voidptr(&indirect_block), inode.blocks[13] * fs.block_size +
+			single_index * 4, 4) or { return none }
 
 		if indirect_block == 0 {
-			new_block := fs.allocate_block() or {
-				return none
-			}
+			new_block := fs.allocate_block() or { return none }
 
-			fs.raw_device_write(voidptr(&new_block), inode.blocks[13] * fs.block_size + single_index * 4, 4) or {
-				return none
-			}
-			
+			fs.raw_device_write(voidptr(&new_block), inode.blocks[13] * fs.block_size +
+				single_index * 4, 4) or { return none }
+
 			indirect_block = new_block
 		}
 
-		fs.raw_device_write(voidptr(&disk_block), indirect_block * fs.block_size + indirect_offset * 4, 4) or {
-			return none
-		}
-		
+		fs.raw_device_write(voidptr(&disk_block), indirect_block * fs.block_size +
+			indirect_offset * 4, 4) or { return none }
+
 		return disk_block
 	} else {
 		if inode.blocks[12] == 0 {
-			inode.blocks[12] = fs.allocate_block() or {
-				return none
-			}
+			inode.blocks[12] = fs.allocate_block() or { return none }
 
-			inode.write_entry(mut fs, inode_index) or {
-				return none
-			}
+			inode.write_entry(mut fs, inode_index) or { return none }
 		}
 
-		fs.raw_device_write(voidptr(&disk_block), inode.blocks[12] * fs.block_size + block * 4, 4) or {
-			return none
-		}
+		fs.raw_device_write(voidptr(&disk_block), inode.blocks[12] * fs.block_size + block * 4,
+			4) or { return none }
 	}
 
 	return disk_block
@@ -683,48 +629,40 @@ fn (mut inode EXT2Inode) get_block(mut fs &EXT2Filesystem, iblock u32) ?u32 {
 			indirect_offset = block % blocks_per_level
 			single_indirect_index := u32(0)
 
-			fs.raw_device_read(voidptr(&single_indirect_index), inode.blocks[14] * fs.block_size + double_indirect_index * 4, 4) or {
-				return none
-			}
+			fs.raw_device_read(voidptr(&single_indirect_index), inode.blocks[14] * fs.block_size +
+				double_indirect_index * 4, 4) or { return none }
 
-			fs.raw_device_read(voidptr(&indirect_block), double_indirect_index * fs.block_size + single_indirect_index * 4, 4) or {
-				return none
-			}
+			fs.raw_device_read(voidptr(&indirect_block), double_indirect_index * fs.block_size +
+				single_indirect_index * 4, 4) or { return none }
 
-			fs.raw_device_read(voidptr(&disk_block_index), indirect_block * fs.block_size + indirect_offset * 4, 4) or {
-				return none
-			}
+			fs.raw_device_read(voidptr(&disk_block_index), indirect_block * fs.block_size +
+				indirect_offset * 4, 4) or { return none }
 
 			return disk_block_index
 		}
 
-		fs.raw_device_read(voidptr(&indirect_block), inode.blocks[13] * fs.block_size + single_index * 4, 4) or {
-			return none
-		}
+		fs.raw_device_read(voidptr(&indirect_block), inode.blocks[13] * fs.block_size +
+			single_index * 4, 4) or { return none }
 
-		fs.raw_device_read(voidptr(&disk_block_index), indirect_block * fs.block_size + indirect_offset * 4, 4) or {
-			return none
-		}
+		fs.raw_device_read(voidptr(&disk_block_index), indirect_block * fs.block_size +
+			indirect_offset * 4, 4) or { return none }
 
 		return disk_block_index
 	}
 
-	fs.raw_device_read(voidptr(&disk_block_index), inode.blocks[12] * fs.block_size + block * 4, 4) or {
-		return none
-	}
+	fs.raw_device_read(voidptr(&disk_block_index), inode.blocks[12] * fs.block_size + block * 4,
+		4) or { return none }
 
 	return disk_block_index
 }
 
 fn (mut fs EXT2Filesystem) allocate_block() ?u32 {
-	mut bgd := &EXT2BlockGroupDescriptor { }
+	mut bgd := &EXT2BlockGroupDescriptor{}
 
 	for i := u32(0); i < fs.bgd_cnt; i++ {
 		bgd.read_entry(mut fs, i)
-		
-		block_index := bgd.allocate_block(mut fs, i) or {
-			continue
-		}
+
+		block_index := bgd.allocate_block(mut fs, i) or { continue }
 
 		return u32(block_index + i * fs.superblock.blocks_per_group)
 	}
@@ -733,14 +671,12 @@ fn (mut fs EXT2Filesystem) allocate_block() ?u32 {
 }
 
 fn (mut fs EXT2Filesystem) allocate_inode() ?u64 {
-	mut bgd := &EXT2BlockGroupDescriptor {}
+	mut bgd := &EXT2BlockGroupDescriptor{}
 
 	for i := u32(0); i < fs.bgd_cnt; i++ {
 		bgd.read_entry(mut fs, i)
-		
-		inode_index := bgd.allocate_inode(mut fs, i) or {
-			continue
-		}
+
+		inode_index := bgd.allocate_inode(mut fs, i) or { continue }
 
 		return inode_index + i * fs.superblock.blocks_per_group
 	}
@@ -753,7 +689,7 @@ fn (mut fs EXT2Filesystem) free_block(block u32) ?int {
 	bitmap_index := block - bgd_index * fs.superblock.blocks_per_group
 	bitmap := memory.calloc(lib.div_roundup(fs.block_size, u64(8)), 1)
 
-	mut bgd := &EXT2BlockGroupDescriptor {}
+	mut bgd := &EXT2BlockGroupDescriptor{}
 	bgd.read_entry(mut fs, bgd_index)
 
 	fs.raw_device_read(bitmap, bgd.block_addr_bitmap * fs.block_size, fs.block_size) or {
@@ -786,7 +722,7 @@ fn (mut fs EXT2Filesystem) free_inode(inode u32) ?int {
 	bitmap_index := inode - bgd_index * fs.superblock.inodes_per_group
 	bitmap := memory.calloc(lib.div_roundup(fs.block_size, u64(8)), 1)
 
-	mut bgd := &EXT2BlockGroupDescriptor {}
+	mut bgd := &EXT2BlockGroupDescriptor{}
 	bgd.read_entry(mut fs, bgd_index)
 
 	fs.raw_device_read(bitmap, bgd.block_addr_inode * fs.block_size, fs.block_size) or {
@@ -814,7 +750,7 @@ fn (mut fs EXT2Filesystem) free_inode(inode u32) ?int {
 	return 0
 }
 
-fn (mut bgd EXT2BlockGroupDescriptor) read_entry(mut fs &EXT2Filesystem, bgd_index u32) int {	
+fn (mut bgd EXT2BlockGroupDescriptor) read_entry(mut fs &EXT2Filesystem, bgd_index u32) int {
 	mut bgd_offset := u64(0)
 
 	if fs.block_size >= 2048 {
@@ -823,7 +759,8 @@ fn (mut bgd EXT2BlockGroupDescriptor) read_entry(mut fs &EXT2Filesystem, bgd_ind
 		bgd_offset = fs.block_size * 2
 	}
 
-	fs.raw_device_read(voidptr(&bgd), bgd_offset + sizeof(EXT2BlockGroupDescriptor) * bgd_index, sizeof(EXT2BlockGroupDescriptor)) or {
+	fs.raw_device_read(voidptr(&bgd), bgd_offset + sizeof(EXT2BlockGroupDescriptor) * bgd_index,
+		sizeof(EXT2BlockGroupDescriptor)) or {
 		print('ext2: unable to read bgd entry\n')
 		return -1
 	}
@@ -840,7 +777,8 @@ fn (mut bgd EXT2BlockGroupDescriptor) write_entry(mut fs &EXT2Filesystem, bgd_in
 		bgd_offset = fs.block_size * 2
 	}
 
-	fs.raw_device_write(voidptr(&bgd), bgd_offset + sizeof(EXT2BlockGroupDescriptor) * bgd_index, sizeof(EXT2BlockGroupDescriptor)) or {
+	fs.raw_device_write(voidptr(&bgd), bgd_offset + sizeof(EXT2BlockGroupDescriptor) * bgd_index,
+		sizeof(EXT2BlockGroupDescriptor)) or {
 		print('ext2: unable to read bgd entry\n')
 		return -1
 	}
@@ -868,7 +806,7 @@ fn (mut bgd EXT2BlockGroupDescriptor) allocate_block(mut fs &EXT2Filesystem, bgd
 				print('ext2: unable to write bgd bitmap\n')
 				return none
 			}
-	
+
 			bgd.unallocated_blocks--
 			bgd.write_entry(mut fs, bgd_index)
 
@@ -922,10 +860,11 @@ fn (mut inode EXT2Inode) read_entry(mut fs &EXT2Filesystem, inode_index u32) ?in
 	inode_table_index := (inode_index - 1) % fs.superblock.inodes_per_group
 	bgd_index := (inode_index - 1) / fs.superblock.inodes_per_group
 
-	mut bgd := &EXT2BlockGroupDescriptor { }
+	mut bgd := &EXT2BlockGroupDescriptor{}
 	bgd.read_entry(mut fs, bgd_index)
 
-	fs.raw_device_read(voidptr(&inode), bgd.inode_table_block * fs.block_size + fs.superblock.inode_size * inode_table_index, sizeof(EXT2Inode)) or {
+	fs.raw_device_read(voidptr(&inode), bgd.inode_table_block * fs.block_size +
+		fs.superblock.inode_size * inode_table_index, sizeof(EXT2Inode)) or {
 		print('ext2: unable to read inode entry\n')
 		return none
 	}
@@ -937,10 +876,11 @@ fn (mut inode EXT2Inode) write_entry(mut fs &EXT2Filesystem, inode_index u32) ?i
 	inode_table_index := (inode_index - 1) % fs.superblock.inodes_per_group
 	bgd_index := (inode_index - 1) / fs.superblock.inodes_per_group
 
-	mut bgd := &EXT2BlockGroupDescriptor { }
+	mut bgd := &EXT2BlockGroupDescriptor{}
 	bgd.read_entry(mut fs, bgd_index)
 
-	fs.raw_device_write(voidptr(&inode), bgd.inode_table_block * fs.block_size + fs.superblock.inode_size * inode_table_index, sizeof(EXT2Inode)) or {
+	fs.raw_device_write(voidptr(&inode), bgd.inode_table_block * fs.block_size +
+		fs.superblock.inode_size * inode_table_index, sizeof(EXT2Inode)) or {
 		print('ext2: unable to read inode entry\n')
 		return none
 	}
@@ -959,7 +899,8 @@ fn (mut fs EXT2Filesystem) raw_device_read(buf voidptr, loc u64, count u64) ?i64
 	lba_start := u64(loc / lba_size)
 	lba_cnt := u64(lib.div_roundup(count, lba_size) + alignment)
 
-	buffer := voidptr(u64(memory.pmm_alloc(lib.div_roundup(lba_cnt * lba_size, page_size))) + higher_half)
+	buffer := voidptr(u64(memory.pmm_alloc(lib.div_roundup(lba_cnt * lba_size, page_size))) +
+		higher_half)
 
 	fs.backing_device.resource.read(0, buffer, lba_start * lba_size, lba_cnt * lba_size) or {
 		print('ext2: unable to read from device\n')
@@ -970,7 +911,8 @@ fn (mut fs EXT2Filesystem) raw_device_read(buf voidptr, loc u64, count u64) ?i64
 
 	unsafe { C.memcpy(buf, voidptr(u64(buffer) + lba_offset), count) }
 
-	memory.pmm_free(voidptr(u64(buffer) - higher_half), lib.div_roundup(lba_cnt * lba_size, page_size))
+	memory.pmm_free(voidptr(u64(buffer) - higher_half), lib.div_roundup(lba_cnt * lba_size,
+		page_size))
 
 	return i64(count)
 }
@@ -986,7 +928,8 @@ fn (mut fs EXT2Filesystem) raw_device_write(buf voidptr, loc u64, count u64) ?i6
 	lba_start := u64(loc / lba_size)
 	lba_cnt := u64(lib.div_roundup(count, lba_size) + alignment)
 
-	buffer := voidptr(u64(memory.pmm_alloc(lib.div_roundup(lba_cnt * lba_size, page_size))) + higher_half)
+	buffer := voidptr(u64(memory.pmm_alloc(lib.div_roundup(lba_cnt * lba_size, page_size))) +
+		higher_half)
 
 	fs.backing_device.resource.read(0, buffer, lba_start * lba_size, lba_cnt * lba_size) or {
 		print('ext2: unable to write from device\n')
@@ -1002,21 +945,21 @@ fn (mut fs EXT2Filesystem) raw_device_write(buf voidptr, loc u64, count u64) ?i6
 		return none
 	}
 
-	memory.pmm_free(voidptr(u64(buffer) - higher_half), lib.div_roundup(lba_cnt * lba_size, page_size))
+	memory.pmm_free(voidptr(u64(buffer) - higher_half), lib.div_roundup(lba_cnt * lba_size,
+		page_size))
 
 	return i64(count)
 }
 
 pub fn ext2_init(backing_device &fs.VFSNode) (&EXT2Filesystem, bool) {
-	mut new_filesystem := &EXT2Filesystem {
+	mut new_filesystem := &EXT2Filesystem{
 		backing_device: unsafe { backing_device }
-		superblock: &EXT2Superblock { }
-		root_inode: &EXT2Inode { }
+		superblock: &EXT2Superblock{}
+		root_inode: &EXT2Inode{}
 	}
 
-	new_filesystem.raw_device_read(new_filesystem.superblock, backing_device.resource.stat.blksize * 2, sizeof(EXT2Superblock)) or {
-		return 0, false
-	}
+	new_filesystem.raw_device_read(new_filesystem.superblock, backing_device.resource.stat.blksize * 2,
+		sizeof(EXT2Superblock)) or { return 0, false }
 
 	if new_filesystem.superblock.signature != 0xef53 {
 		return 0, false

--- a/kernel/modules/fs/vfs.v
+++ b/kernel/modules/fs/vfs.v
@@ -11,15 +11,15 @@ import proc
 import file
 import errno
 
-pub const at_fdcwd            = -100
-pub const at_empty_path       = 0x1000
-pub const at_symlink_follow   = 0x400
+pub const at_fdcwd = -100
+pub const at_empty_path = 0x1000
+pub const at_symlink_follow = 0x400
 pub const at_symlink_nofollow = 0x100
-pub const at_removedir        = 0x200
-pub const at_eaccess          = 0x200
-pub const seek_cur            = 1
-pub const seek_end            = 2
-pub const seek_set            = 0
+pub const at_removedir = 0x200
+pub const at_eaccess = 0x200
+pub const seek_cur = 1
+pub const seek_end = 2
+pub const seek_set = 0
 
 interface FileSystem {
 mut:
@@ -33,12 +33,12 @@ mut:
 
 pub struct VFSNode {
 pub mut:
-	mountpoint     &VFSNode = unsafe { nil }
-	redir          &VFSNode = unsafe { nil }
+	mountpoint     &VFSNode           = unsafe { nil }
+	redir          &VFSNode           = unsafe { nil }
 	resource       &resource.Resource = unsafe { nil }
 	filesystem     &FileSystem        = unsafe { nil }
 	name           string
-	parent         &VFSNode = unsafe { nil }
+	parent         &VFSNode             = unsafe { nil }
 	children       &map[string]&VFSNode = unsafe { nil }
 	symlink_target string
 }
@@ -479,7 +479,6 @@ pub fn syscall_rmdirat(_ voidptr, dirfd int, _path charptr) (u64, u64) {
 		free(target_node.children['..'])
 		free(target_node.children)
 	}
-
 	parent_of_tgt_node.children.delete(basename)
 
 	return 0, 0

--- a/kernel/modules/futex/futex.v
+++ b/kernel/modules/futex/futex.v
@@ -24,7 +24,8 @@ pub fn syscall_futex_wait(_ voidptr, ptr &int, expected int) (u64, u64) {
 	mut current_thread := proc.current_thread()
 	mut process := current_thread.process
 
-	C.printf(c'\n\e[32m%s\e[m: futex_wait(0x%llx, %d)\n', process.name.str, voidptr(ptr), expected)
+	C.printf(c'\n\e[32m%s\e[m: futex_wait(0x%llx, %d)\n', process.name.str, voidptr(ptr),
+		expected)
 	defer {
 		C.printf(c'\e[32m%s\e[m: returning\n', process.name.str)
 	}
@@ -34,7 +35,9 @@ pub fn syscall_futex_wait(_ voidptr, ptr &int, expected int) (u64, u64) {
 	}
 
 	mut e := &eventstruct.Event(unsafe { nil })
-	phys := proc.current_thread().process.pagemap.virt2phys(u64(ptr)) or { return errno.err, errno.get() }
+	phys := proc.current_thread().process.pagemap.virt2phys(u64(ptr)) or {
+		return errno.err, errno.get()
+	}
 
 	futex_lock.acquire()
 
@@ -68,7 +71,9 @@ pub fn syscall_futex_wake(_ voidptr, ptr &int) (u64, u64) {
 	// Ensure this page is not lazily mapped
 	katomic.load(ptr)
 
-	phys := proc.current_thread().process.pagemap.virt2phys(u64(ptr)) or { return errno.err, errno.get() }
+	phys := proc.current_thread().process.pagemap.virt2phys(u64(ptr)) or {
+		return errno.err, errno.get()
+	}
 
 	futex_lock.acquire()
 	defer {

--- a/kernel/modules/initramfs/initramfs.v
+++ b/kernel/modules/initramfs/initramfs.v
@@ -30,13 +30,13 @@ struct USTARHeader {
 }
 
 enum USTARFileType {
-	regular_file = 0x30
-	hard_link = 0x31
-	sym_link = 0x32
-	char_dev = 0x33
-	block_dev = 0x34
-	directory = 0x35
-	fifo = 0x36
+	regular_file  = 0x30
+	hard_link     = 0x31
+	sym_link      = 0x32
+	char_dev      = 0x33
+	block_dev     = 0x34
+	directory     = 0x35
+	fifo          = 0x36
 	gnu_long_path = 0x4c
 }
 
@@ -49,8 +49,8 @@ fn octal_to_int(s string) u64 {
 	return ret
 }
 
-@[cinit]
 @[_linker_section: '.requests']
+@[cinit]
 __global (
 	volatile module_req = limine.LimineModuleRequest{
 		response: unsafe { nil }
@@ -115,29 +115,29 @@ pub fn initialise() {
 			}
 			.directory {
 				fs.create(vfs_root, name, u32(mode | stat.ifdir)) or {
-					panic('initramfs: failed to create directory $name')
+					panic('initramfs: failed to create directory ${name}')
 				}
 			}
 			.regular_file {
 				new_node := fs.create(vfs_root, name, u32(mode | stat.ifreg)) or {
-					panic('initramfs: failed to create file $name')
+					panic('initramfs: failed to create file ${name}')
 				}
 				mut new_resource := new_node.resource
 				buf := voidptr(u64(current_header) + 512)
 				new_resource.write(0, buf, 0, size) or {
-					panic('initramfs: failed to write file $name')
+					panic('initramfs: failed to write file ${name}')
 				}
 			}
 			.sym_link {
 				fs.symlink(vfs_root, link_name, name) or {
-					panic('initramfs: failed to create symlink $name')
+					panic('initramfs: failed to create symlink ${name}')
 				}
 			}
 			else {}
 		}
 
 		next:
-		//memory.pmm_free(voidptr(u64(current_header) - higher_half), (u64(512) +
+		// memory.pmm_free(voidptr(u64(current_header) - higher_half), (u64(512) +
 		//	lib.align_up(size, 512)) / page_size)
 
 		current_header = &USTARHeader(usize(current_header) + usize(512) +

--- a/kernel/modules/ioctl/common.v
+++ b/kernel/modules/ioctl/common.v
@@ -25,20 +25,20 @@ pub const ioc_dirshift = (ioc_sizeshift + ioc_sizebits)
 
 @[inline]
 pub fn ioctl_dir(ioc u32) u32 {
-	return (ioc >> ioc_dirshift) & ioc_dirmask
+	return (ioc >> ioctl.ioc_dirshift) & ioctl.ioc_dirmask
 }
 
 @[inline]
 pub fn ioctl_type(ioc u32) u32 {
-	return (ioc >> ioc_typeshift) & ioc_typemask
+	return (ioc >> ioctl.ioc_typeshift) & ioctl.ioc_typemask
 }
 
 @[inline]
 pub fn ioctl_size(ioc u32) u32 {
-	return (ioc >> ioc_sizeshift) & ioc_sizemask
+	return (ioc >> ioctl.ioc_sizeshift) & ioctl.ioc_sizemask
 }
 
 @[inline]
 pub fn ioctl_nr(ioc u32) u32 {
-	return (ioc >> ioc_nrshift) & ioc_nrmask
+	return (ioc >> ioctl.ioc_nrshift) & ioctl.ioc_nrmask
 }

--- a/kernel/modules/katomic/katomic.v
+++ b/kernel/modules/katomic/katomic.v
@@ -4,12 +4,11 @@
 
 module katomic
 
-pub fn bts<T>(mut var T, bit u8) bool {
+pub fn bts[T](mut var T, bit u8) bool {
 	mut ret := false
 	unsafe {
 		asm volatile amd64 {
-			lock
-			bts var, bit
+			lock bts var, bit
 			; +m (*var) as var
 			  =@ccc (ret)
 			; r (u16(bit)) as bit
@@ -19,12 +18,11 @@ pub fn bts<T>(mut var T, bit u8) bool {
 	return ret
 }
 
-pub fn btr<T>(mut var T, bit u8) bool {
+pub fn btr[T](mut var T, bit u8) bool {
 	mut ret := false
 	unsafe {
 		asm volatile amd64 {
-			lock
-			btr var, bit
+			lock btr var, bit
 			; +m (*var) as var
 			  =@ccc (ret)
 			; r (u16(bit)) as bit
@@ -34,13 +32,12 @@ pub fn btr<T>(mut var T, bit u8) bool {
 	return ret
 }
 
-pub fn cas<T>(mut here T, _ifthis T, writethis T) bool {
+pub fn cas[T](mut here T, _ifthis T, writethis T) bool {
 	mut ret := false
 	mut ifthis := _ifthis
 	unsafe {
 		asm volatile amd64 {
-			lock
-			cmpxchg here, writethis
+			lock cmpxchg here, writethis
 			; +a (ifthis)
 			  +m (*here) as here
 			  =@ccz (ret)
@@ -51,12 +48,11 @@ pub fn cas<T>(mut here T, _ifthis T, writethis T) bool {
 	return ret
 }
 
-pub fn inc<T>(mut var T) T {
+pub fn inc[T](mut var T) T {
 	mut diff := unsafe { T(1) }
 	unsafe {
 		asm volatile amd64 {
-			lock
-			xadd var, diff
+			lock xadd var, diff
 			; +m (*var) as var
 			  +r (diff)
 			; ; memory
@@ -65,13 +61,12 @@ pub fn inc<T>(mut var T) T {
 	return diff
 }
 
-pub fn dec<T>(mut var T) bool {
+pub fn dec[T](mut var T) bool {
 	mut ret := false
 	unsafe {
 		mut diff := T(-1)
 		asm volatile amd64 {
-			lock
-			xadd var, diff
+			lock xadd var, diff
 			; +m (*var) as var
 			  +r (diff)
 			  =@ccnz (ret)
@@ -81,11 +76,10 @@ pub fn dec<T>(mut var T) bool {
 	return ret
 }
 
-pub fn store<T>(mut var T, value T) {
+pub fn store[T](mut var T, value T) {
 	unsafe {
 		asm volatile amd64 {
-			lock
-			xchg var, value
+			lock xchg var, value
 			; +m (*var) as var
 			  +r (value)
 			; ; memory
@@ -93,12 +87,11 @@ pub fn store<T>(mut var T, value T) {
 	}
 }
 
-pub fn load<T>(var &T) T {
+pub fn load[T](var &T) T {
 	mut ret := unsafe { T(0) }
 	unsafe {
 		asm volatile amd64 {
-			lock
-			xadd var, ret
+			lock xadd var, ret
 			; +m (*var) as var
 			  +r (ret)
 			; ; memory

--- a/kernel/modules/lib/math.v
+++ b/kernel/modules/lib/math.v
@@ -4,7 +4,7 @@
 
 module lib
 
-pub fn div_roundup<T>(a T, b T) T {
+pub fn div_roundup[T](a T, b T) T {
 	return (a + (b - 1)) / b
 }
 

--- a/kernel/modules/limine/limine.v
+++ b/kernel/modules/limine/limine.v
@@ -1,25 +1,28 @@
 module limine
 
-@[cinit]
 @[_linker_section: '.requests_start_marker']
+@[cinit]
 __global (
 	volatile limine_requests_start_marker = [
-		u64(0xf6b8f4b39de7d1ae), 0xfab91a6940fcb9cf,
-		0x785c6ed015d3e316, 0x181e920a7852b9d9
+		u64(0xf6b8f4b39de7d1ae),
+		0xfab91a6940fcb9cf,
+		0x785c6ed015d3e316,
+		0x181e920a7852b9d9,
 	]!
 )
 
-@[cinit]
 @[_linker_section: '.requests_end_marker']
+@[cinit]
 __global (
 	volatile limine_requests_end_marker = [
-		u64(0xadc0e0531bb10d03), 0x9572709f31764c62
+		u64(0xadc0e0531bb10d03),
+		0x9572709f31764c62,
 	]!
 )
 
 pub struct LimineBaseRevision {
 pub mut:
-	id [2]u64 = [ u64(0xf9562b2d5c95a6c8), 0x6a7b384944536bdc ]!
+	id       [2]u64 = [u64(0xf9562b2d5c95a6c8), 0x6a7b384944536bdc]!
 	revision u64
 }
 
@@ -33,20 +36,20 @@ pub mut:
 
 pub struct LimineFile {
 pub mut:
-	revision u64
-	address voidptr
-	size u64
-	path charptr
-	cmdline charptr
-	media_type u32
-	unused u32
-	tftp_ip u32
-	tftp_port u32
+	revision        u64
+	address         voidptr
+	size            u64
+	path            charptr
+	cmdline         charptr
+	media_type      u32
+	unused          u32
+	tftp_ip         u32
+	tftp_port       u32
 	partition_index u32
-	mbr_disk_id u32
-	gpt_disk_uuid LimineUUID
-	gpt_part_uuid LimineUUID
-	part_uuid LimineUUID
+	mbr_disk_id     u32
+	gpt_disk_uuid   LimineUUID
+	gpt_part_uuid   LimineUUID
+	part_uuid       LimineUUID
 }
 
 // Boot info
@@ -54,16 +57,18 @@ pub mut:
 pub struct LimineBootloaderInfoResponse {
 pub mut:
 	revision u64
-	name charptr
-	version charptr
+	name     charptr
+	version  charptr
 }
 
 pub struct LimineBootloaderInfoRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0xf55038d8e2a1202f, 0x279426fcf5f59740
-	]!
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0xf55038d8e2a1202f,
+	0x279426fcf5f59740,
+]!
 	revision u64
 	response &LimineBootloaderInfoResponse
 }
@@ -78,11 +83,13 @@ pub mut:
 pub struct LimineStackSizeRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0x224ef0460a8e8926, 0xe1cb0fc25f46ea3d
-	]!
-	revision u64
-	response &LimineStackSizeResponse
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0x224ef0460a8e8926,
+	0xe1cb0fc25f46ea3d,
+]!
+	revision   u64
+	response   &LimineStackSizeResponse
 	stack_size u64
 }
 
@@ -91,15 +98,17 @@ pub mut:
 pub struct LimineHHDMResponse {
 pub mut:
 	revision u64
-	offset u64
+	offset   u64
 }
 
 pub struct LimineHHDMRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0x48dcf1cb8ad2b852, 0x63984e959a98244b
-	]!
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0x48dcf1cb8ad2b852,
+	0x63984e959a98244b,
+]!
 	revision u64
 	response &LimineHHDMResponse
 }
@@ -108,36 +117,38 @@ pub mut:
 
 pub struct LimineFramebuffer {
 pub mut:
-	address voidptr
-	width u64
-	height u64
-	pitch u64
-	bpp u16
-	memory_model u8
-	red_mask_size u8
-	red_mask_shift u8
-	green_mask_size u8
+	address          voidptr
+	width            u64
+	height           u64
+	pitch            u64
+	bpp              u16
+	memory_model     u8
+	red_mask_size    u8
+	red_mask_shift   u8
+	green_mask_size  u8
 	green_mask_shift u8
-	blue_mask_size u8
-	blue_mask_shift u8
-	unused u8
-	edid_size u64
-	edid voidptr
+	blue_mask_size   u8
+	blue_mask_shift  u8
+	unused           u8
+	edid_size        u64
+	edid             voidptr
 }
 
 pub struct LimineFramebufferResponse {
 pub mut:
-	revision u64
+	revision          u64
 	framebuffer_count u64
-	framebuffers &&LimineFramebuffer
+	framebuffers      &&LimineFramebuffer
 }
 
 pub struct LimineFramebufferRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0x9d5827dcd881dd75, 0xa3148604f6fab11b
-	]!
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0x9d5827dcd881dd75,
+	0xa3148604f6fab11b,
+]!
 	revision u64
 	response &LimineFramebufferResponse
 }
@@ -150,18 +161,20 @@ pub const limine_paging_mode_x86_64_5lvl = 1
 pub struct LiminePagingModeResponse {
 pub mut:
 	revision u64
-	mode u64
+	mode     u64
 }
 
 pub struct LiminePagingModeRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0x95c1a0edab0944cb, 0xa4e5cb3842f7488a
-	]!
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0x95c1a0edab0944cb,
+	0xa4e5cb3842f7488a,
+]!
 	revision u64
 	response &LiminePagingModeResponse
-	mode u64
+	mode     u64
 	max_mode u64
 	min_mode u64
 }
@@ -170,31 +183,33 @@ pub mut:
 
 pub struct LimineSMPInfo {
 pub mut:
-	processor_id u32
-	lapic_id u32
-	reserved u64
-	goto_address fn(&LimineSMPInfo) = unsafe { nil }
+	processor_id   u32
+	lapic_id       u32
+	reserved       u64
+	goto_address   fn (&LimineSMPInfo) = unsafe { nil }
 	extra_argument u64
 }
 
 pub struct LimineSMPResponse {
 pub mut:
-	revision u64
-	flags u32
+	revision     u64
+	flags        u32
 	bsp_lapic_id u32
-	cpu_count u64
-	cpus &&LimineSMPInfo
+	cpu_count    u64
+	cpus         &&LimineSMPInfo
 }
 
 pub struct LimineSMPRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0x95a67b819a1b857e, 0xa0b61b723b6a73e0
-	]!
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0x95a67b819a1b857e,
+	0xa0b61b723b6a73e0,
+]!
 	revision u64
 	response &LimineSMPResponse
-	flags u64
+	flags    u64
 }
 
 // Memory map
@@ -205,24 +220,26 @@ pub const limine_memmap_kernel_and_modules = 6
 
 pub struct LimineMemmapEntry {
 pub mut:
-	base u64
+	base   u64
 	length u64
-	@type u64
+	@type  u64
 }
 
 pub struct LimineMemmapResponse {
 pub mut:
-	revision u64
+	revision    u64
 	entry_count u64
-	entries &&LimineMemmapEntry
+	entries     &&LimineMemmapEntry
 }
 
 pub struct LimineMemmapRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0x67cf3d9d378a806f, 0xe304acdfc50c3c62
-	]!
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0x67cf3d9d378a806f,
+	0xe304acdfc50c3c62,
+]!
 	revision u64
 	response &LimineMemmapResponse
 }
@@ -237,28 +254,32 @@ pub mut:
 pub struct LimineEntryPointRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0x13d86c035a1cd3e1, 0x2b0caa89d8f3026a
-	]!
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0x13d86c035a1cd3e1,
+	0x2b0caa89d8f3026a,
+]!
 	revision u64
 	response &LimineEntryPointResponse
-	entry fn() = unsafe { nil }
+	entry    fn () = unsafe { nil }
 }
 
 // Kernel file
 
 pub struct LimineKernelFileResponse {
 pub mut:
-	revision u64
+	revision    u64
 	kernel_file &LimineFile
 }
 
 pub struct LimineKernelFileRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0xad97e90e83f1ed67, 0x31eb5d1c5ff23b69
-	]!
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0xad97e90e83f1ed67,
+	0x31eb5d1c5ff23b69,
+]!
 	revision u64
 	response &LimineKernelFileResponse
 }
@@ -267,17 +288,19 @@ pub mut:
 
 pub struct LimineModuleResponse {
 pub mut:
-	revision u64
+	revision     u64
 	module_count u64
-	modules &&LimineFile
+	modules      &&LimineFile
 }
 
 pub struct LimineModuleRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0x3e7e279702be32af, 0xca1c4f3bd1280cee
-	]!
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0x3e7e279702be32af,
+	0xca1c4f3bd1280cee,
+]!
 	revision u64
 	response &LimineModuleResponse
 }
@@ -287,15 +310,17 @@ pub mut:
 pub struct LimineRSDPResponse {
 pub mut:
 	revision u64
-	address voidptr
+	address  voidptr
 }
 
 pub struct LimineRSDPRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0xc5e77b6b397e7b43, 0x27637845accdcf3c
-	]!
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0xc5e77b6b397e7b43,
+	0x27637845accdcf3c,
+]!
 	revision u64
 	response &LimineRSDPResponse
 }
@@ -312,9 +337,11 @@ pub mut:
 pub struct LimineSMBIOSRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0x9e9046f11e095391, 0xaa4a520fefbde5ee
-	]!
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0x9e9046f11e095391,
+	0xaa4a520fefbde5ee,
+]!
 	revision u64
 	response &LimineSMBIOSResponse
 }
@@ -324,15 +351,17 @@ pub mut:
 pub struct LimineEFISystemTableResponse {
 pub mut:
 	revision u64
-	address voidptr
+	address  voidptr
 }
 
 pub struct LimineEFISystemTableRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0x5ceba5163eaaf6d6, 0x0a6981610cf65fcc
-	]!
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0x5ceba5163eaaf6d6,
+	0x0a6981610cf65fcc,
+]!
 	revision u64
 	response &LimineEFISystemTableResponse
 }
@@ -341,16 +370,18 @@ pub mut:
 
 pub struct LimineBootTimeResponse {
 pub mut:
-	revision u64
+	revision  u64
 	boot_time i64
 }
 
 pub struct LimineBootTimeRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0x502746e184c088aa, 0xfbc5ec83e6327893
-	]!
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0x502746e184c088aa,
+	0xfbc5ec83e6327893,
+]!
 	revision u64
 	response &LimineBootTimeResponse
 }
@@ -359,17 +390,19 @@ pub mut:
 
 pub struct LimineKernelAddressResponse {
 pub mut:
-	revision u64
+	revision      u64
 	physical_base u64
-	virtual_base u64
+	virtual_base  u64
 }
 
 pub struct LimineKernelAddressRequest {
 pub mut:
 	id [4]u64 = [
-		u64(0xc7b1dd30df4c8b88), 0x0a82e883a194f07b,
-		0x71ba76863cc55f63, 0xb2644a48c516a487
-	]!
+	u64(0xc7b1dd30df4c8b88),
+	0x0a82e883a194f07b,
+	0x71ba76863cc55f63,
+	0xb2644a48c516a487,
+]!
 	revision u64
 	response &LimineKernelAddressResponse
 }

--- a/kernel/modules/memory/mmap/mmap.v
+++ b/kernel/modules/memory/mmap/mmap.v
@@ -12,14 +12,14 @@ import x86.cpu
 import x86.cpu.local as cpulocal
 import lib
 
-pub const prot_none     = 0x00
-pub const prot_read     = 0x01
-pub const prot_write    = 0x02
-pub const prot_exec     = 0x04
-pub const map_private   = 0x02
-pub const map_shared    = 0x01
-pub const map_fixed     = 0x10
-pub const map_anon      = 0x20
+pub const prot_none = 0x00
+pub const prot_read = 0x01
+pub const prot_write = 0x02
+pub const prot_exec = 0x04
+pub const map_private = 0x02
+pub const map_shared = 0x01
+pub const map_fixed = 0x10
+pub const map_anon = 0x20
 pub const map_anonymous = 0x20
 
 pub struct MmapRangeLocal {
@@ -47,9 +47,10 @@ pub fn list_ranges(pagemap &memory.Pagemap) {
 	C.printf(c'Ranges for %llx:\n', voidptr(pagemap))
 	for i := u64(0); i < pagemap.mmap_ranges.len; i++ {
 		r := unsafe { &MmapRangeLocal(pagemap.mmap_ranges[i]) }
-		C.printf(c'                                Base: %p  Length: %p  Offset: %p\n', r.base, r.length,
-			r.offset)
-		C.printf(c'    Global: %p  Base: %p  Length: %p  Offset: %p\n', r.global, r.global.base, r.global.length, r.global.offset)
+		C.printf(c'                                Base: %p  Length: %p  Offset: %p\n',
+			r.base, r.length, r.offset)
+		C.printf(c'    Global: %p  Base: %p  Length: %p  Offset: %p\n', r.global, r.global.base,
+			r.global.length, r.global.offset)
 	}
 }
 
@@ -73,7 +74,7 @@ pub fn delete_pagemap(mut pagemap memory.Pagemap) ? {
 	for ptr in mmap_ranges {
 		local_range := unsafe { &MmapRangeLocal(ptr) }
 
-		munmap_unlocked(mut pagemap, voidptr(local_range.base), local_range.length) or { }
+		munmap_unlocked(mut pagemap, voidptr(local_range.base), local_range.length) or {}
 	}
 
 	unsafe {
@@ -372,7 +373,7 @@ pub fn mprotect(mut pagemap memory.Pagemap, addr voidptr, len u64, prot int) ? {
 		pagemap.l.release()
 	}
 
-	mprotect_unlocked(mut pagemap, addr, len, prot) ?
+	mprotect_unlocked(mut pagemap, addr, len, prot)?
 }
 
 pub fn mprotect_unlocked(mut pagemap memory.Pagemap, addr voidptr, _length u64, prot int) ? {
@@ -462,7 +463,7 @@ pub fn munmap(mut pagemap memory.Pagemap, addr voidptr, len u64) ? {
 		pagemap.l.release()
 	}
 
-	munmap_unlocked(mut pagemap, addr, len) ?
+	munmap_unlocked(mut pagemap, addr, len)?
 }
 
 pub fn munmap_unlocked(mut pagemap memory.Pagemap, addr voidptr, _length u64) ? {

--- a/kernel/modules/memory/physical.v
+++ b/kernel/modules/memory/physical.v
@@ -18,8 +18,8 @@ __global (
 	higher_half         = u64(0)
 )
 
-@[cinit]
 @[_linker_section: '.requests']
+@[cinit]
 __global (
 	volatile hhdm_req = limine.LimineHHDMRequest{
 		response: unsafe { nil }
@@ -53,8 +53,8 @@ pub fn pmm_init() {
 
 		// Calculate how big the memory map needs to be.
 		for i := 0; i < memmap.entry_count; i++ {
-			C.printf(c'pmm: Memory map entry %d: 0x%llx->0x%llx  0x%llx\n',
-					 i, entries[i].base, entries[i].length, entries[i].@type)
+			C.printf(c'pmm: Memory map entry %d: 0x%llx->0x%llx  0x%llx\n', i, entries[i].base,
+				entries[i].length, entries[i].@type)
 
 			if entries[i].@type != u32(limine.limine_memmap_usable)
 				&& entries[i].@type != u32(limine.limine_memmap_bootloader_reclaimable)

--- a/kernel/modules/net/hostname.v
+++ b/kernel/modules/net/hostname.v
@@ -8,8 +8,8 @@ import errno
 
 const hostname_len = 64
 
-__global(
-	hostname [hostname_len]char
+__global (
+	hostname [net.hostname_len]char
 )
 
 pub fn syscall_gethostname(_ voidptr, name charptr, len u64) (u64, u64) {
@@ -24,7 +24,7 @@ pub fn syscall_gethostname(_ voidptr, name charptr, len u64) (u64, u64) {
 }
 
 pub fn syscall_sethostname(_ voidptr, name charptr, len u64) (u64, u64) {
-	if len > hostname_len - 1 {
+	if len > net.hostname_len - 1 {
 		return errno.err, errno.einval
 	}
 

--- a/kernel/modules/pci/scan.v
+++ b/kernel/modules/pci/scan.v
@@ -17,7 +17,7 @@ const max_bus = 256
 pub fn initialise() {
 	print('pci: Building device scan\n')
 	mut root_bus := PCIDevice{}
-	configc := root_bus.read<u32>(0xc)
+	configc := root_bus.read[u32](0xc)
 
 	if (configc & 0x800000) == 0 {
 		check_bus(0, -1)
@@ -29,7 +29,7 @@ pub fn initialise() {
 				function: function
 				parent: 0
 			}
-			config0 := host_bridge.read<u32>(0)
+			config0 := host_bridge.read[u32](0)
 			if config0 == 0xffffffff {
 				continue
 			}
@@ -61,18 +61,18 @@ fn check_function(bus u8, slot u8, function u8, parent i64) {
 
 	// Handle PCI to PCI bridges, and we are done.
 	if device.class == 0x6 && device.subclass == 0x4 {
-		config := device.read<u32>(0x18)
+		config := device.read[u32](0x18)
 		check_bus(u8(config >> 8), 1)
 	} else {
 		scanned_devices << device
 
-		status := device.read<u16>(0x6)
+		status := device.read[u16](0x6)
 
 		if (status & (1 << 4)) != 0 { // parse capabilities list
-			mut off := device.read<u8>(0x34)
+			mut off := device.read[u8](0x34)
 
 			for off > 0 {
-				id := device.read<u8>(off)
+				id := device.read[u8](off)
 
 				match id {
 					0x5 {
@@ -83,7 +83,7 @@ fn check_function(bus u8, slot u8, function u8, parent i64) {
 						device.msix_support = true
 						device.msix_offset = off
 
-						message_control := device.read<u16>(off + 2)
+						message_control := device.read[u16](off + 2)
 
 						device.msix_table_size = message_control & 0x7FF
 						device.msix_table_bitmap.initialise(device.msix_table_size)
@@ -91,7 +91,7 @@ fn check_function(bus u8, slot u8, function u8, parent i64) {
 					else {}
 				}
 
-				off = device.read<u8>(off + 1)
+				off = device.read[u8](off + 1)
 			}
 		}
 

--- a/kernel/modules/resource/resource.v
+++ b/kernel/modules/resource/resource.v
@@ -37,11 +37,11 @@ pub const file_status_flags_mask = ~(file_creation_flags_mask | file_descriptor_
 
 pub interface Resource {
 mut:
-	stat stat.Stat
+	stat     stat.Stat
 	refcount int
-	l klock.Lock
-	event eventstruct.Event
-	status int
+	l        klock.Lock
+	event    eventstruct.Event
+	status   int
 	can_mmap bool
 	grow(handle voidptr, new_size u64) ?
 	read(handle voidptr, buf voidptr, loc u64, count u64) ?i64

--- a/kernel/modules/socket/public/public.v
+++ b/kernel/modules/socket/public/public.v
@@ -18,7 +18,6 @@ pub const sock_cloexec = 0o2000000
 
 pub interface Socket {
 	Resource
-
 mut:
 	bind(handle voidptr, _addr voidptr, addrlen u32) ?
 	connect(handle voidptr, _addr voidptr, addrlen u32) ?
@@ -31,16 +30,16 @@ mut:
 pub struct IoVec {
 pub mut:
 	iov_base voidptr
-	iov_len u64
+	iov_len  u64
 }
 
 pub struct MsgHdr {
 pub mut:
-	msg_name voidptr
-	msg_namelen u32
-	msg_iov &IoVec
-	msg_iovlen u64
-	msg_control voidptr
+	msg_name       voidptr
+	msg_namelen    u32
+	msg_iov        &IoVec
+	msg_iovlen     u64
+	msg_control    voidptr
 	msg_controllen u64
-	msg_flags int
+	msg_flags      int
 }

--- a/kernel/modules/socket/socket.v
+++ b/kernel/modules/socket/socket.v
@@ -16,7 +16,7 @@ pub fn initialise() {}
 fn socketpair_create(domain int, @type int, protocol int) ?(&resource.Resource, &resource.Resource) {
 	match domain {
 		sock_pub.af_unix {
-			socket0, socket1 := sock_unix.create_pair(@type) ?
+			socket0, socket1 := sock_unix.create_pair(@type)?
 			return &resource.Resource(*socket0), &resource.Resource(*socket1)
 		}
 		else {
@@ -30,7 +30,7 @@ fn socketpair_create(domain int, @type int, protocol int) ?(&resource.Resource, 
 fn socket_create(domain int, @type int, protocol int) ?&resource.Resource {
 	match domain {
 		sock_pub.af_unix {
-			ret := sock_unix.create(@type) ?
+			ret := sock_unix.create(@type)?
 			return ret
 		}
 		else {
@@ -45,8 +45,8 @@ pub fn syscall_socketpair(_ voidptr, domain int, @type int, protocol int, ret &i
 	mut current_thread := proc.current_thread()
 	mut process := current_thread.process
 
-	C.printf(c'\n\e[32m%s\e[m: socketpair(%d, 0x%x, %d, 0x%llx)\n', process.name.str, domain, @type,
-		protocol, voidptr(ret))
+	C.printf(c'\n\e[32m%s\e[m: socketpair(%d, 0x%x, %d, 0x%llx)\n', process.name.str,
+		domain, @type, protocol, voidptr(ret))
 	defer {
 		C.printf(c'\e[32m%s\e[m: returning\n', process.name.str)
 	}
@@ -79,7 +79,8 @@ pub fn syscall_socket(_ voidptr, domain int, @type int, protocol int) (u64, u64)
 	mut current_thread := proc.current_thread()
 	mut process := current_thread.process
 
-	C.printf(c'\n\e[32m%s\e[m: socket(%d, 0x%x, %d)\n', process.name.str, domain, @type, protocol)
+	C.printf(c'\n\e[32m%s\e[m: socket(%d, 0x%x, %d)\n', process.name.str, domain, @type,
+		protocol)
 	defer {
 		C.printf(c'\e[32m%s\e[m: returning\n', process.name.str)
 	}
@@ -125,13 +126,10 @@ pub fn syscall_accept(_ voidptr, fdnum int) (u64, u64) {
 		return errno.err, errno.einval
 	}
 
-	mut connection_socket := sock.accept(fd.handle) or {
-		return errno.err, errno.get()
-	}
+	mut connection_socket := sock.accept(fd.handle) or { return errno.err, errno.get() }
 
-	ret := file.fdnum_create_from_resource(unsafe { nil }, mut connection_socket, 0, 0, false) or {
-		return errno.err, errno.get()
-	}
+	ret := file.fdnum_create_from_resource(unsafe { nil }, mut connection_socket, 0, 0,
+		false) or { return errno.err, errno.get() }
 
 	return u64(ret), 0
 }
@@ -140,7 +138,8 @@ pub fn syscall_bind(_ voidptr, fdnum int, _addr voidptr, addrlen u32) (u64, u64)
 	mut current_thread := proc.current_thread()
 	mut process := current_thread.process
 
-	C.printf(c'\n\e[32m%s\e[m: bind(%d, 0x%llx, 0x%llx)\n', process.name.str, fdnum, _addr, addrlen)
+	C.printf(c'\n\e[32m%s\e[m: bind(%d, 0x%llx, 0x%llx)\n', process.name.str, fdnum, _addr,
+		addrlen)
 	defer {
 		C.printf(c'\e[32m%s\e[m: returning\n', process.name.str)
 	}
@@ -198,7 +197,8 @@ pub fn syscall_recvmsg(_ voidptr, fdnum int, msg &sock_pub.MsgHdr, flags int) (u
 	mut current_thread := proc.current_thread()
 	mut process := current_thread.process
 
-	C.printf(c'\n\e[32m%s\e[m: recvmsg(%d, 0x%llx, 0x%x)\n', process.name.str, fdnum, voidptr(msg), flags)
+	C.printf(c'\n\e[32m%s\e[m: recvmsg(%d, 0x%llx, 0x%x)\n', process.name.str, fdnum,
+		voidptr(msg), flags)
 	defer {
 		C.printf(c'\e[32m%s\e[m: returning\n', process.name.str)
 	}
@@ -227,7 +227,8 @@ pub fn syscall_connect(_ voidptr, fdnum int, _addr voidptr, addrlen u32) (u64, u
 	mut current_thread := proc.current_thread()
 	mut process := current_thread.process
 
-	C.printf(c'\n\e[32m%s\e[m: connect(%d, 0x%llx, 0x%llx)\n', process.name.str, fdnum, _addr, addrlen)
+	C.printf(c'\n\e[32m%s\e[m: connect(%d, 0x%llx, 0x%llx)\n', process.name.str, fdnum,
+		_addr, addrlen)
 	defer {
 		C.printf(c'\e[32m%s\e[m: returning\n', process.name.str)
 	}
@@ -256,7 +257,8 @@ pub fn syscall_getpeername(_ voidptr, fdnum int, _addr voidptr, addrlen &u32) (u
 	mut current_thread := proc.current_thread()
 	mut process := current_thread.process
 
-	C.printf(c'\n\e[32m%s\e[m: getpeername(%d, 0x%llx, 0x%llx)\n', process.name.str, fdnum, _addr, addrlen)
+	C.printf(c'\n\e[32m%s\e[m: getpeername(%d, 0x%llx, 0x%llx)\n', process.name.str, fdnum,
+		_addr, addrlen)
 	defer {
 		C.printf(c'\e[32m%s\e[m: returning\n', process.name.str)
 	}

--- a/kernel/modules/stat/stat.v
+++ b/kernel/modules/stat/stat.v
@@ -6,13 +6,13 @@ module stat
 
 import time
 
-pub const ifmt   = 0xf000
-pub const ifblk  = 0x6000
-pub const ifchr  = 0x2000
-pub const ififo  = 0x1000
-pub const ifreg  = 0x8000
-pub const ifdir  = 0x4000
-pub const iflnk  = 0xa000
+pub const ifmt = 0xf000
+pub const ifblk = 0x6000
+pub const ifchr = 0x2000
+pub const ififo = 0x1000
+pub const ifreg = 0x8000
+pub const ifdir = 0x4000
+pub const iflnk = 0xa000
 pub const ifsock = 0xc000
 pub const ifpipe = 0x3000
 
@@ -64,14 +64,14 @@ pub mut:
 }
 
 pub const dt_unknown = 0
-pub const dt_fifo    = 1
-pub const dt_chr     = 2
-pub const dt_dir     = 4
-pub const dt_blk     = 6
-pub const dt_reg     = 8
-pub const dt_lnk     = 10
-pub const dt_sock    = 12
-pub const dt_wht     = 14
+pub const dt_fifo = 1
+pub const dt_chr = 2
+pub const dt_dir = 4
+pub const dt_blk = 6
+pub const dt_reg = 8
+pub const dt_lnk = 10
+pub const dt_sock = 12
+pub const dt_wht = 14
 
 pub struct Dirent {
 pub mut:

--- a/kernel/modules/syscall/table/syscall_table.v
+++ b/kernel/modules/syscall/table/syscall_table.v
@@ -23,7 +23,7 @@ __global (
 )
 
 fn syscall_vacant(_ voidptr) (u64, u64) {
-    return u64(-1), errno.enosys
+	return u64(-1), errno.enosys
 }
 
 pub fn init_syscall_table() {

--- a/kernel/modules/term/term.v
+++ b/kernel/modules/term/term.v
@@ -12,8 +12,7 @@ import flanterm as _
 import memory
 
 __global (
-	flanterm_ctx voidptr
-
+	flanterm_ctx        voidptr
 	terminal_print_lock klock.Lock
 	terminal_rows       = u64(0)
 	terminal_cols       = u64(0)
@@ -22,8 +21,8 @@ __global (
 	framebuffer_height  = u64(0)
 )
 
-@[cinit]
 @[_linker_section: '.requests']
+@[cinit]
 __global (
 	volatile fb_req = limine.LimineFramebufferRequest{
 		response: unsafe { nil }
@@ -38,50 +37,45 @@ pub fn initialise() {
 	framebuffer_width = framebuffer_tag.width
 	framebuffer_height = framebuffer_tag.height
 
-	flanterm_ctx = unsafe { C.flanterm_fb_init(voidptr(memory.malloc), voidptr(memory.free),
-											   framebuffer_tag.address, framebuffer_width, framebuffer_height, framebuffer_tag.pitch,
-											   framebuffer_tag.red_mask_size, framebuffer_tag.red_mask_shift,
-											   framebuffer_tag.green_mask_size, framebuffer_tag.green_mask_shift,
-											   framebuffer_tag.blue_mask_size, framebuffer_tag.blue_mask_shift,
-											   nil,
-											   nil, nil,
-											   nil, nil,
-											   nil, nil,
-											   nil, 0, 0, 1,
-											   0, 0,
-											   0) }
+	flanterm_ctx = unsafe {
+		C.flanterm_fb_init(voidptr(memory.malloc), voidptr(memory.free), framebuffer_tag.address,
+			framebuffer_width, framebuffer_height, framebuffer_tag.pitch, framebuffer_tag.red_mask_size,
+			framebuffer_tag.red_mask_shift, framebuffer_tag.green_mask_size, framebuffer_tag.green_mask_shift,
+			framebuffer_tag.blue_mask_size, framebuffer_tag.blue_mask_shift, nil, nil,
+			nil, nil, nil, nil, nil, nil, 0, 0, 1, 0, 0, 0)
+	}
 
 	terminal_rows = C.flanterm_get_rows(flanterm_ctx)
 	terminal_cols = C.flanterm_get_cols(flanterm_ctx)
 }
 
 pub fn framebuffer_init() {
-	sfb_config := simple.SimpleFBConfig {
-		physical_address: u64(framebuffer_tag.address),
-		width: u32(framebuffer_width),
-		height: u32(framebuffer_height),
-		stride: u32(framebuffer_tag.pitch),
-		bits_per_pixel: u32(framebuffer_tag.bpp),
-		red: api.FBBitfield {
-			offset: framebuffer_tag.red_mask_shift,
-			length: framebuffer_tag.red_mask_size,
-			msb_right: 0,
-		},
-		green: api.FBBitfield {
-			offset: framebuffer_tag.green_mask_shift,
-			length: framebuffer_tag.green_mask_size,
-			msb_right: 0,
-		},
-		blue: api.FBBitfield {
-			offset: framebuffer_tag.blue_mask_shift,
-			length: framebuffer_tag.blue_mask_size,
-			msb_right: 0,
-		},
-		transp: api.FBBitfield {
-			offset: 0,
-			length: 0,
-			msb_right: 0,
-		},
+	sfb_config := simple.SimpleFBConfig{
+		physical_address: u64(framebuffer_tag.address)
+		width: u32(framebuffer_width)
+		height: u32(framebuffer_height)
+		stride: u32(framebuffer_tag.pitch)
+		bits_per_pixel: u32(framebuffer_tag.bpp)
+		red: api.FBBitfield{
+			offset: framebuffer_tag.red_mask_shift
+			length: framebuffer_tag.red_mask_size
+			msb_right: 0
+		}
+		green: api.FBBitfield{
+			offset: framebuffer_tag.green_mask_shift
+			length: framebuffer_tag.green_mask_size
+			msb_right: 0
+		}
+		blue: api.FBBitfield{
+			offset: framebuffer_tag.blue_mask_shift
+			length: framebuffer_tag.blue_mask_size
+			msb_right: 0
+		}
+		transp: api.FBBitfield{
+			offset: 0
+			length: 0
+			msb_right: 0
+		}
 	}
 
 	simple.register_simple_framebuffer(sfb_config)

--- a/kernel/modules/time/pit.v
+++ b/kernel/modules/time/pit.v
@@ -11,17 +11,17 @@ import x86.cpu.local as cpulocal
 pub const pit_dividend = u64(1193182)
 
 pub fn pit_get_current_count() u16 {
-	kio.port_out<u8>(0x43, 0)
-	lo := kio.port_in<u8>(0x40)
-	hi := kio.port_in<u8>(0x40)
+	kio.port_out[u8](0x43, 0)
+	lo := kio.port_in[u8](0x40)
+	hi := kio.port_in[u8](0x40)
 	return (u16(hi) << 8) | lo
 }
 
 pub fn pit_set_reload_value(new_count u16) {
 	// Channel 0, lo/hi access mode, mode 2 (rate generator)
-	kio.port_out<u8>(0x43, 0x34)
-	kio.port_out<u8>(0x40, u8(new_count))
-	kio.port_out<u8>(0x40, u8(new_count >> 8))
+	kio.port_out[u8](0x43, 0x34)
+	kio.port_out[u8](0x40, u8(new_count))
+	kio.port_out[u8](0x40, u8(new_count >> 8))
 }
 
 pub fn pit_set_frequency(frequency u64) {

--- a/kernel/modules/time/sys/syscalls.v
+++ b/kernel/modules/time/sys/syscalls.v
@@ -11,7 +11,7 @@ import event.eventstruct
 import proc
 
 pub fn nsleep(ns i64) {
-	mut interval := time.TimeSpec {
+	mut interval := time.TimeSpec{
 		tv_sec: ns / 1000000000
 		tv_nsec: ns
 	}
@@ -34,17 +34,22 @@ pub fn syscall_clock_get(_ voidptr, clock_type int, ret &time.TimeSpec) (u64, u6
 	mut current_thread := proc.current_thread()
 	mut process := current_thread.process
 
-	C.printf(c'\n\e[32m%s\e[m: clock_get(%d, 0x%llx)\n', process.name.str, clock_type, voidptr(ret))
+	C.printf(c'\n\e[32m%s\e[m: clock_get(%d, 0x%llx)\n', process.name.str, clock_type,
+		voidptr(ret))
 	defer {
 		C.printf(c'\e[32m%s\e[m: returning\n', process.name.str)
 	}
 
 	match clock_type {
 		time.clock_type_monotonic {
-			unsafe { *ret = monotonic_clock }
+			unsafe {
+				*ret = monotonic_clock
+			}
 		}
 		time.clock_type_realtime {
-			unsafe { *ret = realtime_clock }
+			unsafe {
+				*ret = realtime_clock
+			}
 		}
 		else {
 			C.printf(c'clock_get: Unknown clock type\n')
@@ -59,7 +64,8 @@ pub fn syscall_nanosleep(_ voidptr, req &time.TimeSpec, mut rem time.TimeSpec) (
 	mut current_thread := proc.current_thread()
 	mut process := current_thread.process
 
-	C.printf(c'\n\e[32m%s\e[m: nanosleep(0x%llx, 0x%llx)\n', process.name.str, voidptr(req), voidptr(rem))
+	C.printf(c'\n\e[32m%s\e[m: nanosleep(0x%llx, 0x%llx)\n', process.name.str, voidptr(req),
+		voidptr(rem))
 
 	defer {
 		C.printf(c'\e[32m%s\e[m: returning\n', process.name.str)

--- a/kernel/modules/time/time.v
+++ b/kernel/modules/time/time.v
@@ -57,11 +57,11 @@ pub fn (mut this TimeSpec) sub(interval TimeSpec) bool {
 
 __global (
 	monotonic_clock TimeSpec
-	realtime_clock TimeSpec
+	realtime_clock  TimeSpec
 )
 
-@[cinit]
 @[_linker_section: '.requests']
+@[cinit]
 __global (
 	volatile boottime_req = limine.LimineBootTimeRequest{
 		response: unsafe { nil }
@@ -84,7 +84,7 @@ pub fn initialise() {
 fn C.event__trigger(mut event eventstruct.Event, drop bool) u64
 
 fn timer_handler() {
-	interval := TimeSpec{0, i64(1000000000 / timer_frequency)}
+	interval := TimeSpec{0, i64(1000000000 / time.timer_frequency)}
 
 	monotonic_clock.add(interval)
 	realtime_clock.add(interval)
@@ -114,7 +114,7 @@ pub mut:
 }
 
 __global (
-	timers_lock klock.Lock
+	timers_lock  klock.Lock
 	armed_timers []&Timer
 )
 

--- a/kernel/modules/userland/signalfd.v
+++ b/kernel/modules/userland/signalfd.v
@@ -81,7 +81,8 @@ pub fn syscall_signalfd(_ voidptr, fdnum int, mask u64, flags int) (u64, u64) {
 	mut current_thread := proc.current_thread()
 	mut process := current_thread.process
 
-	C.printf(c'\n\e[32m%s\e[m: signalfd(%d, 0x%llx, 0x%x)\n', process.name.str, fdnum, mask, flags)
+	C.printf(c'\n\e[32m%s\e[m: signalfd(%d, 0x%llx, 0x%x)\n', process.name.str, fdnum,
+		mask, flags)
 	defer {
 		C.printf(c'\e[32m%s\e[m: returning\n', process.name.str)
 	}
@@ -101,9 +102,8 @@ pub fn syscall_signalfd(_ voidptr, fdnum int, mask u64, flags int) (u64, u64) {
 			refcount: 1
 		}
 
-		newfd = file.fdnum_create_from_resource(unsafe { nil }, mut signalfd, flags, 0, false) or {
-			return errno.err, errno.get()
-		}
+		newfd = file.fdnum_create_from_resource(unsafe { nil }, mut signalfd, flags, 0,
+			false) or { return errno.err, errno.get() }
 
 		t.signalfds << voidptr(signalfd)
 	} else {

--- a/kernel/modules/x86/apic/apic.v
+++ b/kernel/modules/x86/apic/apic.v
@@ -9,17 +9,17 @@ import x86.msr
 import x86.cpu.local as cpulocal
 import time
 
-const lapic_reg_icr0          = 0x300
-const lapic_reg_icr1          = 0x310
-const lapic_reg_spurious      = 0x0f0
-const lapic_reg_eoi           = 0x0b0
-const lapic_reg_timer         = 0x320
+const lapic_reg_icr0 = 0x300
+const lapic_reg_icr1 = 0x310
+const lapic_reg_spurious = 0x0f0
+const lapic_reg_eoi = 0x0b0
+const lapic_reg_timer = 0x320
 const lapic_reg_timer_initcnt = 0x380
-const lapic_reg_timer_curcnt  = 0x390
-const lapic_reg_timer_div     = 0x3e0
+const lapic_reg_timer_curcnt = 0x390
+const lapic_reg_timer_div = 0x3e0
 
 __global (
-	lapic_base = u64(0)
+	lapic_base  = u64(0)
 	x2apic_mode = bool(false)
 )
 
@@ -173,7 +173,7 @@ pub fn io_apic_set_irq_redirect(lapic_id u32, vector u8, irq u8, status bool) {
 	for i := 0; i < madt_isos.len; i++ {
 		if madt_isos[i].irq_source == irq {
 			if status {
-				print('apic: IRQ $irq using override\n')
+				print('apic: IRQ ${irq} using override\n')
 			}
 			io_apic_set_gsi_redirect(lapic_id, vector, madt_isos[i].gsi, madt_isos[i].flags,
 				status)

--- a/kernel/modules/x86/cpu/cpu.v
+++ b/kernel/modules/x86/cpu/cpu.v
@@ -9,8 +9,7 @@ import x86.msr
 pub fn invlpg(addr u64) {
 	asm volatile amd64 {
 		invlpg [addr]
-		;
-		; r (addr)
+		; ; r (addr)
 		; memory
 	}
 }

--- a/kernel/modules/x86/cpu/initialisation/initialisation.v
+++ b/kernel/modules/x86/cpu/initialisation/initialisation.v
@@ -134,7 +134,7 @@ pub fn initialise(smp_info &limine.LimineSMPInfo) {
 
 	apic.lapic_timer_calibrate(mut cpu_local)
 
-	print('smp: CPU $cpu_local.cpu_number online!\n')
+	print('smp: CPU ${cpu_local.cpu_number} online!\n')
 
 	katomic.inc(mut &cpu_local.online)
 

--- a/kernel/modules/x86/cpu/local/local.v
+++ b/kernel/modules/x86/cpu/local/local.v
@@ -65,7 +65,7 @@ pub mut:
 	online               u64
 	is_idle              bool
 	last_run_queue_index int
-	abort_stack          [abort_stack_size]u64
+	abort_stack          [local.abort_stack_size]u64
 	aborted              bool
 }
 

--- a/kernel/modules/x86/isr/isr.v
+++ b/kernel/modules/x86/isr/isr.v
@@ -86,7 +86,7 @@ fn exception_handler(num u32, gpr_state &cpulocal.GPRState) {
 		}
 
 		userland.sendsig(proc.current_thread(), signal)
-		//userland.dispatch_a_signal(gpr_state)
+		// userland.dispatch_a_signal(gpr_state)
 		userland.syscall_exit(unsafe { nil }, 128 + signal)
 	} else {
 		lib.kpanic(gpr_state, isr.exception_names[num])

--- a/kernel/modules/x86/kio/kio.v
+++ b/kernel/modules/x86/kio/kio.v
@@ -4,7 +4,7 @@
 
 module kio
 
-pub fn port_in<T>(port u16) T {
+pub fn port_in[T](port u16) T {
 	mut ret := T(0)
 	asm volatile amd64 {
 		in ret, port
@@ -15,7 +15,7 @@ pub fn port_in<T>(port u16) T {
 	return ret
 }
 
-pub fn port_out<T>(port u16, value T) {
+pub fn port_out[T](port u16, value T) {
 	asm volatile amd64 {
 		out port, value
 		; ; a (value)
@@ -24,7 +24,7 @@ pub fn port_out<T>(port u16, value T) {
 	}
 }
 
-pub fn mmin<T>(addr &T) T {
+pub fn mmin[T](addr &T) T {
 	mut ret := T(0)
 	asm volatile amd64 {
 		mov ret, [addr]
@@ -35,7 +35,7 @@ pub fn mmin<T>(addr &T) T {
 	return ret
 }
 
-pub fn mmout<T>(addr &T, value T) {
+pub fn mmout[T](addr &T, value T) {
 	asm volatile amd64 {
 		mov [addr], value
 		; ; r (addr)

--- a/kernel/modules/x86/smp/smp.v
+++ b/kernel/modules/x86/smp/smp.v
@@ -15,8 +15,8 @@ __global (
 	smp_ready    = false
 )
 
-@[cinit]
 @[_linker_section: '.requests']
+@[cinit]
 __global (
 	volatile smp_req = limine.LimineSMPRequest{
 		flags: 1 // x2apic allowed

--- a/util-vinix/chsh/main.v
+++ b/util-vinix/chsh/main.v
@@ -5,6 +5,7 @@
 module main
 
 import os
+
 #include <unistd.h>
 
 fn C.access(name charptr, mode u32) int
@@ -17,8 +18,8 @@ const passwd_file = '/etc/passwd'
 
 fn main() {
 	// Get command line options, and set defaults.
-	mut username    := ''
-	mut new_shell   := ''
+	mut username := ''
+	mut new_shell := ''
 	mut list_shells := false
 
 	mut idx := 1
@@ -68,7 +69,7 @@ fn main() {
 	// Get the shell list and print them if requested.
 	// TODO: Support comments in the shells file.
 	shells := os.read_lines(shells_file) or {
-		println('$shells_file could not be read')
+		println('${shells_file} could not be read')
 		exit(0)
 	}
 	if list_shells {
@@ -79,25 +80,25 @@ fn main() {
 	}
 
 	// Get the shell.
-	if new_shell == "" {
-		println("Changing shell for $username")
-		new_shell = os.input("New shell: ")
+	if new_shell == '' {
+		println('Changing shell for ${username}')
+		new_shell = os.input('New shell: ')
 	}
 
 	// Check whether the shell is valid.
 	if C.access(new_shell.str, access_f_ok | access_r_ok) == 1 {
-		println("$new_shell cannot be found")
+		println('${new_shell} cannot be found')
 	} else if C.access(new_shell.str, access_x_ok) == 1 {
-		println("$new_shell is not executable")
+		println('${new_shell} is not executable')
 	} else if new_shell !in shells {
-		println("$new_shell is not listed in $shells_file")
-		println("Please consider adding it.")
+		println('${new_shell} is not listed in ${shells_file}')
+		println('Please consider adding it.')
 	}
 
 	// Change the shell in the passwd file.
 	old_shell := os.getenv('SHELL')
 	mut passwd_lines := os.read_lines(passwd_file) or {
-		println('$passwd_file could not be read')
+		println('${passwd_file} could not be read')
 		exit(1)
 	}
 	for i, pswd in passwd_lines {
@@ -106,15 +107,15 @@ fn main() {
 		}
 	}
 	mut new_passwd_file := os.create(passwd_file) or {
-		println('$passwd_file could not be created')
+		println('${passwd_file} could not be created')
 		exit(1)
 	}
 	for ln in passwd_lines {
 		new_passwd_file.writeln(ln) or {
-			println('$passwd_file could not be written')
+			println('${passwd_file} could not be written')
 			exit(1)
 		}
 	}
 	new_passwd_file.close()
-	println("Shell changed $old_shell -> $new_shell")
+	println('Shell changed ${old_shell} -> ${new_shell}')
 }

--- a/util-vinix/fetch/main.v
+++ b/util-vinix/fetch/main.v
@@ -11,8 +11,8 @@ import os
 fn C.getlogin() charptr
 fn C.gethostname(name charptr, len u64) int
 
-const escape_cyan  = '\e[1;36m'
-const escape_blue  = '\e[1;34m'
+const escape_cyan = '\e[1;36m'
+const escape_blue = '\e[1;34m'
 const escape_reset = '\e[0m'
 
 fn main() {
@@ -49,15 +49,15 @@ fn main() {
 
 	user := unsafe { cstring_to_vstring(C.getlogin()) }
 	hostname := unsafe { (&hostname_buffer[0]).vstring() }
-	os_name := '$uname_result.sysname $uname_result.machine $uname_result.version'
+	os_name := '${uname_result.sysname} ${uname_result.machine} ${uname_result.version}'
 	kernel := uname_result.sysname
 	shell := os.getenv('SHELL')
 
 	logo_print(r' __          __   ', '')
-	logo_print(r' \ \        / //  ', '$user$escape_blue@$escape_reset$hostname')
-	logo_print(r'  \ \      / //   ', '${escape_blue}OS$escape_reset:     $os_name')
-	logo_print(r'   \ \    / //    ', '${escape_blue}KERNEL$escape_reset: $kernel')
-	logo_print(r'    \ \  / //     ', '${escape_blue}SHELL$escape_reset:  $shell')
+	logo_print(r' \ \        / //  ', '${user}${escape_blue}@${escape_reset}${hostname}')
+	logo_print(r'  \ \      / //   ', '${escape_blue}OS${escape_reset}:     ${os_name}')
+	logo_print(r'   \ \    / //    ', '${escape_blue}KERNEL${escape_reset}: ${kernel}')
+	logo_print(r'    \ \  / //     ', '${escape_blue}SHELL${escape_reset}:  ${shell}')
 	logo_print(r'     \ \/ //      ', '')
 	logo_print(r'      \/_//       ', '')
 	println('')

--- a/util-vinix/lscpu/cpu_x64.v
+++ b/util-vinix/lscpu/cpu_x64.v
@@ -49,12 +49,12 @@ pub fn (info CPUInfo) print() {
 	println('CPU op-mode(s):   32-bit, 64-bit')
 	println('Address sizes:    ${info.address_sizes.join(', ')}')
 	println('Byte Order:       Little Endian')
-	println('CPU Count:        $info.cpu_count')
-	println('Vendor ID:        $info.vendor_id')
-	println('Model name:       $info.model_name')
-	println('CPU family:       $info.cpu_family')
-	println('Model number:     $info.model_number')
-	println('Stepping:         $info.stepping')
+	println('CPU Count:        ${info.cpu_count}')
+	println('Vendor ID:        ${info.vendor_id}')
+	println('Model name:       ${info.model_name}')
+	println('CPU family:       ${info.cpu_family}')
+	println('Model number:     ${info.model_number}')
+	println('Stepping:         ${info.stepping}')
 	println('Flags:            ${info.flags.join(', ')}')
 }
 
@@ -287,68 +287,68 @@ pub fn get_cpu_info() ?CPUInfo {
 	}
 }
 
-const cpuid_feature_ecx_sse3       = 1 << 0
-const cpuid_feature_ecx_pclmul     = 1 << 1
-const cpuid_feature_ecx_dtes64     = 1 << 2
-const cpuid_feature_ecx_monitor    = 1 << 3
-const cpuid_feature_ecx_ds_cpl     = 1 << 4
-const cpuid_feature_ecx_vmx        = 1 << 5
-const cpuid_feature_ecx_smx        = 1 << 6
-const cpuid_feature_ecx_est        = 1 << 7
-const cpuid_feature_ecx_tm2        = 1 << 8
-const cpuid_feature_ecx_ssse3      = 1 << 9
-const cpuid_feature_ecx_cid        = 1 << 10
-const cpuid_feature_ecx_sdbg       = 1 << 11
-const cpuid_feature_ecx_fma        = 1 << 12
-const cpuid_feature_ecx_cx16       = 1 << 13
-const cpuid_feature_ecx_xtpr       = 1 << 14
-const cpuid_feature_ecx_pdcm       = 1 << 15
-const cpuid_feature_ecx_pdid       = 1 << 17
-const cpuid_feature_ecx_dca        = 1 << 18
-const cpuid_feature_ecx_sse4_1     = 1 << 19
-const cpuid_feature_ecx_sse4_2     = 1 << 20
-const cpuid_feature_ecx_x2apic     = 1 << 21
-const cpuid_feature_ecx_movbe      = 1 << 22
-const cpuid_feature_ecx_popcnt     = 1 << 23
-const cpuid_feature_ecx_tsc        = 1 << 24
-const cpuid_feature_ecx_aes        = 1 << 25
-const cpuid_feature_ecx_xsave      = 1 << 26
-const cpuid_feature_ecx_osxsave    = 1 << 27
-const cpuid_feature_ecx_avx        = 1 << 28
-const cpuid_feature_ecx_f16c       = 1 << 29
-const cpuid_feature_ecx_rdrand     = 1 << 30
+const cpuid_feature_ecx_sse3 = 1 << 0
+const cpuid_feature_ecx_pclmul = 1 << 1
+const cpuid_feature_ecx_dtes64 = 1 << 2
+const cpuid_feature_ecx_monitor = 1 << 3
+const cpuid_feature_ecx_ds_cpl = 1 << 4
+const cpuid_feature_ecx_vmx = 1 << 5
+const cpuid_feature_ecx_smx = 1 << 6
+const cpuid_feature_ecx_est = 1 << 7
+const cpuid_feature_ecx_tm2 = 1 << 8
+const cpuid_feature_ecx_ssse3 = 1 << 9
+const cpuid_feature_ecx_cid = 1 << 10
+const cpuid_feature_ecx_sdbg = 1 << 11
+const cpuid_feature_ecx_fma = 1 << 12
+const cpuid_feature_ecx_cx16 = 1 << 13
+const cpuid_feature_ecx_xtpr = 1 << 14
+const cpuid_feature_ecx_pdcm = 1 << 15
+const cpuid_feature_ecx_pdid = 1 << 17
+const cpuid_feature_ecx_dca = 1 << 18
+const cpuid_feature_ecx_sse4_1 = 1 << 19
+const cpuid_feature_ecx_sse4_2 = 1 << 20
+const cpuid_feature_ecx_x2apic = 1 << 21
+const cpuid_feature_ecx_movbe = 1 << 22
+const cpuid_feature_ecx_popcnt = 1 << 23
+const cpuid_feature_ecx_tsc = 1 << 24
+const cpuid_feature_ecx_aes = 1 << 25
+const cpuid_feature_ecx_xsave = 1 << 26
+const cpuid_feature_ecx_osxsave = 1 << 27
+const cpuid_feature_ecx_avx = 1 << 28
+const cpuid_feature_ecx_f16c = 1 << 29
+const cpuid_feature_ecx_rdrand = 1 << 30
 const cpuid_feature_ecx_hypervisor = 1 << 31
 
-const cpuid_feature_edx_fpu        = 1 << 0
-const cpuid_feature_edx_vme        = 1 << 1
-const cpuid_feature_edx_de         = 1 << 2
-const cpuid_feature_edx_pse        = 1 << 3
-const cpuid_feature_edx_tsc        = 1 << 4
-const cpuid_feature_edx_msr        = 1 << 5
-const cpuid_feature_edx_pae        = 1 << 6
-const cpuid_feature_edx_mce        = 1 << 7
-const cpuid_feature_edx_cx8        = 1 << 8
-const cpuid_feature_edx_apic       = 1 << 9
-const cpuid_feature_edx_sep        = 1 << 11
-const cpuid_feature_edx_mtrr       = 1 << 12
-const cpuid_feature_edx_pge        = 1 << 13
-const cpuid_feature_edx_mca        = 1 << 14
-const cpuid_feature_edx_cmov       = 1 << 15
-const cpuid_feature_edx_pat        = 1 << 16
-const cpuid_feature_edx_pse36      = 1 << 17
-const cpuid_feature_edx_psn        = 1 << 18
-const cpuid_feature_edx_clflush    = 1 << 19
-const cpuid_feature_edx_ds         = 1 << 21
-const cpuid_feature_edx_acpi       = 1 << 22
-const cpuid_feature_edx_mmx        = 1 << 23
-const cpuid_feature_edx_fxmsr      = 1 << 24
-const cpuid_feature_edx_sse        = 1 << 25
-const cpuid_feature_edx_sse2       = 1 << 26
-const cpuid_feature_edx_ss         = 1 << 27
-const cpuid_feature_edx_htt        = 1 << 28
-const cpuid_feature_edx_tm         = 1 << 29
-const cpuid_feature_edx_ia64       = 1 << 30
-const cpuid_feature_edx_pbe        = 1 << 31
+const cpuid_feature_edx_fpu = 1 << 0
+const cpuid_feature_edx_vme = 1 << 1
+const cpuid_feature_edx_de = 1 << 2
+const cpuid_feature_edx_pse = 1 << 3
+const cpuid_feature_edx_tsc = 1 << 4
+const cpuid_feature_edx_msr = 1 << 5
+const cpuid_feature_edx_pae = 1 << 6
+const cpuid_feature_edx_mce = 1 << 7
+const cpuid_feature_edx_cx8 = 1 << 8
+const cpuid_feature_edx_apic = 1 << 9
+const cpuid_feature_edx_sep = 1 << 11
+const cpuid_feature_edx_mtrr = 1 << 12
+const cpuid_feature_edx_pge = 1 << 13
+const cpuid_feature_edx_mca = 1 << 14
+const cpuid_feature_edx_cmov = 1 << 15
+const cpuid_feature_edx_pat = 1 << 16
+const cpuid_feature_edx_pse36 = 1 << 17
+const cpuid_feature_edx_psn = 1 << 18
+const cpuid_feature_edx_clflush = 1 << 19
+const cpuid_feature_edx_ds = 1 << 21
+const cpuid_feature_edx_acpi = 1 << 22
+const cpuid_feature_edx_mmx = 1 << 23
+const cpuid_feature_edx_fxmsr = 1 << 24
+const cpuid_feature_edx_sse = 1 << 25
+const cpuid_feature_edx_sse2 = 1 << 26
+const cpuid_feature_edx_ss = 1 << 27
+const cpuid_feature_edx_htt = 1 << 28
+const cpuid_feature_edx_tm = 1 << 29
+const cpuid_feature_edx_ia64 = 1 << 30
+const cpuid_feature_edx_pbe = 1 << 31
 
 fn cpuid(leaf u32, subleaf u32) (bool, u32, u32, u32, u32) {
 	mut cpuid_max := u32(0)

--- a/util-vinix/mount/main.v
+++ b/util-vinix/mount/main.v
@@ -36,7 +36,7 @@ fn main() {
 				if idx < os.args.len {
 					filesystem = os.args[idx]
 				} else {
-					println("No filesystem was specified for -t")
+					println('No filesystem was specified for -t')
 					exit(0)
 				}
 			}
@@ -49,27 +49,27 @@ fn main() {
 
 	// Check whether we have all the options we need.
 	if filesystem == '' {
-		println("No filesystem was specified")
+		println('No filesystem was specified')
 		exit(0)
 	}
 	if idx < os.args.len {
 		source = os.args[idx]
 		idx++
 	} else {
-		println("No source was specified")
+		println('No source was specified')
 		exit(0)
 	}
 	if idx < os.args.len {
 		destination = os.args[idx]
 		idx++
 	} else {
-		println("No destination was specified")
+		println('No destination was specified')
 		exit(0)
 	}
 
 	// Do the actual mounting.
 	if C.mount(source.str, destination.str, filesystem.str, 0, 0) != 0 {
-        println("Couldn't mount (${C.errno})")
+		println("Couldn't mount (${C.errno})")
 		exit(0)
 	}
 }


### PR DESCRIPTION
The PR contains the result of running the default source code formatting tool over all .v files.

There are no manual changes here, and it should have preserved the semantics completely.