### PR TITLE
aarch64: integrate M1 Air Wi-Fi and complete debug/production kernel build milestone

### DIFF
--- a/.github/workflows/m1-wifi-build.yml
+++ b/.github/workflows/m1-wifi-build.yml
@@ -1,0 +1,41 @@
+name: M1 Wi-Fi kernel build
+on:
+  push:
+    branches: [wifi/m1-air-build]
+  pull_request:
+    paths:
+      - 'kernel/**'
+      - 'tests/m1-wifi/**'
+      - 'tools/m1-wifi/**'
+      - '.github/workflows/m1-wifi-build.yml'
+permissions:
+  contents: read
+concurrency:
+  group: m1-wifi-build-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Snapshot exact source for offline validation
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/wifi-build-source
+          git archive --format=tar.gz HEAD > /tmp/wifi-build-source/source.tar.gz
+          git rev-parse HEAD > /tmp/wifi-build-source/COMMIT
+          git rev-parse 'HEAD^{tree}' > /tmp/wifi-build-source/TREE
+      - uses: actions/upload-artifact@v7
+        with:
+          name: m1-wifi-build-source
+          path: /tmp/wifi-build-source/
+          retention-days: 7
+      - name: Require integrated driver and build acceptance test
+        run: |
+          test -f kernel/modules/apple/wifi/wifi.v
+          test -f tests/m1-wifi/build.sh
+          sh tests/m1-wifi/build.sh

--- a/.github/workflows/m1-wifi-build.yml
+++ b/.github/workflows/m1-wifi-build.yml
@@ -21,21 +21,37 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - name: Snapshot exact source for offline validation
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y clang lld gcc make git curl python3
+      - name: Driver sanitizer and optimized tests
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p /tmp/wifi-build-source
-          git archive --format=tar.gz HEAD > /tmp/wifi-build-source/source.tar.gz
-          git rev-parse HEAD > /tmp/wifi-build-source/COMMIT
-          git rev-parse 'HEAD^{tree}' > /tmp/wifi-build-source/TREE
-      - uses: actions/upload-artifact@v7
-        with:
-          name: m1-wifi-build-source
-          path: /tmp/wifi-build-source/
-          retention-days: 7
-      - name: Require integrated driver and build acceptance test
+          mkdir -p tests/m1-wifi/out
+          CC=clang SANITIZE=1 sh tests/m1-wifi/run.sh | tee tests/m1-wifi/out/wifi-sanitizers.log
+          CC=gcc SANITIZE=0 sh tests/m1-wifi/run.sh | tee tests/m1-wifi/out/wifi-gcc.log
+          CC=clang sh tests/apple-spi-keyboard/run.sh | tee tests/m1-wifi/out/keyboard.log
+          clang -std=c11 -O2 -Wall -Wextra -Werror -iquote kernel/c tools/m1-wifi/wifi-ctl.c -o tests/m1-wifi/out/wifi-ctl-host
+          python3 -m py_compile tools/m1-wifi/package.py tests/m1-wifi/verify_build.py tests/m1-wifi/verify_test.py
+      - name: Bootstrap pinned V1 compiler
+        run: sh tools/m1-wifi/get-v.sh /tmp/vinix-wifi-v
+      - name: Fetch pinned kernel dependencies
+        run: cd kernel && ./get-deps
+      - name: Clean debug and production ARM64 links
+        shell: bash
         run: |
-          test -f kernel/modules/apple/wifi/wifi.v
-          test -f tests/m1-wifi/build.sh
-          sh tests/m1-wifi/build.sh
+          set -euo pipefail
+          V=/tmp/vinix-wifi-v/v JOBS=2 sh tests/m1-wifi/build.sh 2>&1 | tee tests/m1-wifi/out/build-acceptance.log
+      - name: Record source identity
+        if: always()
+        run: |
+          mkdir -p tests/m1-wifi/out
+          git rev-parse HEAD > tests/m1-wifi/out/SOURCE_COMMIT
+          git rev-parse 'HEAD:kernel' > tests/m1-wifi/out/KERNEL_TREE
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: m1-wifi-kernel-build
+          path: tests/m1-wifi/out/
+          retention-days: 7
+          if-no-files-found: error

--- a/docs/apple-wifi.md
+++ b/docs/apple-wifi.md
@@ -1,0 +1,9 @@
+# M1 Air Wi-Fi: build milestone
+
+The experimental driver is integrated and clean debug/production ARM64 kernels
+link successfully. This does **not** establish a working radio or IP stack.
+
+See [build, validation and hardware bring-up instructions](../tests/m1-wifi/README.md).
+
+Hardware probing remains opt-in with `vinix.apple_wifi=1`; firmware is not
+included. `/dev/wlan0` is a raw Ethernet/control interface, not AF_INET sockets.

--- a/kernel/c/brcm_m1.c
+++ b/kernel/c/brcm_m1.c
@@ -1,0 +1,241 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later
+ * Apple M1 PCIe/DART integration. Register sequences based on U-Boot
+ * drivers/pci/pcie_apple.c, Copyright (C) 2021 Alyssa Rosenzweig,
+ * Google LLC, Corellium LLC and Mark Kettenis; and Linux apple-dart.c /
+ * io-pgtable-dart.c, Copyright The Asahi Linux Contributors.
+ *
+ * Owns only PCI 01:00.0 and its declared RID-to-SID entry. The physical
+ * Wi-Fi/Bluetooth combo chip shares PERST: refuse takeover if Bluetooth is
+ * bus mastering. No interrupt handler, DART bypass, or guessed MMIO base.
+ */
+#include "brcm_m1.h"
+#include <string.h>
+#if defined(__AARCH64__) || defined(VINIX_BRCM_M1_TEST)
+
+#ifndef VINIX_BRCM_M1_TEST
+extern uint8_t vinix_mmio_read8(void *);
+extern uint16_t vinix_mmio_read16(void *);
+extern uint32_t vinix_mmio_read32(void *);
+extern void vinix_mmio_write8(void *,uint8_t);
+extern void vinix_mmio_write16(void *,uint16_t);
+extern void vinix_mmio_write32(void *,uint32_t);
+static uint64_t clock_us(void){uint64_t c,f;__asm__ volatile("mrs %0,cntvct_el0":"=r"(c));__asm__ volatile("mrs %0,cntfrq_el0":"=r"(f));return f?(c/f)*1000000+(c%f)*1000000/f:0;}
+static void delay(uint32_t us){uint64_t begin=clock_us();while(clock_us()-begin<us)__asm__ volatile("yield");}
+static void barrier(void){__asm__ volatile("dsb sy":::"memory");}
+static void cache_sync(void *p,size_t n,int to_device){
+    uint64_t ctr;__asm__ volatile("mrs %0,ctr_el0":"=r"(ctr));
+    uintptr_t line=(uintptr_t)4<<((ctr>>16)&15),start=(uintptr_t)p&~(line-1),end=(uintptr_t)p+n;
+    for(uintptr_t a=start;a<end;a+=line){if(to_device)__asm__ volatile("dc civac,%0"::"r"(a):"memory");else __asm__ volatile("dc ivac,%0"::"r"(a):"memory");}barrier();
+}
+#endif
+static uint32_t get32(const uint8_t *p){return (uint32_t)p[0]|(uint32_t)p[1]<<8|(uint32_t)p[2]<<16|(uint32_t)p[3]<<24;}
+static void put32(uint8_t *p,uint32_t v){for(unsigned i=0;i<4;i++)p[i]=(uint8_t)(v>>(8*i));}
+static void put64(uint8_t *p,uint64_t v){put32(p,(uint32_t)v);put32(p+4,(uint32_t)(v>>32));}
+static uint32_t r32(uint64_t a){uint32_t v=vinix_mmio_read32((void *)(uintptr_t)a);barrier();return v;}
+static void w32(uint64_t a,uint32_t v){barrier();vinix_mmio_write32((void *)(uintptr_t)a,v);}
+static void w16(uint64_t a,uint16_t v){barrier();vinix_mmio_write16((void *)(uintptr_t)a,v);}
+static void set(uint64_t a,uint32_t mask){w32(a,r32(a)|mask);}
+static int wait_bits(uint64_t a,uint32_t mask,uint32_t expect,unsigned iterations){
+    for(unsigned i=0;i<iterations;i++){if((r32(a)&mask)==expect)return 0;delay(100);}return BW_ETIME;
+}
+static struct {
+    struct bw_m1_plan p;
+    struct bw_device dev;
+    uint64_t endpoint, bar0, bar2;
+    uint32_t bar0_len, bar2_len, dart_error;
+    int prepared, attempted, endpoint_valid;
+    uint8_t frames[64][BW_MAX_FRAME];
+    uint16_t length[64],head,tail;
+    uint64_t drops;
+    size_t total[4],used[4];
+    uint8_t firmware[4u*1024u*1024u],nvram[65536],clm[1024u*1024u],txcap[1024u*1024u];
+} host;
+static int flush_dart(void){
+    w32(host.p.dart+0x34,1u<<host.p.sid);w32(host.p.dart+0x20,1u<<20);
+    return wait_bits(host.p.dart+0x20,4,0,1000);
+}
+static void stop_dma(void *unused){
+    (void)unused;
+    if(host.endpoint_valid){uint16_t cmd=(uint16_t)r32(host.endpoint+4);w16(host.endpoint+4,(uint16_t)(cmd&~4u));(void)r32(host.endpoint+4);}
+    /* Revoke this stream only. Tables/pool remain quarantined for the rest
+     * of this boot, so no late completion can touch a reallocated object. */
+    if(host.prepared){w32(host.p.dart+0x100+host.p.sid*4,0);(void)flush_dart();}
+}
+static uint32_t bus_read(void *unused,unsigned space,uint32_t off,unsigned width){
+    (void)unused;uint64_t base=space==BW_CONFIG?host.endpoint:(space==BW_REGS?host.bar0:host.bar2);
+    uint32_t limit=space==BW_CONFIG?4096:(space==BW_REGS?host.bar0_len:host.bar2_len);
+    if((width!=1&&width!=2&&width!=4)||width>limit||off>limit-width||(off&(width-1)))return UINT32_MAX;
+    void *p=(void *)(uintptr_t)(base+off);uint32_t v=width==1?vinix_mmio_read8(p):(width==2?vinix_mmio_read16(p):vinix_mmio_read32(p));barrier();return v;
+}
+static void bus_write(void *unused,unsigned space,uint32_t off,unsigned width,uint32_t v){
+    (void)unused;uint64_t base=space==BW_CONFIG?host.endpoint:(space==BW_REGS?host.bar0:host.bar2);
+    uint32_t limit=space==BW_CONFIG?4096:(space==BW_REGS?host.bar0_len:host.bar2_len);
+    if((width!=1&&width!=2&&width!=4)||width>limit||off>limit-width||(off&(width-1)))return;
+    void *p=(void *)(uintptr_t)(base+off);barrier();
+    if(width==1)vinix_mmio_write8(p,(uint8_t)v);else if(width==2)vinix_mmio_write16(p,(uint16_t)v);else vinix_mmio_write32(p,v);
+}
+static uint64_t bus_time(void *u){(void)u;return clock_us();}
+static void bus_delay(void *u,uint32_t v){(void)u;delay(v);}
+static void bus_sync(void *u,void *p,size_t n,int to_device){(void)u;cache_sync(p,n,to_device);}
+static void receive(void *u,const uint8_t *p,size_t n){
+    (void)u;unsigned next=(host.tail+1u)%64;
+    if(n>BW_MAX_FRAME||next==host.head){host.drops++;return;}
+    memcpy(host.frames[host.tail],p,n);host.length[host.tail]=(uint16_t)n;host.tail=(uint16_t)next;
+}
+static int dart_prepare(void){
+    struct bw_m1_plan *p=&host.p;
+    if(((r32(p->dart)>>24)&15)!=14 || (r32(p->dart+0x60)&0x8000))return BW_ENOTSUP;
+    /* Validate the existing RID table before modifying any entry. */
+    int slot=-1;
+    for(unsigned i=0;i<16;i++){uint32_t v=r32(p->port+0x828+4*i);
+        if(v&0x80000000u){if((v&0xffff)==0x100)slot=(int)i;
+            else if(((v>>16)&15)==p->sid)return BW_ENOTSUP;
+        }else if(slot<0)slot=(int)i;
+    }
+    if(slot<0)return BW_ENOSPC;
+    /* Install an RID2SID entry ONLY for Wi-Fi's RID 0x100.
+     * Bluetooth has a separate DT stream and is not assigned this mapping. */
+    uint64_t *root=(void *)(uintptr_t)p->tables_cpu,*leaf=root+2048;
+    memset(root,0,32768);root[8]=(p->tables_physical+16384)|1;
+    for(unsigned i=0;i<BW_POOL_MIN/16384;i++)leaf[i]=(p->pool_physical+(uint64_t)i*16384)|3;
+    cache_sync(root,32768,1);
+    host.prepared=1; /* revoke on any subsequent partial-initialization failure */
+    w32(p->dart+0x100+p->sid*4,0);
+    for(unsigned i=0;i<4;i++)w32(p->dart+0x200+p->sid*16+i*4,0);
+    w32(p->dart+0x200+p->sid*16,(uint32_t)(p->tables_physical>>12)|0x80000000u);
+    if(flush_dart())return BW_ETIME;
+    w32(p->dart+0x100+p->sid*4,0x80);set(p->dart+0xfc,1u<<p->sid);
+    w32(p->port+0x828+4*(unsigned)slot,0x80000100u|(p->sid<<16));return 0;
+}
+static int bar_size(unsigned offset,uint64_t *size){
+    uint64_t c=host.endpoint;uint32_t lo=r32(c+offset),hi=r32(c+offset+4);
+    if((lo&7)!=4)return BW_ENOTSUP;
+    w32(c+offset,UINT32_MAX);w32(c+offset+4,UINT32_MAX);
+    uint64_t mask=(uint64_t)r32(c+offset+4)<<32|(r32(c+offset)&~15u);
+    w32(c+offset,lo);w32(c+offset+4,hi);
+    uint64_t n=~mask+1;
+    if(!n||(n&(n-1))||n>16u*1024u*1024u)return BW_EPROTO;
+    *size=n;return 0;
+}
+static int disable_interrupts(void){
+    uint8_t seen[256]={0};unsigned next=r32(host.endpoint+0x34)&0xff;
+    for(unsigned i=0;next&&i<48;i++){
+        if(next<0x40||(next&3)||seen[next])return BW_EPROTO;
+        seen[next]=1;uint32_t cap=r32(host.endpoint+next);unsigned type=cap&255;
+        uint16_t ctl=(uint16_t)(cap>>16);
+        if(type==5)w16(host.endpoint+next+2,(uint16_t)(ctl&~1u));
+        if(type==0x11)w16(host.endpoint+next+2,(uint16_t)((ctl&~0x8000u)|0x4000u));
+        next=(cap>>8)&255;
+    }
+    return next?BW_EPROTO:0;
+}
+static int platform_start(void){
+    struct bw_m1_plan *p=&host.p;int e;
+    /* Existing link: do not take a combo device away from an active driver. */
+    if(r32(p->port+0x208)&1){
+        uint32_t bt=r32(p->config+0x101000);
+        if(bt!=UINT32_MAX&&(r32(p->config+0x101004)&4))return BW_ENOTSUP;
+        if(r32(p->config+0x100000)!=UINT32_MAX&&(r32(p->config+0x100004)&4))return BW_ENOTSUP;
+    }
+    set(p->port+0x800,1);
+    /* GPIO mode=output, peripheral selection cleared; preserve pull settings. */
+    uint32_t gpio=r32(p->gpio)&~(0x60u|0x0fu);gpio|=2u;
+    w32(p->gpio,gpio|(p->gpio_active_low?0:1));
+    set(p->phy+4,1u<<15);set(p->phy,1);
+    if((e=wait_bits(p->phy,4,4,500)))goto reset;
+    set(p->phy,2);if((e=wait_bits(p->phy,8,8,500)))goto reset;
+    w32(p->phy+4,r32(p->phy+4)&~(1u<<15));set(p->phy,0x600);set(p->port+0x810,1);delay(100);
+    set(p->port+0x814,1);w32(p->gpio,gpio|(p->gpio_active_low?1:0));delay(100000);
+    if((e=wait_bits(p->port+0x804,1,1,2500)))goto reset;
+    w32(p->port+0x108,UINT32_MAX);w32(p->port+0x80,1);
+    if((e=wait_bits(p->port+0x208,1,1,1000)))goto reset;
+    /* Only the root port and the fixed DT secondary bus are configured. */
+    uint64_t rc=p->config;
+    if((r32(rc+8)>>16)!=0x0604){e=BW_ENOTSUP;goto reset;}
+    w16(rc+4,0x402);w32(rc+0x18,0x00010100);
+    host.endpoint=p->config+0x100000;
+    if(r32(host.endpoint)!=0x442514e4u){e=BW_ENOTSUP;goto reset;}
+    host.endpoint_valid=1;w16(host.endpoint+4,0x400);
+    if((e=disable_interrupts()))goto reset;
+    uint64_t size0,size2;if((e=bar_size(0x10,&size0))||(e=bar_size(0x18,&size2)))goto reset;
+    if(size0<0x3000||size2<0x400000){e=BW_EPROTO;goto reset;}
+    uint64_t arena=(p->window_bus+p->window_size-32u*1024u*1024u)&~(uint64_t)0xfffffu;
+    uint64_t a0=(arena+size0-1)&~(size0-1),a2=(a0+size0+size2-1)&~(size2-1);
+    if(a0<p->window_bus||a2+size2>p->window_bus+p->window_size){e=BW_ENOSPC;goto reset;}
+    /* 32-bit non-prefetchable bridge window; CPU addresses may exceed 4 GiB. */
+    uint32_t base=(uint32_t)arena,limit=(uint32_t)(a2+size2-1);
+    w32(rc+0x20,((limit>>16)&0xfff0u)<<16|((base>>16)&0xfff0u));
+    w32(host.endpoint+0x10,(uint32_t)a0|4);w32(host.endpoint+0x14,0);
+    w32(host.endpoint+0x18,(uint32_t)a2|4);w32(host.endpoint+0x1c,0);
+    host.bar0=p->window+(a0-p->window_bus);host.bar2=p->window+(a2-p->window_bus);
+    host.bar0_len=(uint32_t)size0;host.bar2_len=(uint32_t)size2;
+    if((e=dart_prepare()))goto reset;
+    host.prepared=1; /* stop_dma can now revoke the stream */
+    w16(rc+4,0x406);w16(host.endpoint+4,0x402); /* MEM, not bus master yet */
+    struct bw_ops ops={bus_read,bus_write,bus_time,bus_delay,bus_sync,stop_dma,receive};
+    if((e=bw_init(&host.dev,&ops,NULL,(void *)(uintptr_t)p->pool_cpu,0x10000000,BW_POOL_MIN,host.bar0_len,host.bar2_len))||(e=bw_probe(&host.dev)))goto reset;
+    return 0;
+reset:
+    stop_dma(NULL);
+    /* Do not leave a failed reset sequence halfway asserted. A failed probe
+     * is terminal for this boot; no allocator object is released/reused. */
+    w32(p->gpio,gpio|(p->gpio_active_low?1:0));
+    host.dev.error=e;host.dev.state=BW_FAULT;return e;
+}
+int brcm_m1_prepare(const struct bw_m1_plan *p){
+    if(!p||host.attempted||!p->config||p->config_size<0x102000||!p->rc||!p->port||!p->phy||!p->gpio||!p->dart||
+       !p->window||p->window_size<64u*1024u*1024u||p->window_bus>UINT32_MAX||p->window_size>0x100000000ull-p->window_bus||
+       !p->pool_cpu||!p->tables_cpu||!p->pool_physical||!p->tables_physical||p->pool_cpu>UINT64_MAX-BW_POOL_MIN||p->tables_cpu>UINT64_MAX-32768||(p->pool_cpu&16383)||(p->pool_physical&16383)||(p->tables_cpu&16383)||(p->tables_physical&16383)||
+       p->pool_physical>0x1000000000ull-BW_POOL_MIN||p->tables_physical>0x1000000000ull-32768||(p->pool_physical<p->tables_physical+32768&&p->tables_physical<p->pool_physical+BW_POOL_MIN)||p->sid!=1||p->gpio_active_low>1||
+       !p->calibration||!p->calibration_len||p->calibration_len>1024u*1024u||!p->seed||p->seed_len!=256||!p->antenna[0]||p->antenna[15])return BW_EINVAL;
+    host.attempted=1;host.p=*p;return platform_start();
+}
+int brcm_m1_status(uint8_t *out){
+    if(!out)return BW_EINVAL;
+    memset(out,0,BW_STATUS_SIZE);
+    put32(out,host.dev.state);put32(out+4,(uint32_t)host.dev.error);put32(out+8,host.dev.revision);put32(out+12,host.dart_error);
+    put64(out+16,host.dev.rx_frames);put64(out+24,host.dev.tx_frames);memcpy(out+32,host.p.mac,6);
+    memcpy(out+40,host.dev.otp.module,16);memcpy(out+56,host.dev.otp.vendor,16);memcpy(out+72,host.dev.otp.revision,16);memcpy(out+88,host.dev.otp.silicon,16);
+    memcpy(out+104,host.p.antenna,16);memcpy(out+120,"apple,shikoku",13);put64(out+152,host.drops);return 0;
+}
+static uint8_t *part(unsigned k){return k==0?host.firmware:(k==1?host.nvram:(k==2?host.clm:host.txcap));}
+static size_t part_capacity(unsigned k){return k==0?sizeof(host.firmware):(k==1?sizeof(host.nvram):sizeof(host.clm));}
+int brcm_m1_upload(const uint8_t *q){
+    if(!q||host.dev.state!=BW_CHIP)return BW_EINVAL;
+    uint32_t k=get32(q),total=get32(q+4),off=get32(q+8),n=get32(q+12);
+    if(k>3||!n||n>4096||!total||total>part_capacity(k)||off!=host.used[k]||off>total||n>total-off||(host.total[k]&&total!=host.total[k]))return BW_EINVAL;
+    host.total[k]=total;memcpy(part(k)+off,q+16,n);host.used[k]+=n;return 0;
+}
+static int string_equal(const uint8_t *a,const char *b,size_t n){size_t len=0;while(len<n&&b[len])len++;return len<n&&!memcmp(a,b,len)&&a[len]==0;}
+int brcm_m1_boot(const uint8_t *q){
+    if(!q||host.dev.state!=BW_CHIP||get32(q)!=host.dev.revision||get32(q+4)||
+       !string_equal(q+8,host.dev.otp.module,16)||!string_equal(q+24,host.dev.otp.vendor,16)||!string_equal(q+40,host.dev.otp.revision,16)||
+       !string_equal(q+56,host.p.antenna,16)||!string_equal(q+72,"apple,shikoku",32))return BW_EINVAL;
+    for(unsigned i=104;i<BW_MANIFEST_SIZE;i++)if(q[i])return BW_EINVAL;
+    for(unsigned i=0;i<4;i++)if(!host.total[i]||host.used[i]!=host.total[i])return BW_EINVAL;
+    struct bw_firmware f={host.firmware,host.nvram,host.clm,host.txcap,host.p.calibration,host.p.seed,
+        host.total[0],host.total[1],host.total[2],host.total[3],host.p.calibration_len,host.p.seed_len,host.dev.revision,{0}};
+    memcpy(f.mac,host.p.mac,6);
+    /* DART was populated, enabled and flushed before this first BME write. */
+    w16(host.endpoint+4,0x406);
+    int e=bw_start(&host.dev,&f);
+    /* Caller owns the entropy storage and must wipe its consumed copy. */
+    return e;
+}
+int brcm_m1_join(const uint8_t *q){if(!q)return BW_EINVAL;return bw_join_wpa2(&host.dev,q+8,get32(q),q+40,get32(q+4));}
+int brcm_m1_poll(void){
+    if(!host.prepared)return 0;
+    if(host.dev.state>=BW_READY&&host.dev.state!=BW_FAULT){uint32_t err=r32(host.p.dart+0x40);
+        if((err&0x80000000u)&&((err>>24)&15)==host.p.sid){host.dart_error=err;bw_stop(&host.dev);host.dev.error=BW_EIO;return BW_EIO;}
+    }
+    int e=bw_poll(&host.dev,64);return e<0?e:(host.head!=host.tail);
+}
+int brcm_m1_read(uint8_t *p,size_t n){
+    if(!p)return BW_EINVAL;
+    if(host.head==host.tail)return host.dev.state==BW_FAULT?BW_ENOLINK:0;
+    size_t len=host.length[host.head];if(n<len)return BW_ENOSPC;
+    memcpy(p,host.frames[host.head],len);host.head=(uint16_t)((host.head+1)%64);return (int)len;
+}
+int brcm_m1_write(const uint8_t *p,size_t n){return bw_transmit(&host.dev,p,n);}
+void brcm_m1_stop(void){if(host.prepared){if(host.dev.state>=BW_READY&&host.dev.state<BW_FAULT)(void)bw_disconnect(&host.dev);else bw_stop(&host.dev);}}
+#endif

--- a/kernel/c/brcm_m1.h
+++ b/kernel/c/brcm_m1.h
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef VINIX_BRCM_M1_H
+#define VINIX_BRCM_M1_H
+#include "brcm_wifi.h"
+/* Private, kernel-only platform contract. All register pointers are mapped
+ * Device memory. PCI window is the DT non-prefetchable 32-bit range. */
+struct bw_m1_plan {
+    uint64_t config, config_size, rc, port, phy, gpio, dart;
+    uint64_t window, window_bus, window_size;
+    uint64_t pool_cpu, pool_physical, tables_cpu, tables_physical;
+    uint32_t sid, gpio_active_low;
+    const uint8_t *calibration, *seed;
+    size_t calibration_len, seed_len;
+    uint8_t mac[6];
+    char antenna[16];
+};
+#define BW_IOCTL_STATUS 0x5700u
+#define BW_IOCTL_UPLOAD 0x5701u
+#define BW_IOCTL_BOOT   0x5702u
+#define BW_IOCTL_JOIN   0x5703u
+#define BW_IOCTL_STOP   0x5704u
+#define BW_STATUS_SIZE 256u
+#define BW_UPLOAD_SIZE 4112u
+#define BW_JOIN_SIZE 104u
+#define BW_MANIFEST_SIZE 128u
+/* Fixed-size UAPI byte arrays, no embedded pointers. Integer fields LE.
+ * STATUS: state@0,error@4,revision@8,dart_error@12,rx64@16,tx64@24,
+ *         MAC@32,OTP module@40,vendor@56,revision@72,silicon@88,
+ *         antenna@104,board@120 (32 bytes),drops64@152.
+ * UPLOAD: part@0,total@4,offset@8,count@12,data[4096]@16.
+ *         part 0 firmware,1 NVRAM text,2 CLM,3 TXCAP.
+ * BOOT: revision@0,module[16]@8,vendor[16]@24,modrev[16]@40,
+ *       antenna[16]@56,board[32]@72; other bytes MUST be zero.
+ * JOIN: SSID length32@0,passphrase length32@4,SSID[32]@8,password[64]@40.
+ */
+int brcm_m1_prepare(const struct bw_m1_plan *);
+int brcm_m1_status(uint8_t *output);
+int brcm_m1_upload(const uint8_t *chunk);
+int brcm_m1_boot(const uint8_t *manifest);
+int brcm_m1_join(const uint8_t *request);
+int brcm_m1_poll(void);
+int brcm_m1_read(uint8_t *, size_t);
+int brcm_m1_write(const uint8_t *, size_t);
+void brcm_m1_stop(void);
+#endif

--- a/kernel/c/brcm_wifi.c
+++ b/kernel/c/brcm_wifi.c
@@ -1,0 +1,555 @@
+/* SPDX-License-Identifier: ISC
+ * Copyright (c) 2010-2016 Broadcom Corporation
+ * Copyright (c) 2016,2017 Patrick Wildt <patrick@blueri.se>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * New bounded Vinix implementation of the BCM4378 PCIe FullMAC protocol.
+ * Register and wire-layout reference: OpenBSD bwfm{,reg}.h/.c and
+ * if_bwfm_pci{.c,.h}. Not a transplant of the OpenBSD networking stack.
+ * No allocation in the receive path. All entry points require serialization.
+ */
+#include "brcm_wifi.h"
+#include <string.h>
+
+#define CC 0x800u
+#define D11 0x812u
+#define PCIE 0x83cu
+#define GCI 0x840u
+#define CA7 0x847u
+#define SYSMEM 0x849u
+#define RAM_BASE 0x352000u
+#define IOVAR_GET 262u
+#define IOVAR_SET 263u
+#define RX_DATA 1u
+#define RX_IOCTL 2u
+#define RX_EVENT 3u
+#define MAX_CTL 8192u
+
+static uint16_t l16(const void *q) { const uint8_t *p=q; return (uint16_t)(p[0]|(uint16_t)p[1]<<8); }
+static uint32_t l32(const void *q) { const uint8_t *p=q; return (uint32_t)p[0]|(uint32_t)p[1]<<8|(uint32_t)p[2]<<16|(uint32_t)p[3]<<24; }
+static uint16_t b16(const void *q) { const uint8_t *p=q; return (uint16_t)((uint16_t)p[0]<<8|p[1]); }
+static uint32_t b32(const void *q) { const uint8_t *p=q; return (uint32_t)p[0]<<24|(uint32_t)p[1]<<16|(uint32_t)p[2]<<8|p[3]; }
+static void s16(void *q,uint16_t v) { uint8_t *p=q; p[0]=(uint8_t)v;p[1]=(uint8_t)(v>>8); }
+static void s32(void *q,uint32_t v) { uint8_t *p=q; p[0]=(uint8_t)v;p[1]=(uint8_t)(v>>8);p[2]=(uint8_t)(v>>16);p[3]=(uint8_t)(v>>24); }
+static void s64(void *p,uint64_t v) { s32(p,(uint32_t)v);s32((uint8_t *)p+4,(uint32_t)(v>>32)); }
+static void erase(void *p,size_t n) { volatile uint8_t *q=p;while(n--)*q++=0; }
+static int range(uint32_t p,size_t n,uint32_t low,uint32_t high) { return p>=low && p<=high && n<=(size_t)(high-p); }
+static int mac_ok(const uint8_t *m) { unsigned any=0;for(unsigned i=0;i<6;i++)any|=m[i];return any && !(m[0]&1); }
+static int fail(struct bw_device *d,int e) {
+    if(d->state!=BW_FAULT)d->ops.stop_dma(d->cookie);
+    d->state=BW_FAULT;d->associated=d->keyed=0;d->error=e;return e;
+}
+static uint32_t rd(struct bw_device *d,unsigned s,uint32_t o,unsigned w) { return d->ops.read(d->cookie,s,o,w); }
+static void wr(struct bw_device *d,unsigned s,uint32_t o,unsigned w,uint32_t v) { d->ops.write(d->cookie,s,o,w,v); }
+static uint32_t bp_read(struct bw_device *d,uint32_t a) {
+    wr(d,BW_CONFIG,0x80,4,a&~0xfffu);(void)rd(d,BW_CONFIG,0x80,4);
+    return rd(d,BW_REGS,a&0xfffu,4);
+}
+static void bp_write(struct bw_device *d,uint32_t a,uint32_t v) {
+    wr(d,BW_CONFIG,0x80,4,a&~0xfffu);(void)rd(d,BW_CONFIG,0x80,4);
+    wr(d,BW_REGS,a&0xfffu,4,v);
+}
+static struct bw_core *core(struct bw_device *d,unsigned id) {
+    for(unsigned i=0;i<d->core_count;i++) {
+        if(d->cores[i].id==id)return &d->cores[i];
+    }
+    return NULL;
+}
+static int chip_address(uint32_t p) { return p>=0x18000000u && p<=0x18ffe000u && !(p&0xfffu); }
+static int ram_address(struct bw_device *d,uint32_t p,size_t n) { return range(p,n,d->ram_base,d->ram_base+d->ram_size); }
+static void tcm_copy(struct bw_device *d,uint32_t a,const uint8_t *p,size_t n) {
+    while(n && (a&3)){wr(d,BW_TCM,a++,1,*p++);n--;}
+    while(n>=4){wr(d,BW_TCM,a,4,l32(p));a+=4;p+=4;n-=4;}
+    while(n--){wr(d,BW_TCM,a++,1,*p++);}
+}
+static int alloc_mem(struct bw_device *d,size_t n,struct bw_mem *m) {
+    size_t off=(d->allocated+127u)&~(size_t)127u;
+    if(!n || n>d->pool.len || off>d->pool.len-n)return BW_ENOSPC;
+    m->cpu=d->pool.cpu+off;m->dma=d->pool.dma+off;m->len=n;
+    d->allocated=off+n;memset(m->cpu,0,n);d->ops.sync(d->cookie,m->cpu,n,1);return 0;
+}
+
+int bw_nvram_pack(const uint8_t *in,size_t n,uint8_t *out,size_t cap,size_t *used) {
+    size_t pos=0,w=0;unsigned lines=0;
+    if(!in||!out||!used||!n||n>65536||cap<8)return BW_EINVAL;
+    *used=0;
+    while(pos<n){
+        size_t a=pos,b,e;
+        while(pos<n && in[pos]!='\n' && in[pos]!='\r'){
+            if(!in[pos] || (in[pos]<32 && in[pos]!='\t') || in[pos]>126)return BW_EINVAL;
+            pos++;
+        }
+        b=pos;while(pos<n && (in[pos]=='\n'||in[pos]=='\r'))pos++;
+        while(a<b && (in[a]==' '||in[a]=='\t'))a++;
+        for(e=a;e<b;e++)if(in[e]=='#'){b=e;break;}
+        while(b>a && (in[b-1]==' '||in[b-1]=='\t'))b--;
+        if(a==b)continue;
+        for(e=a;e<b&&in[e]!='=';e++){
+            uint8_t c=in[e];if(!((c>='a'&&c<='z')||(c>='A'&&c<='Z')||(c>='0'&&c<='9')||c=='_'||c=='.'||c=='/'||c==':'))return BW_EINVAL;
+        }
+        if(e==a||e==b||b-a>1024||++lines>1024)return BW_EINVAL;
+        /* No duplicate keys: ambiguous board calibration must not be guessed. */
+        for(size_t q=0;q<w;){size_t k=q;while(k<w&&out[k]!='=')k++;
+            if(k-q==e-a&&!memcmp(out+q,in+a,e-a))return BW_EINVAL;
+            while(q<w&&out[q])q++;
+            q++;
+        }
+        if(b-a+1>cap-w)return BW_ENOSPC;
+        memcpy(out+w,in+a,b-a);w+=b-a;out[w++]=0;
+    }
+    if(!lines||w>65528)return BW_EINVAL;
+    size_t padded=(w+1+3)&~(size_t)3;
+    if(padded>cap-4)return BW_ENOSPC;
+    memset(out+w,0,padded-w);uint32_t words=(uint32_t)(padded/4);
+    s32(out+padded,words|((~words&0xffffu)<<16));*used=padded+4;return 0;
+}
+static int otp_value(char *out,const uint8_t *in,size_t len) {
+    if(!len||len>=16)return BW_EPROTO;
+    for(size_t i=0;i<len;i++){
+        uint8_t c=in[i];if(!((c>='A'&&c<='Z')||(c>='a'&&c<='z')||(c>='0'&&c<='9')||c=='_'||c=='-'||c=='.'))return BW_EPROTO;
+    }
+    if(out[0]&&(out[len]!=0||memcmp(out,in,len)))return BW_EPROTO;
+    memcpy(out,in,len);out[len]=0;return 0;
+}
+int bw_otp_parse(const uint8_t *in,size_t n,struct bw_otp *out) {
+    size_t p=0;int found=0;if(!in||!out||!n||n>4096)return BW_EINVAL;
+    memset(out,0,sizeof(*out));
+    while(p<n){uint8_t tag=in[p++];if(tag==0xff)break;if(!tag)continue;
+        if(p==n)return BW_EPROTO;
+        size_t len=in[p++];
+        if(len>n-p)return BW_EPROTO;
+        if(tag==0x15 && len>=4 && l32(in+p)==8){
+            size_t q=p+4,end=p+len;
+            while(q<end){while(q<end&&(in[q]==0||in[q]==' '))q++;if(q==end||in[q]==0xff)break;
+                size_t s=q;while(q<end&&in[q]&&in[q]!=' '&&in[q]!=0xff)q++;
+                if(q-s>=3&&in[s+1]=='='){
+                    char *v=NULL;switch(in[s]){case 'M':v=out->module;break;case 'V':v=out->vendor;break;case 'm':v=out->revision;break;case 's':v=out->silicon;break;default:break;}
+                    if(v&&otp_value(v,in+s+2,q-s-2))return BW_EPROTO;
+                }
+            }
+            found=1;
+        }
+        p+=len;
+    }
+    return found&&out->module[0]&&out->vendor[0]&&out->revision[0]?0:BW_EPROTO;
+}
+int bw_init(struct bw_device *d,const struct bw_ops *ops,void *cookie,
+    void *cpu,uint64_t dma,size_t len,uint32_t regs,uint32_t tcm) {
+    if(!d||!ops||!ops->read||!ops->write||!ops->sync||!ops->time_us||!ops->delay_us||!ops->stop_dma||!ops->receive||
+       !cpu||((uintptr_t)cpu&127)||!dma||(dma&127)||len<BW_POOL_MIN||len>16u*1024u*1024u||dma>UINT64_MAX-len||regs<0x3000||tcm<0x400000)return BW_EINVAL;
+    memset(d,0,sizeof(*d));d->ops=*ops;d->cookie=cookie;d->pool=(struct bw_mem){cpu,dma,len};
+    d->regs_size=regs;d->tcm_size=tcm;d->next_token=1;return 0;
+}
+static int inventory(struct bw_device *d){
+    uint32_t erom=bp_read(d,0x180000fcu);
+    if(!chip_address(erom))return BW_EPROTO;
+    uint32_t words[1024];for(unsigned i=0;i<1024;i++)words[i]=bp_read(d,erom+4*i);
+    unsigned p=0;d->core_count=0;
+    while(p<1024){uint32_t a=words[p++];if((a&15)==15)return d->core_count?0:BW_EPROTO;
+        if((a&15)!=1)continue;
+        if(p==1024)return BW_EPROTO;
+        uint32_t b=words[p++];
+        if((b&15)!=1)return BW_EPROTO;
+        struct bw_core c={0,0,(uint16_t)((a>>8)&0xfff),(uint8_t)(b>>24)};
+        unsigned wraptype=(p<1024&&(words[p]&15)==3)?3:2;
+        unsigned wrapcount=((b>>14)&31)+((b>>19)&31);
+        while(p<1024){uint32_t v=words[p];unsigned type=v&15;
+            if(type==1||type==15)break;
+            p++;
+            if((type&~8u)!=5)continue;
+            if(type&8){if(p==1024||words[p++]!=0)return BW_ENOTSUP;}
+            unsigned sz=(v>>4)&3;
+            if(sz==3){if(p==1024)return BW_EPROTO;uint32_t z=words[p++];if(z&8){if(p==1024)return BW_EPROTO;p++;}continue;}
+            if(sz>1)continue;
+            unsigned st=(v>>6)&3;
+            if(!st&&!c.base)c.base=v&0xfffff000u;
+            if(st==wraptype&&!c.wrap)c.wrap=v&0xfffff000u;
+        }
+        if(!wrapcount&&c.id!=GCI&&c.id!=0x827)continue;
+        if(!chip_address(c.base)||(wrapcount&&!chip_address(c.wrap)))return BW_EPROTO;
+        if(d->core_count==BW_MAX_CORES)return BW_ENOSPC;
+        d->cores[d->core_count++]=c;
+    }
+    return BW_EPROTO;
+}
+int bw_probe(struct bw_device *d){
+    if(!d||d->state!=BW_OFF)return BW_EINVAL;
+    if(rd(d,BW_CONFIG,0,4)!=0x442514e4u)return BW_ENOTSUP;
+    uint32_t id=bp_read(d,0x18000000);if((id&0xffff)!=0x4378||((id>>28)&15)!=1)return BW_ENOTSUP;
+    d->revision=(uint8_t)((id>>16)&15);if(d->revision!=3&&d->revision!=5)return BW_ENOTSUP;
+    int e=inventory(d);if(e)return e;
+    if(!core(d,CA7)||!core(d,SYSMEM)||!core(d,PCIE)||!core(d,CC)||!core(d,GCI))return BW_ENOTSUP;
+    d->pcie_revision=core(d,PCIE)->rev;
+    uint8_t otp[0x2e0];uint32_t base=core(d,GCI)->base+0x1120;
+    for(unsigned i=0;i<sizeof(otp);i+=4)s32(otp+i,bp_read(d,base+i));
+    if((e=bw_otp_parse(otp,sizeof(otp),&d->otp)))return e;
+    d->ram_base=RAM_BASE;d->state=BW_CHIP;return 0;
+}
+static int core_disable(struct bw_device *d,struct bw_core *c,uint32_t pre,uint32_t reset){
+    if(!c||!c->wrap)return BW_EPROTO;
+    if(!(bp_read(d,c->wrap+0x800)&1)){
+        bp_write(d,c->wrap+0x408,pre|3);(void)bp_read(d,c->wrap+0x408);
+        bp_write(d,c->wrap+0x800,1);d->ops.delay_us(d->cookie,20);
+        unsigned i;for(i=0;i<300;i++)if(bp_read(d,c->wrap+0x800)&1)break;
+        if(i==300)return BW_ETIME;
+    }
+    bp_write(d,c->wrap+0x408,reset|3);(void)bp_read(d,c->wrap+0x408);return 0;
+}
+static int core_reset(struct bw_device *d,struct bw_core *c,uint32_t pre,uint32_t reset,uint32_t post){
+    int e=core_disable(d,c,pre,reset);if(e)return e;
+    unsigned i;for(i=0;i<50;i++){
+        bp_write(d,c->wrap+0x800,0);d->ops.delay_us(d->cookie,60);
+        if(!(bp_read(d,c->wrap+0x800)&1))break;
+    }
+    if(i==50)return BW_ETIME;
+    bp_write(d,c->wrap+0x408,post|1);(void)bp_read(d,c->wrap+0x408);return 0;
+}
+static int passive(struct bw_device *d){
+    struct bw_core *c=core(d,CA7);int e=core_reset(d,c,bp_read(d,c->wrap+0x408)&0x20,0x20,0x20);if(e)return e;
+    for(unsigned i=0;i<d->core_count;i++)if(d->cores[i].id==D11){e=core_disable(d,&d->cores[i],12,4);if(e)return e;}
+    c=core(d,SYSMEM);
+    if(bp_read(d,c->wrap+0x800)&1){e=core_reset(d,c,0,0,0);if(e)return e;}
+    return 0;
+}
+static uint32_t pcie_off(struct bw_device *d,uint32_t old,uint32_t newer){return 0x2000+(d->pcie_revision>=64?newer:old);}
+static void bell(struct bw_device *d){wr(d,BW_REGS,pcie_off(d,0x140,0xa20),4,1);}
+static int firmware_boot(struct bw_device *d,const struct bw_firmware *f){
+    int e=passive(d);if(e)return e;
+    uint32_t link=rd(d,BW_CONFIG,0xbc,4);wr(d,BW_CONFIG,0xbc,4,link&~3u);
+    bp_write(d,core(d,CC)->base+0x80,4);d->ops.delay_us(d->cookie,100000);
+    wr(d,BW_CONFIG,0xbc,4,link&~3u); /* no ASPM until suspend/resume exists */
+    if((e=passive(d)))return e;
+    wr(d,BW_REGS,pcie_off(d,0x4c,0xc34),4,0); /* polled; no MSI */
+    wr(d,BW_REGS,0x2120,4,0x4e0);uint32_t bar2=rd(d,BW_REGS,0x2124,4);wr(d,BW_REGS,0x2124,4,bar2);
+    struct bw_core *ram=core(d,SYSMEM);uint32_t banks=(bp_read(d,ram->base)>>4)&15,total=0;
+    for(uint32_t i=0;i<banks;i++){bp_write(d,ram->base+0x10,i);total+=((bp_read(d,ram->base+0x40)&127)+1)*8192;}
+    if(f->code_len<0x74||l32(f->code+0x6c)!=0x534d4152)return BW_EPROTO;
+    d->ram_size=l32(f->code+0x70);
+    if(!total||d->ram_size>total||d->ram_size<0x20000||!range(d->ram_base,d->ram_size,0,d->tcm_size)||(d->ram_size&3))return BW_EPROTO;
+    struct bw_mem packed;size_t nvlen=0;
+    if((e=alloc_mem(d,65536,&packed)))return e;
+    if((e=bw_nvram_pack(f->nvram,f->nvram_len,packed.cpu,packed.len,&nvlen)))return e;
+    if(nvlen+264>=d->ram_size||f->code_len>d->ram_size-nvlen-264)return BW_ENOSPC;
+    tcm_copy(d,d->ram_base,f->code,f->code_len);
+    uint32_t top=d->ram_base+d->ram_size,nv=top-(uint32_t)nvlen;
+    tcm_copy(d,nv,packed.cpu,nvlen);uint32_t token=l32(packed.cpu+nvlen-4);
+    wr(d,BW_TCM,nv-8,4,256);wr(d,BW_TCM,nv-4,4,0xfeedc0de);
+    tcm_copy(d,nv-264,f->seed,256);
+    wr(d,BW_TCM,0,4,l32(f->code));
+    if((e=core_reset(d,core(d,CA7),0x20,0,0)))return e;
+    for(unsigned i=0;i<500;i++){
+        d->ops.delay_us(d->cookie,10000);uint32_t shared=rd(d,BW_TCM,top-4,4);
+        if(shared&&shared!=token){if((shared&3)||!ram_address(d,shared,0x74))return BW_EPROTO;d->shared=shared;return 0;}
+    }
+    return BW_ETIME;
+}
+
+static uint16_t index_read(struct bw_device *d,struct bw_ring *r,int write_index){
+    uint32_t a=write_index?r->wi:r->ri;
+    if(r->dma_indices){d->ops.sync(d->cookie,d->pool.cpu+a,2,0);return l16(d->pool.cpu+a);}
+    return (uint16_t)rd(d,BW_TCM,a,2);
+}
+static void index_write(struct bw_device *d,struct bw_ring *r,int write_index,uint16_t v){
+    uint32_t a=write_index?r->wi:r->ri;
+    if(r->dma_indices){s16(d->pool.cpu+a,v);d->ops.sync(d->cookie,d->pool.cpu+a,2,1);}
+    else wr(d,BW_TCM,a,2,v);
+}
+static int setup_ring(struct bw_device *d,unsigned k,unsigned count,unsigned item,
+    uint32_t wi,uint32_t ri,uint32_t descriptor){
+    struct bw_ring *r=&d->rings[k];r->count=(uint16_t)count;r->item=(uint16_t)item;
+    r->wi=wi;r->ri=ri;r->dma_indices=d->index_size!=0;
+    int e=alloc_mem(d,(size_t)count*item,&r->mem);if(e)return e;
+    index_write(d,r,0,0);index_write(d,r,1,0);
+    if(descriptor){wr(d,BW_TCM,descriptor+4,2,count);wr(d,BW_TCM,descriptor+6,2,item);
+        wr(d,BW_TCM,descriptor+8,4,(uint32_t)r->mem.dma);wr(d,BW_TCM,descriptor+12,4,(uint32_t)(r->mem.dma>>32));}
+    return 0;
+}
+static int submit(struct bw_device *d,unsigned k,const uint8_t *msg,size_t n){
+    struct bw_ring *r=&d->rings[k];if(n>r->item||!r->count)return BW_EINVAL;
+    uint16_t ri=index_read(d,r,0);if(ri>=r->count)return fail(d,BW_EPROTO);
+    uint16_t next=(uint16_t)((r->write+1)%r->count);if(next==ri)return BW_ENOSPC;
+    uint8_t *p=r->mem.cpu+(size_t)r->write*r->item;memset(p,0,r->item);memcpy(p,msg,n);
+    d->ops.sync(d->cookie,p,r->item,1);r->write=next;index_write(d,r,1,next);bell(d);return 0;
+}
+static uint32_t next_token(struct bw_device *d){
+    uint32_t t=d->next_token++;
+    if(t==0xfffe)t=d->next_token++;
+    if(!t||!d->next_token){(void)fail(d,BW_EPROTO);return 0;}return t;
+}
+static int post_one(struct bw_device *d,unsigned i){
+    struct bw_packet *p=&d->rx[i];uint8_t m[40]={0};
+    if(p->owner)return 0;
+    uint32_t token=next_token(d);if(!token)return BW_EPROTO;
+    m[0]=p->kind==RX_DATA?0x11:(p->kind==RX_IOCTL?0x0b:0x0d);s32(m+4,token);
+    if(p->kind==RX_DATA){s16(m+10,(uint16_t)p->mem.len);s64(m+24,p->mem.dma);}
+    else{s16(m+8,(uint16_t)p->mem.len);s64(m+16,p->mem.dma);}
+    /* Buffer is device-owned only after the descriptor has been published. */
+    d->ops.sync(d->cookie,p->mem.cpu,p->mem.len,1);
+    int e=submit(d,p->kind==RX_DATA?1:0,m,p->kind==RX_DATA?32:40);
+    if(!e){p->owner=1;p->token=token;}return e;
+}
+static int replenish(struct bw_device *d){
+    for(unsigned i=0;i<BW_PACKET_COUNT;i++)if(d->rx[i].kind&&!d->rx[i].owner){int e=post_one(d,i);if(e==BW_ENOSPC)return 0;if(e)return e;}
+    return 0;
+}
+static int rings_start(struct bw_device *d){
+    uint32_t s=d->shared;d->flags=rd(d,BW_TCM,s,4);d->version=(uint8_t)d->flags;
+    if(d->version<5||d->version>7)return BW_ENOTSUP;
+    d->rx_offset=rd(d,BW_TCM,s+0x24,4);if(d->rx_offset>512)return BW_EPROTO;
+    d->max_rx=(uint16_t)rd(d,BW_TCM,s+0x22,2);if(!d->max_rx)d->max_rx=255;
+    if(d->max_rx>BW_RX_COUNT)return BW_ENOSPC;
+    d->h2d_mb=rd(d,BW_TCM,s+0x28,4);d->d2h_mb=rd(d,BW_TCM,s+0x2c,4);
+    d->ring_info=rd(d,BW_TCM,s+0x30,4);
+    if((d->ring_info&3)||!ram_address(d,d->ring_info,60))return BW_EPROTO;
+    uint8_t info[60];for(unsigned i=0;i<60;i+=4)s32(info+i,rd(d,BW_TCM,d->ring_info+i,4));
+    unsigned flows=l16(info+52);
+    d->submission_count=d->version>=6?l16(info+54):(uint16_t)flows;
+    d->completion_count=d->version>=6?l16(info+56):3;
+    if(d->submission_count<3||d->submission_count>1024||d->completion_count<3||d->completion_count>64||!flows)return BW_EPROTO;
+    if(d->version>=6&&flows>d->submission_count-2u)return BW_EPROTO;
+    uint32_t descriptors=l32(info);
+    if((descriptors&3)||!ram_address(d,descriptors,80))return BW_EPROTO;
+    d->index_size=(d->flags&0x10000)?((d->flags&0x100000)?2:4):0;
+    d->mb_via_ctl=d->version>=6 && !(d->flags&0x2000000);
+    if(!d->mb_via_ctl&&((d->h2d_mb&3)||(d->d2h_mb&3)||!ram_address(d,d->h2d_mb,4)||!ram_address(d,d->d2h_mb,4)))return BW_EPROTO;
+    unsigned stride=d->index_size?d->index_size:4;
+    uint32_t idx[4];
+    for(unsigned i=0;i<4;i++){
+        unsigned count=i<2?d->submission_count:d->completion_count;
+        if(d->index_size){
+            int e=alloc_mem(d,(size_t)count*stride,&d->indices[i]);if(e)return e;
+            idx[i]=(uint32_t)(d->indices[i].cpu-d->pool.cpu);
+            wr(d,BW_TCM,d->ring_info+20+8*i,4,(uint32_t)d->indices[i].dma);
+            wr(d,BW_TCM,d->ring_info+24+8*i,4,(uint32_t)(d->indices[i].dma>>32));
+        }else{idx[i]=l32(info+4+4*i);if((idx[i]&3)||!ram_address(d,idx[i],(size_t)count*stride))return BW_EPROTO;}
+    }
+    const unsigned counts[6]={64,1024,64,1024,1024,512};
+    unsigned sizes[6]={40,32,24,d->version==7?24u:16u,d->version==7?40u:32u,48};
+    for(unsigned k=0;k<6;k++){
+        unsigned i=k<2?k:(k==5?2:k-2),a=(k<2||k==5)?0:2;
+        int e=setup_ring(d,k,counts[k],sizes[k],idx[a]+i*stride,idx[a+1]+i*stride,k<5?descriptors+16*k:0);if(e)return e;
+    }
+    struct bw_mem scratch,updates;
+    int e=alloc_mem(d,8,&scratch);if(e)return e;
+    if((e=alloc_mem(d,1024,&updates))||(e=alloc_mem(d,BW_CTL_SIZE,&d->request)))return e;
+    wr(d,BW_TCM,s+0x38,4,(uint32_t)scratch.dma);wr(d,BW_TCM,s+0x3c,4,(uint32_t)(scratch.dma>>32));wr(d,BW_TCM,s+0x34,4,8);
+    wr(d,BW_TCM,s+0x44,4,(uint32_t)updates.dma);wr(d,BW_TCM,s+0x48,4,(uint32_t)(updates.dma>>32));wr(d,BW_TCM,s+0x40,4,1024);
+    for(unsigned i=0;i<BW_PACKET_COUNT;i++){
+        struct bw_packet *p=&d->rx[i];
+        p->kind=i<d->max_rx?RX_DATA:(i>=BW_RX_COUNT?(i<BW_RX_COUNT+BW_CTL_COUNT?RX_IOCTL:RX_EVENT):0);
+        if(p->kind&&(e=alloc_mem(d,p->kind==RX_DATA?2048:BW_CTL_SIZE,&p->mem)))return e;
+    }
+    for(unsigned i=0;i<BW_TX_COUNT;i++)if((e=alloc_mem(d,2048,&d->tx[i].mem)))return e;
+    if(d->version>=6){uint32_t cap=d->version|0x1000u;
+        if(d->flags&0x10000000)cap|=0x400;
+        if(d->flags&0x80000000)cap|=0x10000;
+        wr(d,BW_TCM,s+0x54,4,cap);wr(d,BW_TCM,s+0x70,4,0);
+    }
+    if(d->flags&0x10000000)wr(d,BW_REGS,pcie_off(d,0x144,0xa24),4,1);
+    d->state=BW_READY;return replenish(d);
+}
+static struct bw_packet *find_packet(struct bw_packet *ps,unsigned count,uint32_t token,unsigned kind){
+    for(unsigned i=0;i<count;i++) {
+        if(ps[i].owner&&ps[i].token==token&&(!kind||ps[i].kind==kind))return &ps[i];
+    }
+    return NULL;
+}
+static int mailbox(struct bw_device *d,uint32_t data){
+    if(data&0x10000000u)return fail(d,BW_EIO);
+    /* Refuse deep sleep: there is no safe wake path in this polling driver.
+     * Do not ACK a sleep request and then keep touching sleeping BARs. */
+    if(data&2u)return fail(d,BW_ENOTSUP);
+    return 0;
+}
+static int event_message(struct bw_device *d,const uint8_t *p,size_t n){
+    if(n<72||b16(p+12)!=0x886c||b16(p+14)!=0x8001||p[18]!=0||memcmp(p+19,"\x00\x10\x18",3)||b16(p+22)!=1||b16(p+24)!=2||p[70]!=0||p[71]!=0||b32(p+44)>n-72)return BW_EPROTO;
+    unsigned type=b32(p+28),status=b32(p+32),flags=b16(p+26);
+    if(d->state!=BW_JOINING&&d->state!=BW_LINK)return 0;
+    if(type==0){
+        if(status)return fail(d,BW_ENOLINK);
+        if(!mac_ok(p+48))return BW_EPROTO;
+        memcpy(d->bssid,p+48,6);d->associated=1;
+    }else if(type==46){
+        if(status==6)d->keyed=1;
+        else if(status==7)return fail(d,BW_ENOLINK);
+    }else if(type==5||type==6||type==11||type==12||(type==16&&!(flags&1))){return fail(d,BW_ENOLINK);}
+    if(d->associated&&d->keyed)d->state=BW_LINK;
+    return 0;
+}
+static int completion(struct bw_device *d,unsigned ring,const uint8_t *m,size_t n){
+    unsigned type=m[0];uint32_t token=l32(m+4);struct bw_packet *p=NULL;
+    if(m[1]!=0&&type!=0x24)return BW_EPROTO;
+    if(ring==2){
+        if(type==1||type==2)return l16(m+8)?BW_EIO:0;
+        if(type==0x0a){if(token!=0xfffeu||!d->request_busy||l16(m+8))return BW_EPROTO;d->request_busy=0;return 0;}
+        if(type==4){if(!d->flow_pending||l16(m+10)!=2||l16(m+8))return BW_EPROTO;d->flow_open=1;d->flow_pending=0;return 0;}
+        if(type==0x24)return mailbox(d,l32(m+12));
+        if(type!=0x0c&&type!=0x0e)return BW_EPROTO;
+        p=find_packet(d->rx,BW_PACKET_COUNT,token,type==0x0c?RX_IOCTL:RX_EVENT);
+        if(!p)return BW_EPROTO;
+        d->ops.sync(d->cookie,p->mem.cpu,p->mem.len,0);
+        size_t len=l16(m+12),off=type==0x0e?d->rx_offset:0;
+        if(off>p->mem.len||len>p->mem.len-off)return BW_EPROTO;
+        int e=0;
+        if(type==0x0c){
+            if(d->reply_ready||l16(m+14)!=d->transaction||l32(m+16)!=d->reply_command)return BW_EPROTO;
+            memcpy(d->reply,p->mem.cpu,len);d->reply_length=(uint16_t)len;d->reply_status=(int16_t)l16(m+8);d->reply_ready=1;
+        }else if(!l16(m+8)){e=event_message(d,p->mem.cpu+off,len);}
+        p->owner=0;return e;
+    }
+    if(ring==3){
+        if(type!=0x10||n<16||l16(m+10)!=2)return BW_EPROTO;
+        p=find_packet(d->tx,BW_TX_COUNT,token,0);if(!p)return BW_EPROTO;
+        d->ops.sync(d->cookie,p->mem.cpu,p->mem.len,0);p->owner=0;
+        if(!l16(m+8)&&!l16(m+14))d->tx_frames++;
+        return 0;
+    }
+    if(ring!=4||type!=0x12||n<32)return BW_EPROTO;
+    p=find_packet(d->rx,BW_PACKET_COUNT,token,RX_DATA);if(!p)return BW_EPROTO;
+    size_t len=l16(m+14),off=l16(m+16);if(!off)off=d->rx_offset;
+    if(off>p->mem.len||len>p->mem.len-off)return BW_EPROTO;
+    d->ops.sync(d->cookie,p->mem.cpu,p->mem.len,0);
+    /* Only authenticated data, never vendor-event interpretation of RX data. */
+    if(!l16(m+8)&&d->state==BW_LINK&&len>=14&&len<=BW_MAX_FRAME&&b16(p->mem.cpu+off+12)!=0x886c){
+        d->ops.receive(d->cookie,p->mem.cpu+off,len);d->rx_frames++;
+    }
+    p->owner=0;return 0;
+}
+int bw_poll(struct bw_device *d,unsigned budget){
+    if(!d)return BW_EINVAL;
+    if(d->state==BW_FAULT)return d->error;
+    if(d->state<BW_READY)return 0;
+    if(budget>256)budget=256;
+    if(!d->mb_via_ctl){uint32_t m=rd(d,BW_TCM,d->d2h_mb,4);if(m){wr(d,BW_TCM,d->d2h_mb,4,0);int e=mailbox(d,m);if(e)return e;}}
+    unsigned done=0;
+    for(unsigned k=2;k<5&&done<budget;k++){
+        struct bw_ring *r=&d->rings[k];uint16_t wi=index_read(d,r,1);
+        if(wi>=r->count)return fail(d,BW_EPROTO);
+        while(r->read!=wi&&done<budget){
+            uint8_t m[40];uint8_t *p=r->mem.cpu+(size_t)r->read*r->item;
+            d->ops.sync(d->cookie,p,r->item,0);memcpy(m,p,r->item);
+            int e=completion(d,k,m,r->item);
+            if(e){d->bad_completions++;return fail(d,e);}
+            r->read=(uint16_t)((r->read+1)%r->count);done++;
+        }
+        index_write(d,r,0,r->read);
+    }
+    uint64_t now=d->ops.time_us(d->cookie);
+    if((d->state==BW_JOINING&&now>=d->join_deadline)||(d->flow_pending&&now>=d->flow_deadline))return fail(d,BW_ETIME);
+    int e=replenish(d);return e?e:(int)done;
+}
+static int command(struct bw_device *d,uint32_t cmd,const void *in,size_t inlen,void *out,size_t cap,size_t *actual){
+    if(d->state<BW_READY||d->state==BW_FAULT||inlen>MAX_CTL||cap>MAX_CTL||d->request_busy||(!in&&inlen)||(!out&&cap))return BW_EINVAL;
+    if(d->transaction==UINT16_MAX)return fail(d,BW_EPROTO); /* never alias stale replies */
+    d->transaction++;d->reply_command=cmd;d->reply_ready=0;d->reply_length=0;
+    memset(d->request.cpu,0,d->request.len);if(inlen)memcpy(d->request.cpu,in,inlen);
+    d->ops.sync(d->cookie,d->request.cpu,d->request.len,1);
+    uint8_t m[40]={9};s32(m+4,0xfffe);s32(m+8,cmd);s16(m+12,d->transaction);
+    s16(m+14,(uint16_t)inlen);s16(m+16,(uint16_t)(cap?cap:inlen));s64(m+24,d->request.dma);
+    int e=submit(d,0,m,sizeof(m));if(e)return e;d->request_busy=1;
+    for(unsigned i=0;i<20000;i++){
+        e=bw_poll(d,128);if(e<0)return e;
+        if(d->reply_ready&&!d->request_busy){
+            size_t count=d->reply_length;
+            if(cap&&count>cap)return fail(d,BW_EPROTO);
+            if(cap)memcpy(out,d->reply,count);
+            if(actual)*actual=count;
+            e=d->reply_status?BW_EIO:0;
+            erase(d->request.cpu,d->request.len);d->ops.sync(d->cookie,d->request.cpu,d->request.len,1);
+            erase(d->reply,sizeof(d->reply));d->reply_ready=0;return e;
+        }
+        d->ops.delay_us(d->cookie,100);
+    }
+    /* The firmware could still DMA the input buffer. Quiesce, don't reuse it. */
+    return fail(d,BW_ETIME);
+}
+static int var_set(struct bw_device *d,const char *name,const void *data,size_t n){
+    uint8_t b[MAX_CTL];size_t k=0;
+    while(k<64 && name[k])k++;
+    k++;
+    if(k>64||n>sizeof(b)-k)return BW_EINVAL;
+    memcpy(b,name,k);if(n)memcpy(b+k,data,n);
+    int e=command(d,IOVAR_SET,b,k+n,NULL,0,NULL);erase(b,k+n);return e;
+}
+static int var_int(struct bw_device *d,const char *name,uint32_t val){uint8_t b[4];s32(b,val);return var_set(d,name,b,4);}
+static int cmd_int(struct bw_device *d,uint32_t cmd,uint32_t val){uint8_t b[4];s32(b,val);return command(d,cmd,b,4,NULL,0,NULL);}
+static int download_blob(struct bw_device *d,const char *name,const uint8_t *p,size_t n){
+    uint8_t b[1412];size_t off=0;
+    if(!p||!n||n>1024u*1024u)return BW_EINVAL;
+    while(off<n){size_t take=n-off;if(take>1400)take=1400;
+        memset(b,0,12);s16(b,(uint16_t)(0x1000|(off==0?2:0)|(off+take==n?4:0)));
+        s16(b+2,2);s32(b+4,(uint32_t)take);memcpy(b+12,p+off,take);
+        int e=var_set(d,name,b,take+12);if(e)return e;off+=take;
+    }
+    return 0;
+}
+int bw_start(struct bw_device *d,const struct bw_firmware *f){
+    if(!d||!f||d->state!=BW_CHIP||!f->code||!f->nvram||!f->clm||!f->txcap||!f->calibration||!f->seed||
+       f->seed_len!=256||!mac_ok(f->mac)||f->silicon_revision!=d->revision||f->code_len>4u*1024u*1024u||!f->nvram_len||
+       f->nvram_len>65536||!f->clm_len||f->clm_len>1024u*1024u||!f->txcap_len||f->txcap_len>1024u*1024u||!f->calibration_len||f->calibration_len>1024u*1024u)return BW_EINVAL;
+    d->state=BW_BOOTING;int e=firmware_boot(d,f);if(e)return fail(d,e);
+    if((e=rings_start(d)))return fail(d,e);
+    memcpy(d->mac,f->mac,6);
+    if((e=var_set(d,"cur_etheraddr",f->mac,6))||
+       (e=download_blob(d,"clmload",f->clm,f->clm_len))||
+       (e=download_blob(d,"txcapload",f->txcap,f->txcap_len))||
+       (e=download_blob(d,"calload",f->calibration,f->calibration_len))||
+       (e=var_int(d,"mpc",0))||(e=cmd_int(d,86,0))||
+       (e=cmd_int(d,20,1)))return fail(d,e);
+    uint8_t events[16]={0};const unsigned types[]={0,5,6,11,12,16,46};
+    for(unsigned i=0;i<sizeof(types)/sizeof(types[0]);i++)events[types[i]/8]|=(uint8_t)(1u<<(types[i]%8));
+    if((e=var_set(d,"event_msgs",events,sizeof(events)))||(e=cmd_int(d,2,1)))return fail(d,e);
+    return 0;
+}
+int bw_join_wpa2(struct bw_device *d,const uint8_t *ssid,size_t sn,const uint8_t *pass,size_t pn){
+    if(!d||d->state!=BW_READY||!ssid||!sn||sn>32||!pass||pn<8||pn>63)return BW_EINVAL;
+    for(size_t i=0;i<pn;i++)if(pass[i]<32||pass[i]>126)return BW_EINVAL;
+    /* RSN IE: WPA2-PSK + CCMP only; never fall back to an open network. */
+    static const uint8_t rsn[]={0x30,20,1,0,0,0x0f,0xac,4,1,0,0,0x0f,0xac,4,1,0,0,0x0f,0xac,2,0,0};
+    int e;
+    if((e=var_int(d,"auth",0))||(e=var_int(d,"wsec",4))||(e=var_int(d,"wpa_auth",0x80))||
+       (e=var_int(d,"mfp",0))||(e=var_set(d,"wpaie",rsn,sizeof(rsn)))||
+       (e=var_int(d,"sup_wpa",1)))return fail(d,e);
+    uint8_t pmk[68]={0};s16(pmk,(uint16_t)pn);s16(pmk+2,1);memcpy(pmk+4,pass,pn);
+    e=command(d,268,pmk,sizeof(pmk),NULL,0,NULL);erase(pmk,sizeof(pmk));if(e)return fail(d,e);
+    uint8_t join[36]={0};s32(join,(uint32_t)sn);memcpy(join+4,ssid,sn);
+    d->associated=d->keyed=0;d->state=BW_JOINING;d->join_deadline=d->ops.time_us(d->cookie)+30000000;
+    e=command(d,26,join,sizeof(join),NULL,0,NULL);return e?fail(d,e):0;
+}
+int bw_transmit(struct bw_device *d,const uint8_t *p,size_t n){
+    if(!d||!p||n<14||n>BW_MAX_FRAME)return BW_EINVAL;
+    if(d->state!=BW_LINK)return BW_ENOLINK;
+    if(memcmp(p+6,d->mac,6))return BW_EINVAL;
+    if(!d->flow_open){
+        if(d->flow_pending)return BW_ENOSPC;
+        uint8_t c[40]={3};memcpy(c+8,p,6);memcpy(c+14,d->mac,6);s16(c+22,2);
+        s16(c+28,512);s16(c+30,48);s64(c+32,d->rings[5].mem.dma);
+        int e=submit(d,0,c,sizeof(c));if(e)return e;
+        d->flow_pending=1;d->flow_deadline=d->ops.time_us(d->cookie)+2000000;return BW_ENOSPC;
+    }
+    struct bw_packet *t=NULL;for(unsigned i=0;i<BW_TX_COUNT;i++)if(!d->tx[i].owner){t=&d->tx[i];break;}
+    if(!t)return BW_ENOSPC;
+    uint32_t token=next_token(d);if(!token)return BW_EPROTO;
+    memcpy(t->mem.cpu,p,n);d->ops.sync(d->cookie,t->mem.cpu,n,1);
+    uint8_t m[48]={0x0f};s32(m+4,token);memcpy(m+8,p,14);m[22]=1;m[23]=1;s64(m+32,t->mem.dma+14);s16(m+42,(uint16_t)(n-14));
+    int e=submit(d,5,m,sizeof(m));if(!e){t->owner=1;t->token=token;}return e;
+}
+int bw_disconnect(struct bw_device *d){
+    if(!d||d->state<BW_READY||d->state==BW_FAULT)return BW_EINVAL;
+    int e=command(d,52,NULL,0,NULL,0,NULL);bw_stop(d);return e;
+}
+void bw_stop(struct bw_device *d){if(!d)return;d->ops.stop_dma(d->cookie);d->associated=d->keyed=0;d->state=BW_FAULT;d->error=BW_ENOLINK;}
+const char *bw_state_name(enum bw_state s){
+    static const char *const names[]={"off","chip detected","firmware boot","firmware ready","authenticating","authenticated link","stopped"};
+    return (unsigned)s<sizeof(names)/sizeof(names[0])?names[s]:"invalid";
+}

--- a/kernel/c/brcm_wifi.h
+++ b/kernel/c/brcm_wifi.h
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: ISC
+ * Experimental BCM4378 FullMAC PCIe driver for Vinix.
+ * The caller owns the PCIe host, DART mapping, firmware files and serialization.
+ * Firmware/DMA addresses are never CPU pointers. See tests/m1-wifi/README.md.
+ */
+#ifndef VINIX_BRCM_WIFI_H
+#define VINIX_BRCM_WIFI_H
+#include <stddef.h>
+#include <stdint.h>
+
+#define BW_POOL_MIN (4u * 1024u * 1024u)
+#define BW_MAX_FRAME 1514u
+#define BW_RX_COUNT 512u
+#define BW_TX_COUNT 128u
+#define BW_CTL_COUNT 8u
+#define BW_CTL_SIZE 8192u
+#define BW_PACKET_COUNT (BW_RX_COUNT + 2u * BW_CTL_COUNT)
+#define BW_MAX_CORES 32u
+
+enum bw_space { BW_CONFIG, BW_REGS, BW_TCM };
+enum bw_state { BW_OFF, BW_CHIP, BW_BOOTING, BW_READY, BW_JOINING, BW_LINK, BW_FAULT };
+enum bw_error { BW_OK = 0, BW_EINVAL = -1, BW_ENOSPC = -2, BW_EIO = -3,
+    BW_ETIME = -4, BW_EPROTO = -5, BW_ENOTSUP = -6, BW_ENOLINK = -7 };
+
+struct bw_ops {
+    uint32_t (*read)(void *, unsigned space, uint32_t offset, unsigned width);
+    void (*write)(void *, unsigned space, uint32_t offset, unsigned width, uint32_t value);
+    uint64_t (*time_us)(void *);
+    void (*delay_us)(void *, uint32_t);
+    /* DMA sync is required even on machines where ordinary RAM is coherent.
+     * to_device: clean/invalidate before publishing ownership to the device.
+     * to_cpu: invalidate after observing a device-written completion/index.
+     * Each allocated area is isolated on at least 128-byte cache boundaries. */
+    void (*sync)(void *, void *cpu, size_t length, int to_device);
+    /* Must disable PCI bus mastering and drain/quiesce before return.
+     * The driver NEVER frees or reuses the DMA pool after a fatal error. */
+    void (*stop_dma)(void *);
+    void (*receive)(void *, const uint8_t *ethernet, size_t length);
+};
+struct bw_core { uint32_t base, wrap; uint16_t id; uint8_t rev; };
+struct bw_mem { uint8_t *cpu; uint64_t dma; size_t len; };
+struct bw_ring {
+    struct bw_mem mem;
+    uint32_t wi, ri;
+    uint16_t count, item, read, write;
+    uint8_t dma_indices;
+};
+struct bw_packet { struct bw_mem mem; uint32_t token; uint8_t owner, kind; };
+struct bw_otp { char module[16], vendor[16], revision[16], silicon[16]; };
+struct bw_firmware {
+    const uint8_t *code, *nvram, *clm, *txcap, *calibration, *seed;
+    size_t code_len, nvram_len, clm_len, txcap_len, calibration_len, seed_len;
+    uint8_t silicon_revision;
+    uint8_t mac[6];
+};
+struct bw_device {
+    struct bw_ops ops;
+    void *cookie;
+    enum bw_state state;
+    int error;
+    uint32_t regs_size, tcm_size, ram_base, ram_size, shared, flags, rx_offset;
+    uint32_t ring_info, h2d_mb, d2h_mb;
+    uint16_t submission_count, completion_count, max_rx;
+    uint8_t revision, pcie_revision, version, index_size, mb_via_ctl;
+    struct bw_core cores[BW_MAX_CORES];
+    unsigned core_count;
+    struct bw_otp otp;
+    struct bw_mem pool, indices[4];
+    size_t allocated;
+    struct bw_ring rings[6]; /* five common rings and station best-effort TX */
+    struct bw_packet rx[BW_PACKET_COUNT], tx[BW_TX_COUNT];
+    struct bw_mem request;
+    uint32_t next_token;
+    uint16_t transaction, reply_length;
+    int16_t reply_status;
+    uint32_t reply_command;
+    uint8_t request_busy, reply_ready, flow_pending, flow_open;
+    uint8_t associated, keyed, mac[6], bssid[6];
+    uint64_t join_deadline, flow_deadline, rx_frames, tx_frames, bad_completions;
+    uint8_t reply[BW_CTL_SIZE];
+};
+
+/* Initialize software only. Pool must already be isolated by DART; bus master
+ * remains disabled until platform code has established that isolation. */
+int bw_init(struct bw_device *, const struct bw_ops *, void *cookie,
+    void *pool_cpu, uint64_t pool_dma, size_t pool_len,
+    uint32_t registers_size, uint32_t tcm_size);
+/* Probe only accesses the declared endpoint. Reads core inventory and OTP;
+ * it does not upload firmware or turn on the radio. */
+int bw_probe(struct bw_device *);
+int bw_start(struct bw_device *, const struct bw_firmware *);
+int bw_join_wpa2(struct bw_device *, const uint8_t *ssid, size_t ssid_len,
+    const uint8_t *passphrase, size_t passphrase_len);
+int bw_disconnect(struct bw_device *);
+int bw_poll(struct bw_device *, unsigned budget);
+int bw_transmit(struct bw_device *, const uint8_t *ethernet, size_t length);
+void bw_stop(struct bw_device *);
+
+/* Bounded, host-testable parsers. NVRAM input is board-specific text; output
+ * includes double NUL, padding, and the Broadcom complement length token. */
+int bw_nvram_pack(const uint8_t *, size_t, uint8_t *, size_t, size_t *);
+int bw_otp_parse(const uint8_t *, size_t, struct bw_otp *);
+const char *bw_state_name(enum bw_state);
+#endif

--- a/kernel/modules/apple/ans/ans.v
+++ b/kernel/modules/apple/ans/ans.v
@@ -101,7 +101,7 @@ fn (mut this AnsBlock) write(_handle voidptr, buffer voidptr, loc u64, count u64
 	if result != 0 {
 		C.printf(c'ans: write/flush failed error=%d stage=%u status=0x%x; writes stopped\n',
 			result, C.vinix_ans_stage(), C.vinix_ans_completion_status())
-		errno.set(if result == -12 { errno.erofs } else { errno.eio })
+		errno.set(u64(if result == -12 { errno.erofs } else { errno.eio }))
 		return none
 	}
 	return i64(bytes)

--- a/kernel/modules/apple/ans/rootfs.v
+++ b/kernel/modules/apple/ans/rootfs.v
@@ -60,7 +60,7 @@ fn (mut this AnsRootResource) mmap(_handle voidptr, page u64, flags int) voidptr
 	}
 	this.l.acquire()
 	defer { this.l.release() }
-	if page in this.pages { return this.pages[page] }
+	if page in this.pages { return unsafe { this.pages[page] } }
 	physical := memory.pmm_alloc_fallible(1)
 	if physical == unsafe { nil } { return unsafe { nil } }
 	mut n := u64(this.stat.size) - page * 4096
@@ -140,13 +140,13 @@ fn (mut this AnsRootFS) make_node(parent &fs.VFSNode, name string, ino u32) ?&fs
 	if stat.islnk(mode) {
 		mut text := []u8{len: int(fields[0]) + 1}
 		ans_lock.acquire()
-		n := C.vinix_ans_root_read(ino, &text[0], 0, fields[0])
+		n := C.vinix_ans_root_read(ino, text.data, 0, fields[0])
 		ans_lock.release()
 		if n != i64(fields[0]) { unsafe { text.free() }; return none }
 		for i in 0 .. int(fields[0]) {
 			if text[i] == 0 { unsafe { text.free() }; return none }
 		}
-		node.symlink_target = unsafe { tos(&char(text.data), int(fields[0])).clone() }
+		node.symlink_target = unsafe { tos(&u8(text.data), int(fields[0])).clone() }
 		unsafe { text.free() }
 	}
 	return node

--- a/kernel/modules/apple/wifi/wifi.v
+++ b/kernel/modules/apple/wifi/wifi.v
@@ -1,0 +1,618 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+@[has_globals]
+module wifi
+
+import aarch64.pmgr
+import crypto.sha256
+import devicetree
+import errno
+import event
+import event.eventstruct
+import file
+import fs
+import katomic
+import klock
+import limine
+import memory
+import resource
+import stat
+import usercopy
+
+#include "brcm_m1.h"
+
+struct C.bw_m1_plan {
+mut:
+	config          u64
+	config_size     u64
+	rc              u64
+	port            u64
+	phy             u64
+	gpio            u64
+	dart            u64
+	window          u64
+	window_bus      u64
+	window_size     u64
+	pool_cpu        u64
+	pool_physical   u64
+	tables_cpu      u64
+	tables_physical u64
+	sid             u32
+	gpio_active_low u32
+	calibration     &u8 = unsafe { nil }
+	seed            &u8 = unsafe { nil }
+	calibration_len usize
+	seed_len        usize
+	mac             [6]u8
+	antenna         [16]u8
+}
+
+fn C.brcm_m1_prepare(plan &C.bw_m1_plan) int
+
+fn C.brcm_m1_status(output &u8) int
+
+fn C.brcm_m1_upload(input &u8) int
+
+fn C.brcm_m1_boot(input &u8) int
+
+fn C.brcm_m1_join(input &u8) int
+
+fn C.brcm_m1_poll() int
+
+fn C.brcm_m1_read(output &u8, capacity usize) int
+
+fn C.brcm_m1_write(input &u8, count usize) int
+
+fn C.brcm_m1_stop()
+
+@[_linker_section: '.requests']
+@[cinit]
+__global (
+	wifi_kernel_req = limine.LimineKernelFileRequest{ response: unsafe { nil } }
+)
+__global (
+	wifi_lock klock.Lock
+	wifi_res  = &WifiDevice(unsafe { nil })
+	wifi_seed [256]u8
+)
+
+struct PowerDomain {
+	handle u32
+	region devicetree.DTReg
+	offset u32
+}
+
+struct Plan {
+mut:
+	power    []PowerDomain
+	config   devicetree.DTReg
+	rc       devicetree.DTReg
+	port     devicetree.DTReg
+	phy      devicetree.DTReg
+	dart     devicetree.DTReg
+	gpio     devicetree.DTReg
+	gpio_pin u32
+	gpio_low u32
+	window   devicetree.DTReg
+	bus_base u64
+	sid      u32
+	cal      devicetree.DTProperty
+	mac      [6]u8
+	antenna  [16]u8
+}
+
+fn compatible(node &devicetree.DTNode, name string) bool {
+	values := devicetree.get_string_list(node, 'compatible') or { return false }
+	defer { unsafe { values.free() }
+	 }
+	return name in values
+}
+
+fn enabled(node &devicetree.DTNode) bool {
+	mut cur := node
+	for _ in 0 .. 64 {
+		if cur == unsafe { nil } {
+			return true
+		}
+		status := devicetree.get_string_prop(cur, 'status') or { 'okay' }
+		if status != 'okay' && status != 'ok' {
+			return false
+		}
+		cur = cur.parent
+	}
+	return false
+}
+
+fn has_prop(node &devicetree.DTNode, name string) bool {
+	_ := devicetree.get_property(node, name) or { return false }
+	return true
+}
+
+fn valid_region(r devicetree.DTReg, minimum u64) bool {
+	return r.base != 0 && r.base & 3 == 0 && r.size >= minimum && r.base <= ~u64(0) - r.size
+}
+
+fn first_region(node &devicetree.DTNode, minimum u64) ?devicetree.DTReg {
+	ranges := devicetree.get_translated_reg_ranges(node) or { return none }
+	defer { unsafe { ranges.free() }
+	 }
+	if ranges.len != 1 || !valid_region(ranges[0], minimum) {
+		return none
+	}
+	return ranges[0]
+}
+
+fn plan_power(node &devicetree.DTNode, depth int, mut p Plan) bool {
+	if depth > 16 || p.power.len > 64 {
+		return false
+	}
+	if !has_prop(node, 'power-domains') {
+		return true
+	}
+	handles := devicetree.get_u32_array(node, 'power-domains') or { return false }
+	defer { unsafe { handles.free() }
+	 }
+	if handles.len > 8 {
+		return false
+	}
+	for handle in handles {
+		mut seen := false
+		for power in p.power {
+			if power.handle == handle {
+				seen = true
+			}
+		}
+		if seen {
+			continue
+		}
+		domain := devicetree.find_phandle(handle) or { return false }
+		if !enabled(domain) || !compatible(domain, 'apple,pmgr-pwrstate')
+			|| (devicetree.get_u32(domain, '#power-domain-cells') or { u32(1) }) != 0 {
+			return false
+		}
+		parent := domain.parent
+		if parent == unsafe { nil } || !compatible(parent, 'apple,t8103-pmgr') {
+			return false
+		}
+		region := first_region(parent, 4) or { return false }
+		cells := devicetree.get_u32_array(domain, 'reg') or { return false }
+		defer { unsafe { cells.free() }
+		 }
+		if cells.len != 2 || cells[0] & 3 != 0 || cells[1] < 4 || u64(cells[0]) > region.size - 4
+			|| u64(cells[1]) > region.size - u64(cells[0]) {
+			return false
+		}
+		if !plan_power(domain, depth + 1, mut p) {
+			return false
+		}
+		p.power << PowerDomain{ handle: handle, region: region, offset: cells[0] }
+	}
+	return true
+}
+
+fn named_or_index(node &devicetree.DTNode, name string, index int, minimum u64) ?devicetree.DTReg {
+	if has_prop(node, 'reg-names') {
+		r := devicetree.get_named_reg(node, name) or { return none }
+		if !valid_region(r, minimum) {
+			return none
+		}
+		return r
+	}
+	ranges := devicetree.get_translated_reg_ranges(node) or { return none }
+	defer { unsafe { ranges.free() }
+	 }
+	if index >= ranges.len || !valid_region(ranges[index], minimum) {
+		return none
+	}
+	return ranges[index]
+}
+
+fn exact_cells(node &devicetree.DTNode, name string, expected []u32) bool {
+	cells := devicetree.get_u32_array(node, name) or { return false }
+	defer { unsafe { cells.free() }
+	 }
+	return cells == expected
+}
+
+fn discover(mut p Plan) bool {
+	root := devicetree.find_node('/') or { return false }
+	if !compatible(root, 'apple,j313') || !compatible(root, 'apple,t8103') {
+		return false
+	}
+	wifi := devicetree.find_compatible('pci14e4,4425') or { return false }
+	if !enabled(wifi) || !exact_cells(wifi, 'reg', [u32(0x10000), 0, 0, 0, 0])
+		|| (devicetree.get_string_prop(wifi, 'brcm,board-type') or { '' }) != 'apple,shikoku' {
+		return false
+	}
+	port := wifi.parent
+	if port == unsafe { nil } || !exact_cells(port, 'reg', [u32(0), 0, 0, 0, 0])
+		|| !exact_cells(port, 'bus-range', [u32(1), 1]) {
+		return false
+	}
+	host := port.parent
+	if host == unsafe { nil } || !compatible(host, 'apple,t8103-pcie') || !enabled(host) {
+		return false
+	}
+	p.config = named_or_index(host, 'config', 0, 0x200000) or { return false }
+	p.rc = named_or_index(host, 'rc', 1, 0x100000) or { return false }
+	p.port = named_or_index(host, 'port0', 2, 0x1000) or { return false }
+	p.phy = devicetree.get_named_reg(host, 'phy0') or {
+		devicetree.DTReg{ base: p.rc.base + 0x84000, size: 0x4000 }
+	}
+	if !valid_region(p.phy, 0x4000) {
+		return false
+	}
+	if (devicetree.get_u32(host, '#address-cells') or { u32(0) }) != 3
+		|| (devicetree.get_u32(host, '#size-cells') or { u32(0) }) != 2 {
+		return false
+	}
+	// Parse PCI ranges explicitly; generic DT reg parsing does not support
+	// three-cell PCI addresses. Parent is the CPU-addressed /soc bus on J313.
+	if host.parent == unsafe { nil } || (devicetree.get_u32(host.parent, '#address-cells') or { u32(2) }) != 2 {
+		return false
+	}
+	ranges := devicetree.get_u32_array(host, 'ranges') or { return false }
+	defer { unsafe { ranges.free() }
+	 }
+	if ranges.len == 0 || ranges.len % 7 != 0 {
+		return false
+	}
+	for i := 0; i < ranges.len; i += 7 {
+		if ranges[i] != 0x02000000 || ranges[i + 1] != 0 {
+			continue
+		}
+		cpu_base := (u64(ranges[i + 3]) << 32) | ranges[i + 4]
+		size := (u64(ranges[i + 5]) << 32) | ranges[i + 6]
+		bus_base := u64(ranges[i + 2])
+		if size < 0x4000000 || cpu_base > ~u64(0) - size || size > u64(0x100000000) - bus_base {
+			return false
+		}
+		// Map only the last 64 MiB, not the entire multi-GiB PCI window.
+		p.window = devicetree.DTReg{ base: cpu_base + size - 0x4000000, size: 0x4000000 }
+		p.bus_base = bus_base + size - 0x4000000
+		break
+	}
+	if p.window.base == 0 {
+		return false
+	}
+	mask := devicetree.get_u32(host, 'iommu-map-mask') or { u32(0xffffffff) }
+	mapping := devicetree.get_u32_array(host, 'iommu-map') or { return false }
+	defer { unsafe { mapping.free() }
+	 }
+	if mapping.len == 0 || mapping.len % 4 != 0 {
+		return false
+	}
+	rid := u32(0x100) & mask
+	mut dart_node := &devicetree.DTNode(unsafe { nil })
+	for i := 0; i < mapping.len; i += 4 {
+		if rid >= mapping[i] && rid - mapping[i] < mapping[i + 3] {
+			if dart_node != unsafe { nil } {
+				return false
+			}
+			dart_node = devicetree.find_phandle(mapping[i + 1]) or { return false }
+			if mapping[i + 2] > 15 || rid - mapping[i] > 15 - mapping[i + 2] {
+				return false
+			}
+			p.sid = mapping[i + 2] + rid - mapping[i]
+		}
+	}
+	if dart_node == unsafe { nil } || !enabled(dart_node) || !compatible(dart_node, 'apple,t8103-dart')
+		|| (devicetree.get_u32(dart_node, '#iommu-cells') or { u32(0) }) != 1 || p.sid != 1 {
+		return false
+	}
+	p.dart = first_region(dart_node, 0x4000) or { return false }
+	gpio := devicetree.get_u32_array(port, 'reset-gpios') or { return false }
+	defer { unsafe { gpio.free() }
+	 }
+	if gpio.len != 3 || gpio[2] > 1 {
+		return false
+	}
+	gpio_node := devicetree.find_phandle(gpio[0]) or { return false }
+	if !enabled(gpio_node) || !compatible(gpio_node, 'apple,t8103-pinctrl')
+		|| (devicetree.get_u32(gpio_node, '#gpio-cells') or { u32(0) }) != 2 {
+		return false
+	}
+	p.gpio = first_region(gpio_node, 4) or { return false }
+	gpio_ranges := devicetree.get_u32_array(gpio_node, 'gpio-ranges') or { return false }
+	defer { unsafe { gpio_ranges.free() }
+	 }
+	if gpio_ranges.len != 4 || gpio_ranges[0] != gpio[0] || gpio_ranges[1] != 0 || gpio_ranges[2] != 0
+		|| gpio[1] >= gpio_ranges[3] || u64(gpio_ranges[3]) > p.gpio.size / 4 {
+		return false
+	}
+	p.gpio_pin = gpio[1]
+	p.gpio_low = gpio[2]
+	p.cal = devicetree.get_property(wifi, 'brcm,cal-blob') or { return false }
+	if p.cal.len == 0 || p.cal.len > 0x100000 {
+		return false
+	}
+	mac := devicetree.get_property(wifi, 'local-mac-address') or { return false }
+	if mac.len != 6 {
+		return false
+	}
+	unsafe { C.memcpy(&p.mac[0], mac.data, 6) }
+	if p.mac[0] & 1 != 0 || p.mac == [6]u8{} {
+		return false
+	}
+	antenna := devicetree.get_string_prop(wifi, 'apple,antenna-sku') or { return false }
+	if antenna.len == 0 || antenna.len >= 16 || antenna == 'XX' {
+		return false
+	}
+	for i, c in antenna {
+		if !((c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_` || c == `-`) {
+			return false
+		}
+		p.antenna[i] = c
+	}
+	return plan_power(host, 0, mut p) && plan_power(dart_node, 0, mut p) && plan_power(gpio_node, 0, mut p)
+}
+
+fn prepare_seed() bool {
+	chosen := devicetree.find_node('/chosen') or { return false }
+	seed := devicetree.get_property(chosen, 'rng-seed') or { return false }
+	if seed.len < 32 || seed.len > 4096 {
+		return false
+	}
+	// Domain-separated SHA-256 expansion of bootloader entropy. M1n1's SEP
+	// path supplies 128 bytes. No timer-based or deterministic fallback.
+	domain := 'Vinix BCM4378 firmware seed v1'
+	mut input := []u8{len: domain.len + int(seed.len) + 1}
+	defer {
+		unsafe {
+			C.memset(input.data, 0, input.len)
+			input.free()
+		}
+	}
+	unsafe {
+		C.memcpy(input.data, domain.str, domain.len)
+		C.memcpy(&input[domain.len], seed.data, seed.len)
+	}
+	for i in 0 .. 8 {
+		input[input.len - 1] = u8(i)
+		digest := sha256.sum(input)
+		unsafe {
+			C.memcpy(&wifi_seed[i * 32], digest.data, 32)
+			C.memset(digest.data, 0, digest.len)
+			digest.free()
+		}
+	}
+	return true
+}
+
+fn alloc_aligned(bytes u64) u64 {
+	raw := memory.pmm_alloc(bytes / 4096 + 3)
+	if raw == unsafe { nil } {
+		return 0
+	}
+	// This reservation, including alignment slack, is never reused while the
+	// endpoint can DMA. Failed bring-up deliberately quarantines it as well.
+	return (u64(raw) + 0x3fff) & ~u64(0x3fff)
+}
+
+fn setup(mut p Plan) bool {
+	pool := alloc_aligned(0x400000)
+	tables := alloc_aligned(0x8000)
+	if pool == 0 || tables == 0 {
+		return false
+	}
+	for power in p.power {
+		if !pmgr.enable_region(power.region.base, power.region.size, power.offset) {
+			return false
+		}
+	}
+	mut c := C.bw_m1_plan{
+		config: memory.map_mmio(p.config.base, 0x200000)
+		config_size: 0x200000
+		rc: memory.map_mmio(p.rc.base, 0x100000)
+		port: memory.map_mmio(p.port.base, 0x1000)
+		phy: memory.map_mmio(p.phy.base, 0x4000)
+		dart: memory.map_mmio(p.dart.base, 0x4000)
+		gpio: memory.map_mmio(p.gpio.base, p.gpio.size) + u64(p.gpio_pin) * 4
+		window: memory.map_mmio(p.window.base, p.window.size)
+		window_bus: p.bus_base
+		window_size: p.window.size
+		pool_cpu: pool + higher_half
+		pool_physical: pool
+		tables_cpu: tables + higher_half
+		tables_physical: tables
+		sid: p.sid
+		gpio_active_low: p.gpio_low
+		calibration: &u8(p.cal.data)
+		calibration_len: usize(p.cal.len)
+		seed: &wifi_seed[0]
+		seed_len: 256
+		mac: p.mac
+		antenna: p.antenna
+	}
+	return C.brcm_m1_prepare(&c) == 0
+}
+
+fn requested() bool {
+	if wifi_kernel_req.response == unsafe { nil } {
+		return false
+	}
+	f := wifi_kernel_req.response.kernel_file
+	if f == unsafe { nil } || f.cmdline == unsafe { nil } {
+		return false
+	}
+	line := unsafe { cstring_to_vstring(f.cmdline) }
+	args := line.split(' ')
+	defer { unsafe { args.free() }
+	 }
+	return 'vinix.apple_wifi=1' in args
+}
+
+pub fn initialise() {
+	if !requested() {
+		return
+	}
+	mut p := Plan{}
+	defer { unsafe { p.power.free() }
+	 }
+	if !devicetree.is_available() || !discover(mut p) || !prepare_seed() {
+		println('wifi: missing/unsupported J313 device tree, calibration, or boot entropy; not probing')
+		return
+	}
+	ok := setup(mut p)
+	wifi_res = &WifiDevice{}
+	wifi_res.stat.mode = 0o600 | stat.ifchr
+	wifi_res.stat.blksize = 1514
+	wifi_res.stat.rdev = resource.create_dev_id()
+	wifi_res.status = file.pollout
+	fs.devtmpfs_add_device(wifi_res, 'wlan0')
+	if ok {
+		println('wifi: BCM4378 detected; upload matching firmware with wifi-ctl')
+	} else {
+		println('wifi: PCIe/DART/chip probe failed; /dev/wlan0 exposes diagnostics only')
+	}
+}
+
+pub fn poll() {
+	if wifi_res == unsafe { nil } || !wifi_lock.test_and_acquire() {
+		return
+	}
+	defer { wifi_lock.release() }
+	result := C.brcm_m1_poll()
+	if result != 0 {
+		wifi_res.status |= file.pollin
+		event.trigger(mut wifi_res.event, false)
+	}
+}
+
+fn error_code(value int) {
+	match value {
+		-1 { errno.set(errno.einval) }
+		-2 { errno.set(errno.ewouldblock) }
+		-4 { errno.set(errno.etimedout) }
+		else { errno.set(errno.eio) }
+	}
+}
+
+struct WifiDevice {
+pub mut:
+	stat     stat.Stat
+	refcount int
+	l        klock.Lock
+	event    eventstruct.Event
+	status   int
+	can_mmap bool
+}
+
+fn (mut d WifiDevice) mmap(_ voidptr, _ u64, _ int) voidptr {
+	return unsafe { nil }
+}
+
+fn (mut d WifiDevice) grow(_ voidptr, _ u64) ? {
+	return none
+}
+
+fn (mut d WifiDevice) read(_ voidptr, output voidptr, _ u64, count u64) ?i64 {
+	if count == 0 {
+		return i64(0)
+	}
+	mut data := [1514]u8{}
+	capacity := if count < 1514 { count } else { u64(1514) }
+	wifi_lock.acquire()
+	defer { wifi_lock.release() }
+	got := C.brcm_m1_read(&data[0], usize(capacity))
+	if got == 0 {
+		d.status &= ~file.pollin
+		errno.set(errno.ewouldblock)
+		return none
+	}
+	if got < 0 {
+		error_code(got)
+		return none
+	}
+	if !usercopy.copy_to_user(u64(output), &data[0], u64(got)) {
+		errno.set(errno.efault)
+		return none
+	}
+	return i64(got)
+}
+
+fn (mut d WifiDevice) write(_ voidptr, input voidptr, _ u64, count u64) ?i64 {
+	if count < 14 || count > 1514 {
+		errno.set(errno.einval)
+		return none
+	}
+	mut data := [1514]u8{}
+	if !usercopy.copy_from_user(&data[0], u64(input), count) {
+		errno.set(errno.efault)
+		return none
+	}
+	wifi_lock.acquire()
+	defer { wifi_lock.release() }
+	result := C.brcm_m1_write(&data[0], usize(count))
+	if result != 0 {
+		error_code(result)
+		return none
+	}
+	return i64(count)
+}
+
+fn (mut d WifiDevice) ioctl(_ voidptr, request u64, arg voidptr) ?int {
+	wifi_lock.acquire()
+	defer { wifi_lock.release() }
+	mut result := 0
+	match request {
+		0x5700 {
+			mut data := [256]u8{}
+			result = C.brcm_m1_status(&data[0])
+			if !usercopy.copy_to_user(u64(arg), &data[0], 256) {
+				errno.set(errno.efault)
+				return none
+			}
+		}
+		0x5701 {
+			mut data := [4112]u8{}
+			if !usercopy.copy_from_user(&data[0], u64(arg), 4112) {
+				errno.set(errno.efault)
+				return none
+			}
+			result = C.brcm_m1_upload(&data[0])
+		}
+		0x5702 {
+			mut data := [128]u8{}
+			if !usercopy.copy_from_user(&data[0], u64(arg), 128) {
+				errno.set(errno.efault)
+				return none
+			}
+			result = C.brcm_m1_boot(&data[0])
+			if result != -1 {
+				unsafe { C.memset(&wifi_seed[0], 0, 256) }
+			}
+		}
+		0x5703 {
+			mut data := [104]u8{}
+			defer { unsafe { C.memset(&data[0], 0, 104) }
+			 }
+			if !usercopy.copy_from_user(&data[0], u64(arg), 104) {
+				errno.set(errno.efault)
+				return none
+			}
+			result = C.brcm_m1_join(&data[0])
+		}
+		0x5704 { C.brcm_m1_stop() }
+		else {
+			errno.set(errno.enotty)
+			return none
+		}
+	}
+	if result != 0 {
+		error_code(result)
+		return none
+	}
+	return 0
+}
+
+fn (mut d WifiDevice) unref(_ voidptr) ? {
+	katomic.dec(mut &d.refcount)
+}
+
+fn (mut d WifiDevice) link(_ voidptr) ? {
+	katomic.inc(mut &d.stat.nlink)
+}
+
+fn (mut d WifiDevice) unlink(_ voidptr) ? {
+	katomic.dec(mut &d.stat.nlink)
+}

--- a/kernel/modules/dev/console/console_arm64.v
+++ b/kernel/modules/dev/console/console_arm64.v
@@ -18,6 +18,7 @@ import katomic
 import sched
 import aarch64.uart
 import aarch64.virtio_input
+import apple.wifi
 import apple.spi_keyboard
 import flanterm as _
 
@@ -176,6 +177,7 @@ pub fn poll_uart_input() {
 	if apple_count > 0 {
 		add_to_buf(&apple_input[0], u64(apple_count), true)
 	}
+	wifi.poll()
 }
 
 fn dec_private(esc_val_count u64, esc_values &u32, final u64) {
@@ -244,6 +246,7 @@ pub fn initialise() {
 
 	// Initialize only after console/termios setup and before polling starts.
 	spi_keyboard.initialise()
+	wifi.initialise()
 
 	// Register UART polling callback with the scheduler's await() loop.
 	// Under HVF, IRQ injection is broken, so we can't use a separate

--- a/tests/m1-wifi/.gitignore
+++ b/tests/m1-wifi/.gitignore
@@ -1,0 +1,2 @@
+/out/
+/__pycache__/

--- a/tests/m1-wifi/README.md
+++ b/tests/m1-wifi/README.md
@@ -1,0 +1,165 @@
+# Experimental M1 Air Wi-Fi bring-up for Vinix
+
+**This is not a claim of working Wi-Fi or Internet access.** This source bundle
+implements an experimental BCM4378 FullMAC transport and a raw
+Ethernet/control interface. Actual M1 firmware boot, WPA2 association, and DMA
+operation have not been verified on hardware. The V integration and complete clean debug/production ARM64 kernel builds
+are now verified. Do not replace your only working boot entry.
+
+Vinix's existing socket implementation supports Unix-domain sockets, not an IP
+network stack. Even an authenticated Layer-2 link from this driver does not make
+AF_INET applications, DNS, DHCP, `curl`, or ordinary `ping` work. An IP stack and
+its socket integration are separate unfinished work, not hidden dependencies
+that this patch supplies.
+
+## Source layout
+
+* `kernel/c/brcm_wifi.{c,h}`: BCM4378 core inventory/OTP, firmware bootstrap,
+  board NVRAM packing, CLM/TXCAP/calibration loading, PCIe message rings,
+  completion ownership, firmware commands, WPA2-PSK/CCMP, and raw Ethernet.
+* `kernel/c/brcm_m1.{c,h}`: Apple PCIe port reset/clock sequencing, BAR allocation,
+  a bounded 4 MiB DART mapping, exact-width MMIO and cache maintenance, loader
+  staging, diagnostics and a bounded receive queue.
+* `kernel/modules/apple/wifi/wifi.v`: J313 device-tree validation, PMGR and MMIO
+  setup, entropy expansion, `/dev/wlan0`, checked user copies and poll integration.
+* `tools/m1-wifi/`: explicit firmware packager and control utility.
+* `tests/m1-wifi/`: portable protocol tests, simulated platform policy tests,
+  parser mutation tests and a sanitizer-enabled runner.
+
+The implementation is limited to `apple,j313` / `apple,t8103`, PCI 01:00.0
+(vendor 14e4/device 4425), and chip revisions 3 and 5. It requires the bootloader's
+matching device tree, board calibration, actual MAC, antenna SKU and RNG seed.
+No guessed register base, IOMMU bypass, generic NVRAM fallback, or deterministic
+entropy fallback is used. Hardware initialization is disabled unless the kernel
+command line contains the exact argument `vinix.apple_wifi=1`.
+
+## Build milestone (completed)
+
+The integration is based on master `d87e6fea15759f943072611ef357c2170e97f21b`.
+Its entire pristine kernel subtree was verified against Git tree
+`6425969a80617193a3c5eadc4848138265054850` before applying the changes. The
+existing ANS/storage, SMC, desktop and keyboard work is preserved.
+
+Both **debug and production** now complete the real kernel makefile's V-to-C,
+freestanding C/assembly compilation and final `ld.lld` link. These are static
+AArch64 executables, not relocatable objects. The verifier rejects unresolved
+symbols, wrong architecture/type, dynamic-loader dependencies, missing Wi-Fi
+symbols and missing console hooks. It checks 18 retained Wi-Fi symbols after
+linker garbage collection, plus initialization and polling call sites. Ten
+negative/positive verifier tests run against the linked production image.
+
+Other validation: 24 protocol groups (including 100,000 parser mutations) and
+7 simulated-platform groups pass with Clang ASan/UBSan and optimized GCC.
+Both driver C files separately compile using the kernel's freestanding headers
+with `-Wall -Wextra -Werror`. All 17 SPI keyboard regression groups pass. The
+full kernel still emits existing V notices and third-party warnings; this is
+not a claim that the whole tree is warning-free. The control utility is
+host-compiled; target userspace execution has not been validated.
+
+Build fixes include typed user-copy addresses in the V adapter, removal of
+unavailable `strlen` dependencies, host tests using `-iquote` rather than
+shadowing libc headers, and four minimal V compatibility fixes in the existing
+ANS wrappers. No missing function was replaced with a success stub and no
+existing subsystem was compiled out to obtain a passing build.
+
+On Linux, with Clang, LLD, GCC, make, git, curl and Python 3 installed, use a
+**clean disposable checkout** (the existing kernel dependency script resets
+its dependency checkouts):
+
+```sh
+sh tools/m1-wifi/get-v.sh /tmp/vinix-wifi-v
+(cd kernel && ./get-deps)
+CC=clang SANITIZE=1 sh tests/m1-wifi/run.sh
+CC=gcc SANITIZE=0 sh tests/m1-wifi/run.sh
+CC=clang sh tests/apple-spi-keyboard/run.sh
+V=/tmp/vinix-wifi-v/v JOBS=2 sh tests/m1-wifi/build.sh
+```
+
+`get-v.sh` pins V to `71437d263bfc57f99e27588781f34bfc91746910` and its bootstrap
+C compiler source to `99e94ae6099edabce1c6d621eca4c4904e3c2324`. It refuses an
+existing destination. Already having that compiler is sufficient: set `V` to
+its executable. `kernel/get-deps` pins the kernel dependency revisions.
+
+`build.sh` cleans kernel objects before each mode. It writes the two ELF files,
+compiler versions, full build logs, verification output, strict driver objects
+and `SHA256SUMS` under `tests/m1-wifi/out/`. A failed build exits nonzero and
+never issues a success checksum manifest. Do not run simultaneous builds in
+one checkout. Different compiler versions/absolute paths may change the debug
+information and hashes; the script provides a repeatable procedure, not a
+cross-host byte-identical-build guarantee.
+
+The console source already contains the Wi-Fi initialization and polling
+hooks. Do not apply the obsolete experimental bundle's `apply-console.py`.
+There is no need to change source lists or paste integration snippets.
+
+Build the control utility with the compiler for the target ARM64 **userspace**
+sysroot, not the freestanding kernel compiler:
+
+```sh
+cc -std=c11 -O2 -Wall -Wextra -Werror -iquote kernel/c tools/m1-wifi/wifi-ctl.c -o wifi-ctl
+```
+
+Here `cc` must target the userspace you intend to run. Include the utility and
+locally selected firmware in a test initramfs. The supplied ELF files are
+kernel-only build artifacts, not an installed boot image or hardware test.
+Keep your existing m1n1/U-Boot/Limine chain and a known-working boot entry.
+
+## Firmware and association
+
+No proprietary firmware is included or downloaded. Firmware, textual board
+NVRAM, CLM and TXCAP must be extracted locally and explicitly selected for the
+reported chip revision, `apple,shikoku` board, module, vendor, module revision,
+and antenna. The per-device calibration blob comes from the device tree.
+Do not substitute files from a different Mac or bypass power/regulatory limits.
+
+1. Boot the experimental entry and run `wifi-ctl status`. A successful probe is
+   `chip detected`, **not** a connected radio. Save `wifi-ctl status-raw status.bin`.
+2. On the build host, run `tools/m1-wifi/package.py --status status.bin
+   --firmware MATCHING.bin --nvram MATCHING.txt --clm MATCHING.clm_blob
+   --txcap MATCHING.txcap_blob --output wifi-bundle`. Paths are explicit: the
+   script does not guess a firmware filename hierarchy. Its identity manifest
+   does not prove that the supplied files are appropriate; correct selection
+   remains required. SHA-256 provenance records are provided for auditing.
+3. Include the resulting directory in the test initramfs, then use
+   `wifi-ctl load /path/to/wifi-bundle` and `wifi-ctl join 'SSID'`.
+   The utility prompts with terminal echo disabled; it does not take a password
+   through argv or write one to a configuration file.
+
+`firmware ready` and `authenticating` are not success. `authenticated link`
+requires a successful association event **and** firmware confirmation that WPA2
+keys are established. There is no open-network or weaker-security fallback.
+
+The receive/transmit ABI is raw Ethernet through `/dev/wlan0`; readers must
+handle EAGAIN and preserve complete frames. It is not a socket/IP interface.
+The fixed-size ioctl ABI is documented in `kernel/c/brcm_m1.h`; it exposes no
+kernel pointers or arbitrary register access. Device permissions are 0600. Vinix does not yet have a complete credential/
+capability model; the mode is not a substitute for enforcing a multi-user
+security boundary. Use a controlled, single-user bring-up image.
+
+## Failure and unsupported behavior
+
+Timeouts, malformed completions, DART faults, link loss, unexpected deep-sleep
+requests, unsupported firmware, or unsupported security stop the driver.
+Bus mastering is disabled and the Wi-Fi DART stream is revoked; allocations are
+quarantined for the rest of the boot rather than reusing memory that may have
+outstanding DMA. Initialization is one-shot. Reboot to retry after a fatal error,
+interrupted upload, disconnect, or stopped state.
+
+This is not a suspend/resume implementation. Bluetooth shares the physical
+combo-chip reset and may be affected; takeover is refused when it is observed
+bus-mastering. Trackpad/keyboard drivers are unrelated. WPA3, enterprise Wi-Fi,
+AP mode, scanning UI, roaming, reconnect, powersave, and IPv4/IPv6/socket support
+are not implemented. These limitations are substantial: this bundle is a
+bring-up contribution, not a completed answer to making normal networking work.
+
+## Primary implementation references and licensing
+
+Wire layouts and chip procedures were checked against OpenBSD `sys/dev/pci/
+if_bwfm_pci.{c,h}` and `sys/dev/ic/bwfm{,reg}.{c,h}`. The core retains the ISC
+notice. Apple PCIe sequencing follows U-Boot `drivers/pci/pcie_apple.c`;
+DART formats follow Linux `drivers/iommu/apple-dart.c` and `io-pgtable-dart.c`.
+FullMAC firmware download/security behavior also references Linux's
+`drivers/net/wireless/broadcom/brcm80211/brcmfmac/` implementation. Apple machine
+properties are from Linux `arch/arm64/boot/dts/apple/t8103*.dts*`. These are
+protocol/register references, not evidence that this implementation works on
+real hardware.

--- a/tests/m1-wifi/build.sh
+++ b/tests/m1-wifi/build.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Run from any directory. Dependencies: ./kernel/get-deps and a V1 compiler.
+# Clean builds avoid stale objects from other architectures or VFLAGS/PROD modes.
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+V=${V:-v}
+CC=${CC:-clang}
+LD_AARCH64=${LD_AARCH64:-ld.lld}
+JOBS=${JOBS:-2}
+OUT=${OUT:-"$ROOT/tests/m1-wifi/out"}
+VFLAGS=${VFLAGS:--old-compiler}
+case "$JOBS" in ''|0|*[!0-9]*) echo 'JOBS must be a positive integer' >&2; exit 2;; esac
+mkdir -p "$OUT"
+OUT=$(CDPATH= cd -- "$OUT" && pwd)
+# Resolve V before make changes working directory; allow an absolute path.
+V=$(command -v "$V")
+case "$V" in
+    /*) ;;
+    */*) V="$(CDPATH= cd -- "$(dirname -- "$V")" && pwd)/$(basename -- "$V")" ;;
+esac
+# A failed run must not leave an earlier kernel looking like a new result.
+rm -f "$OUT/vinix-aarch64-debug.elf" "$OUT/vinix-aarch64-production.elf" "$OUT/SHA256SUMS"
+{
+    "$V" version
+    "$CC" --version
+    "$LD_AARCH64" --version
+    printf 'VFLAGS=%s\n' "$VFLAGS"
+    git -C "$ROOT" rev-parse HEAD 2>/dev/null || true
+} > "$OUT/toolchain.txt"
+# Unlike host tests, compile against the kernel's real freestanding headers.
+for source in brcm_wifi brcm_m1; do
+    "$CC" --target=aarch64-unknown-none -std=gnu99 -O2 -Wall -Wextra -Werror \
+        -nostdinc -ffreestanding -fno-builtin -fno-stack-protector \
+        -mgeneral-regs-only -march=armv8.4-a -D__AARCH64__ \
+        -I "$ROOT/kernel/c" -isystem "$ROOT/kernel/freestnd-c-hdrs" \
+        -c "$ROOT/kernel/c/$source.c" -o "$OUT/$source.aarch64.o"
+done
+for mode in debug production; do
+    prod=true
+    [ "$mode" != debug ] || prod=false
+    make -C "$ROOT/kernel" clean > "$OUT/$mode.log" 2>&1
+    if ! make -C "$ROOT/kernel" ARCH=aarch64 CC="$CC" V="$V" \
+        VFLAGS="$VFLAGS" PROD="$prod" LD_AARCH64="$LD_AARCH64" \
+        -j"$JOBS" all >> "$OUT/$mode.log" 2>&1; then
+        tail -n 100 "$OUT/$mode.log" >&2
+        exit 1
+    fi
+    cp "$ROOT/kernel/bin/vinix" "$OUT/vinix-aarch64-$mode.elf"
+    python3 "$ROOT/tests/m1-wifi/verify_build.py" \
+        "$OUT/vinix-aarch64-$mode.elf" "$ROOT/kernel/obj/blob.c" \
+        > "$OUT/$mode-verification.txt"
+    cat "$OUT/$mode-verification.txt"
+done
+python3 "$ROOT/tests/m1-wifi/verify_test.py" "$OUT/vinix-aarch64-production.elf" "$ROOT/kernel/obj/blob.c"
+(cd "$OUT" && sha256sum vinix-aarch64-*.elf > SHA256SUMS)
+printf 'PASS clean debug and production kernel builds (not a hardware test)\n'

--- a/tests/m1-wifi/platform_test.c
+++ b/tests/m1-wifi/platform_test.c
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later
+ * Native platform policy tests with MMIO replaced by an explicit register map.
+ * These verify programmed values/ordering, not physical PCIe or IOMMU behavior.
+ */
+#define _POSIX_C_SOURCE 200809L
+#define VINIX_BRCM_M1_TEST
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "brcm_m1.h"
+struct reg {uint64_t address;uint32_t value;};
+static struct reg regs[256];static unsigned nr,reads,writes,sync_calls;
+static uint64_t elapsed,probe_bar;static uint64_t probe_size;
+static uint32_t reg_get(uint64_t a){for(unsigned i=0;i<nr;i++)if(regs[i].address==a)return regs[i].value;return 0;}
+static void reg_set(uint64_t a,uint32_t v){for(unsigned i=0;i<nr;i++)if(regs[i].address==a){regs[i].value=v;return;}assert(nr<256);regs[nr++]=(struct reg){a,v};}
+static uint8_t vinix_mmio_read8(void *p){reads++;return (uint8_t)(reg_get((uintptr_t)p&~3ull)>>(((uintptr_t)p&3)*8));}
+static uint16_t vinix_mmio_read16(void *p){reads++;return (uint16_t)(reg_get((uintptr_t)p&~3ull)>>(((uintptr_t)p&2)*8));}
+static uint32_t vinix_mmio_read32(void *p){reads++;uint64_t a=(uintptr_t)p;uint32_t v=reg_get(a);if(probe_bar&&a==probe_bar&&v==UINT32_MAX)return (uint32_t)(~(probe_size-1))|4;return v;}
+static void vinix_mmio_write8(void *p,uint8_t v){writes++;uint64_t a=(uintptr_t)p;unsigned sh=(a&3)*8;reg_set(a&~3ull,(reg_get(a&~3ull)&~(255u<<sh))|((uint32_t)v<<sh));}
+static void vinix_mmio_write16(void *p,uint16_t v){writes++;uint64_t a=(uintptr_t)p;unsigned sh=(a&2)*8;reg_set(a&~3ull,(reg_get(a&~3ull)&~(65535u<<sh))|((uint32_t)v<<sh));}
+static void vinix_mmio_write32(void *p,uint32_t v){writes++;reg_set((uintptr_t)p,v);}
+static uint64_t clock_us(void){return elapsed;}
+static void delay(uint32_t us){elapsed+=us;}
+static void barrier(void){}
+static void cache_sync(void *p,size_t n,int to_device){assert(p&&n&&to_device>=0&&to_device<=1);sync_calls++;}
+#include "../../kernel/c/brcm_m1.c"
+
+static uint8_t seed[256],cal[4]={1,2,3,4};
+static struct bw_m1_plan plan(void){
+    struct bw_m1_plan p={0};p.config=0x100000;p.config_size=0x200000;p.rc=0x300000;p.port=0x400000;p.phy=0x500000;p.gpio=0x600000;p.dart=0x700000;
+    p.window=0x100000000;p.window_bus=0x80000000;p.window_size=0x4000000;p.pool_cpu=0x800000;p.pool_physical=0x800000;p.tables_cpu=0xc00000;p.tables_physical=0xc00000;
+    p.sid=1;p.gpio_active_low=1;p.calibration=cal;p.calibration_len=sizeof(cal);p.seed=seed;p.seed_len=sizeof(seed);p.mac[0]=2;memcpy(p.antenna,"HRPN",5);return p;
+}
+static void reset(void){memset(&host,0,sizeof(host));memset(regs,0,sizeof(regs));nr=reads=writes=sync_calls=0;elapsed=probe_bar=probe_size=0;}
+static void reject(struct bw_m1_plan *p){reset();assert(brcm_m1_prepare(p)==BW_EINVAL);assert(!reads&&!writes);}
+static void test_validation(void){
+    struct bw_m1_plan p=plan();p.sid=2;reject(&p);
+    p=plan();p.pool_physical=0;reject(&p);
+    p=plan();p.tables_physical=p.pool_physical+0x4000;reject(&p);
+    p=plan();p.tables_physical=1ull<<36;reject(&p);
+    p=plan();p.pool_cpu++;reject(&p);
+    p=plan();p.config_size=4096;reject(&p);
+    p=plan();p.window_bus=0xfffff000;reject(&p);
+    p=plan();p.seed_len=0;reject(&p);
+    p=plan();p.calibration_len=0;reject(&p);
+    p=plan();p.antenna[0]=0;reject(&p);
+}
+static void test_dart_tables(void){
+    reset();host.p=plan();void *tables=NULL;assert(!posix_memalign(&tables,16384,32768));host.p.tables_cpu=(uintptr_t)tables;
+    reg_set(host.p.dart,14u<<24);assert(!dart_prepare());uint64_t *root=tables,*leaf=root+2048;
+    for(unsigned i=0;i<2048;i++)assert(root[i]==(i==8?host.p.tables_physical+16384+1:0));
+    for(unsigned i=0;i<2048;i++)assert(leaf[i]==(i<BW_POOL_MIN/16384?(host.p.pool_physical+(uint64_t)i*16384)|3:0));
+    assert(reg_get(host.p.dart+0x210)==((uint32_t)(host.p.tables_physical>>12)|0x80000000u));
+    assert(reg_get(host.p.dart+0x104)==0x80&&reg_get(host.p.dart+0xfc)==2);
+    assert(reg_get(host.p.port+0x828)==0x80010100u);assert(sync_calls==1);free(tables);
+}
+static void test_stream_conflict(void){reset();host.p=plan();reg_set(host.p.dart,14u<<24);reg_set(host.p.port+0x828,0x80010101u);assert(dart_prepare()==BW_ENOTSUP);assert(!writes&&!sync_calls);}
+static void test_dart_locked(void){reset();host.p=plan();reg_set(host.p.dart,14u<<24);reg_set(host.p.dart+0x60,0x8000);assert(dart_prepare()==BW_ENOTSUP&&!writes);}
+static void test_bar_probe(void){reset();host.endpoint=0x200000;probe_bar=host.endpoint+0x10;probe_size=0x4000;reg_set(probe_bar,0x80000004);reg_set(probe_bar+4,0);uint64_t size=0;assert(!bar_size(0x10,&size)&&size==0x4000);assert(reg_get(probe_bar)==0x80000004&&reg_get(probe_bar+4)==0);}
+static void test_stop_revokes(void){reset();host.p=plan();host.endpoint=0x200000;host.endpoint_valid=host.prepared=1;reg_set(host.endpoint+4,0x406);reg_set(host.p.dart+0x104,0x80);stop_dma(NULL);assert(reg_get(host.endpoint+4)==0x402);assert(reg_get(host.p.dart+0x104)==0);assert(reg_get(host.p.dart+0x34)==2);}
+static void test_config_bounds(void){reset();host.bar0_len=0;assert(bus_read(NULL,BW_REGS,0,4)==UINT32_MAX&&!reads);bus_write(NULL,BW_REGS,0,4,1);assert(!writes);host.bar0_len=0x3000;assert(bus_read(NULL,BW_REGS,0x3000,4)==UINT32_MAX&&!reads);assert(bus_read(NULL,BW_REGS,1,4)==UINT32_MAX&&!reads);}
+int main(void){test_validation();test_dart_tables();test_stream_conflict();test_dart_locked();test_bar_probe();test_stop_revokes();test_config_bounds();puts("7 platform policy groups passed (simulated MMIO, not hardware)");return 0;}

--- a/tests/m1-wifi/run.sh
+++ b/tests/m1-wifi/run.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Host tests must use libc's <...> headers, not the kernel's stubs.
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT HUP INT TERM
+CC=${CC:-clang}
+case ${SANITIZE:-1} in
+    1) SAN_FLAGS='-O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer' ;;
+    0) SAN_FLAGS='-O2' ;;
+    *) echo 'SANITIZE must be 0 or 1' >&2; exit 2 ;;
+esac
+# Intentional word splitting: SAN_FLAGS is selected above, not arbitrary input.
+for source in test platform_test; do
+    "$CC" -D_POSIX_C_SOURCE=200809L -std=c99 -Wall -Wextra -Werror $SAN_FLAGS \
+        -iquote "$ROOT/kernel/c" "$ROOT/tests/m1-wifi/$source.c" \
+        "$ROOT/kernel/c/brcm_wifi.c" -o "$TMP/$source"
+    "$TMP/$source"
+done

--- a/tests/m1-wifi/test.c
+++ b/tests/m1-wifi/test.c
@@ -1,0 +1,156 @@
+/* SPDX-License-Identifier: ISC */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "brcm_wifi.h"
+
+static unsigned tests;
+#define TEST(f) do { f(); tests++; printf("PASS %s\n",#f); } while(0)
+static uint16_t le16(const void *v){const uint8_t *p=v;return (uint16_t)(p[0]|p[1]<<8);}
+static uint32_t le32(const void *v){const uint8_t *p=v;return p[0]|(uint32_t)p[1]<<8|(uint32_t)p[2]<<16|(uint32_t)p[3]<<24;}
+static uint64_t le64(const void *p){return le32(p)|(uint64_t)le32((const uint8_t *)p+4)<<32;}
+static void w16(void *v,uint16_t x){uint8_t *p=v;p[0]=(uint8_t)x;p[1]=(uint8_t)(x>>8);}
+static void w32(void *v,uint32_t x){uint8_t *p=v;for(unsigned i=0;i<4;i++)p[i]=(uint8_t)(x>>(i*8));}
+static void be16(void *v,uint16_t x){uint8_t *p=v;p[0]=(uint8_t)(x>>8);p[1]=(uint8_t)x;}
+static void be32(void *v,uint32_t x){uint8_t *p=v;for(unsigned i=0;i<4;i++)p[i]=(uint8_t)(x>>(24-i*8));}
+
+struct posted {uint32_t token;uint64_t dma;size_t length;};
+struct fake {
+    uint8_t *bp,*tcm,*pool;uint32_t cfg[1024],regs[0x3000/4];
+    struct bw_device *d;
+    struct posted ctl[1024],event[1024],rx[2048];unsigned ctl_n,event_n,rx_n;
+    uint32_t shared,info,desc;uint16_t consumed[3],produced[3];
+    uint64_t idx[4],flow_dma;uint16_t flow_count;
+    uint64_t time;unsigned stopped,received,syncs,commands,tx,keys;
+    int model,boot_timeout,no_reply,no_ack,unsupported_supplicant,withhold_key,bad_shared,version;
+};
+static uint8_t *dma(struct fake *f,uint64_t a,size_t n){assert(a>=0x10000000&&a-0x10000000<=BW_POOL_MIN&&n<=BW_POOL_MIN-(a-0x10000000));return f->pool+(size_t)(a-0x10000000);}
+static void finish(struct fake *f,unsigned ring,const uint8_t *m,size_t n){
+    uint8_t *desc=f->tcm+f->desc+(ring+2)*16;uint16_t count=le16(desc+4),size=le16(desc+6);
+    assert(count&&size>=n);uint64_t addr=le64(desc+8);uint16_t p=f->produced[ring];
+    assert((uint16_t)((p+1)%count)!=le16(dma(f,f->idx[3]+ring*2,2)));
+    memset(dma(f,addr+(uint64_t)p*size,size),0,size);memcpy(dma(f,addr+(uint64_t)p*size,size),m,n);
+    f->produced[ring]=(uint16_t)((p+1)%count);w16(dma(f,f->idx[2]+ring*2,2),f->produced[ring]);
+}
+static void send_event(struct fake *f,uint32_t type,uint32_t status,uint16_t flags){
+    assert(f->event_n);struct posted p=f->event[--f->event_n];uint8_t *frame=dma(f,p.dma,72);memset(frame,0,72);
+    be16(frame+12,0x886c);be16(frame+14,0x8001);be16(frame+16,54);frame[18]=0;memcpy(frame+19,"\x00\x10\x18",3);be16(frame+22,1);be16(frame+24,2);
+    be16(frame+26,flags);be32(frame+28,type);be32(frame+32,status);memcpy(frame+48,"\x02\xaa\xbb\xcc\xdd\xee",6);
+    uint8_t c[24]={0x0e};w32(c+4,p.token);w16(c+12,72);finish(f,0,c,24);
+}
+static void handle_control(struct fake *f,const uint8_t *m){
+    unsigned type=m[0];
+    if(type==0x0b||type==0x0d){struct posted p={le32(m+4),le64(m+16),le16(m+8)};assert(p.length==8192);
+        assert(f->ctl_n<1024&&f->event_n<1024);if(type==0x0b)f->ctl[f->ctl_n++]=p;else f->event[f->event_n++]=p;return;}
+    if(type==3){assert(le16(m+22)==2&&le16(m+30)==48);f->flow_dma=le64(m+32);f->flow_count=le16(m+28);
+        uint8_t c[24]={4};w16(c+10,2);finish(f,0,c,24);return;}
+    assert(type==9);f->commands++;uint32_t cmd=le32(m+8);size_t len=le16(m+14);uint8_t *input=dma(f,le64(m+24),len);
+    int16_t status=0;
+    if(cmd==263){assert(len&&memchr(input,0,len));if(!strcmp((char *)input,"sup_wpa")&&f->unsupported_supplicant)status=-23;}
+    if(cmd==268){assert(len==68&&le16(input)==12&&le16(input+2)==1);assert(!memcmp(input+4,"correct-pass",12));f->keys++;}
+    if(!f->no_ack){uint8_t ack[24]={0x0a};w32(ack+4,le32(m+4));finish(f,0,ack,24);}
+    if(!f->no_reply){assert(f->ctl_n);struct posted p=f->ctl[--f->ctl_n];uint8_t c[24]={0x0c};w32(c+4,p.token);w16(c+8,(uint16_t)status);w16(c+14,le16(m+12));w32(c+16,cmd);finish(f,0,c,24);}
+    if(cmd==26){assert(f->keys);assert(le32(input)==4&&!memcmp(input+4,"test",4));send_event(f,0,0,0);if(!f->withhold_key)send_event(f,46,6,0);}
+}
+static void pump(struct fake *f){
+    if(!f->model||!f->desc||!le64(f->tcm+f->info+20))return;
+    for(unsigned i=0;i<4;i++)f->idx[i]=le64(f->tcm+f->info+20+i*8);
+    for(unsigned ring=0;ring<3;ring++){
+        uint16_t wi=le16(dma(f,f->idx[0]+ring*2,2));
+        uint16_t count=ring==2?f->flow_count:le16(f->tcm+f->desc+ring*16+4);
+        uint16_t size=ring==2?48:le16(f->tcm+f->desc+ring*16+6);
+        uint64_t addr=ring==2?f->flow_dma:le64(f->tcm+f->desc+ring*16+8);
+        if(!count)continue;
+        while(f->consumed[ring]!=wi){uint8_t m[48];memcpy(m,dma(f,addr+(uint64_t)f->consumed[ring]*size,size),size);
+            f->consumed[ring]=(uint16_t)((f->consumed[ring]+1)%count);w16(dma(f,f->idx[1]+ring*2,2),f->consumed[ring]);
+            if(ring==0)handle_control(f,m);
+            else if(ring==1){assert(m[0]==0x11&&f->rx_n<2048);f->rx[f->rx_n++]=(struct posted){le32(m+4),le64(m+24),le16(m+10)};}
+            else{assert(m[0]==0x0f&&m[22]==1&&m[23]==1);(void)dma(f,le64(m+32),le16(m+42));f->tx++;uint8_t c[24]={0x10};w32(c+4,le32(m+4));w16(c+10,2);finish(f,1,c,16);}
+        }
+    }
+}
+static void boot_firmware(struct fake *f){
+    if(f->boot_timeout)return;
+    f->shared=0x362000;f->info=0x362200;f->desc=0x363000;
+    w32(f->tcm+0x452000-4,f->bad_shared?0xfffffffcu:f->shared);
+    w32(f->tcm+f->shared,0x10110000u|(unsigned)f->version);w16(f->tcm+f->shared+0x22,255);w32(f->tcm+f->shared+0x30,f->info);
+    w32(f->tcm+f->info,f->desc);w16(f->tcm+f->info+52,14);w16(f->tcm+f->info+54,16);w16(f->tcm+f->info+56,3);
+}
+static uint32_t read_bus(void *v,unsigned space,uint32_t off,unsigned width){
+    struct fake *f=v;uint8_t *p;
+    if(space==BW_CONFIG){assert(off+width<=4096);p=(uint8_t *)f->cfg+off;}
+    else if(space==BW_TCM){assert(off+width<=0x800000);p=f->tcm+off;}
+    else{assert(off+width<=0x3000);p=off<4096?f->bp+(f->cfg[0x80/4]-0x18000000)+off:(uint8_t *)f->regs+off;}
+    return width==1?p[0]:width==2?le16(p):le32(p);
+}
+static void write_bus(void *v,unsigned space,uint32_t off,unsigned width,uint32_t value){
+    struct fake *f=v;uint8_t *p;
+    if(space==BW_CONFIG){assert(off+width<=4096);p=(uint8_t *)f->cfg+off;}
+    else if(space==BW_TCM){assert(off+width<=0x800000);p=f->tcm+off;}
+    else{assert(off+width<=0x3000);p=off<4096?f->bp+(f->cfg[0x80/4]-0x18000000)+off:(uint8_t *)f->regs+off;}
+    if(width==1)*p=(uint8_t)value;else if(width==2)w16(p,(uint16_t)value);else w32(p,value);
+    if(space==BW_REGS&&off==0x408&&f->cfg[0x80/4]==0x18102000&&value==1)boot_firmware(f);
+    if(space==BW_REGS&&off==0x2a20&&value==1)pump(f);
+}
+static uint64_t time_bus(void *v){return ((struct fake *)v)->time;}
+static void delay_bus(void *v,uint32_t us){((struct fake *)v)->time+=us;}
+static void sync_bus(void *v,void *p,size_t n,int to_device){struct fake *f=v;assert((uint8_t *)p>=f->pool&&(uint8_t *)p<=f->pool+BW_POOL_MIN&&n<=(size_t)(f->pool+BW_POOL_MIN-(uint8_t *)p));assert(to_device==0||to_device==1);f->syncs++;}
+static void stop_bus(void *v){((struct fake *)v)->stopped++;}
+static void receive_bus(void *v,const uint8_t *p,size_t n){struct fake *f=v;assert(n==60&&p[12]==8&&p[13]==0);f->received++;}
+static struct bw_ops ops={read_bus,write_bus,time_bus,delay_bus,sync_bus,stop_bus,receive_bus};
+static struct fake *fixture(void){
+    struct fake *f=calloc(1,sizeof(*f));assert(f);f->bp=calloc(1,0x1000000);f->tcm=calloc(1,0x800000);assert(!posix_memalign((void **)&f->pool,16384,BW_POOL_MIN));memset(f->pool,0,BW_POOL_MIN);f->d=calloc(1,sizeof(*f->d));assert(f->bp&&f->tcm&&f->d);
+    f->model=1;f->version=7;w32(f->cfg,0x442514e4);w32(f->bp,0x10034378);w32(f->bp+0xfc,0x1800f000);
+    unsigned ids[]={0x800,0x83c,0x847,0x849,0x812,0x840};unsigned p=0;
+    for(unsigned i=0;i<6;i++){uint8_t *er=f->bp+0xf000;p+=0;w32(er+4*p++,(ids[i]<<8)|1);w32(er+4*p++,((i==1?64u:1u)<<24)|(1u<<19)|1);
+        w32(er+4*p++,0x18000000u+i*4096+5);w32(er+4*p++,0x18100000u+i*4096+0x85);}
+    w32(f->bp+0xf000+4*p,15);w32(f->bp+0x3000,2u<<4);w32(f->bp+0x3040,63);
+    uint8_t *otp=f->bp+0x5000+0x1120;memset(otp,255,0x2e0);const char text[]="s=b1 M=module V=vendor m=rev";
+    otp[0]=0x15;otp[1]=(uint8_t)(4+sizeof(text));w32(otp+2,8);memcpy(otp+6,text,sizeof(text));otp[6+sizeof(text)]=255;
+    assert(!bw_init(f->d,&ops,f,f->pool,0x10000000,BW_POOL_MIN,0x3000,0x800000));return f;
+}
+static void destroy(struct fake *f){free(f->bp);free(f->tcm);free(f->pool);free(f->d);free(f);}
+static int start(struct fake *f){
+    uint8_t code[128]={0},seed[256];for(unsigned i=0;i<256;i++)seed[i]=(uint8_t)i;
+    w32(code,0x352080);w32(code+0x6c,0x534d4152);w32(code+0x70,0x100000);
+    const uint8_t nv[]="boardrev=0x123\nmacaddr=02:11:22:33:44:55\n",blob[]={1,2,3,4};
+    struct bw_firmware fw={code,nv,blob,blob,blob,seed,sizeof(code),sizeof(nv)-1,sizeof(blob),sizeof(blob),sizeof(blob),sizeof(seed),3,{2,0x11,0x22,0x33,0x44,0x55}};
+    int e=bw_probe(f->d);return e?e:bw_start(f->d,&fw);
+}
+static void join(struct fake *f){assert(!bw_join_wpa2(f->d,(const uint8_t *)"test",4,(const uint8_t *)"correct-pass",12));}
+static void frame(uint8_t *p){memset(p,0,60);memset(p,255,6);memcpy(p+6,"\x02\x11\x22\x33\x44\x55",6);p[12]=8;}
+static void inject_rx(struct fake *f,int bad_offset){
+    assert(f->rx_n);struct posted p=f->rx[--f->rx_n];frame(dma(f,p.dma,60));uint8_t m[40]={0x12};w32(m+4,p.token);w16(m+14,60);w16(m+16,bad_offset?2040:0);finish(f,2,m,32);
+}
+static void test_nvram_golden(void){uint8_t out[64];size_t n=0;assert(!bw_nvram_pack((uint8_t *)" # hi\r\n a=1\n b=two # comment",27,out,sizeof(out),&n));assert(n==16);assert(!memcmp(out,"a=1\0b=two\0\0\0",12));assert(le32(out+12)==0xfffc0003);}
+static void test_nvram_reject(void){uint8_t out[64];size_t n;assert(bw_nvram_pack((uint8_t *)"a=1\na=2",7,out,64,&n)==BW_EINVAL);assert(bw_nvram_pack((uint8_t *)"=x",2,out,64,&n)==BW_EINVAL);assert(bw_nvram_pack((uint8_t *)"a=123",5,out,8,&n)==BW_ENOSPC);uint8_t bad[]={97,61,0};assert(bw_nvram_pack(bad,3,out,64,&n)==BW_EINVAL);}
+static void test_otp(void){struct fake *f=fixture();assert(!bw_probe(f->d));assert(!strcmp(f->d->otp.module,"module"));assert(f->d->revision==3&&f->d->pcie_revision==64&&f->d->state==BW_CHIP);destroy(f);}
+static void test_otp_bounds(void){uint8_t b[]={0x15,255,8};struct bw_otp o;assert(bw_otp_parse(b,sizeof(b),&o)==BW_EPROTO);assert(bw_otp_parse(NULL,0,&o)==BW_EINVAL);}
+static void test_device_gate(void){struct fake *f=fixture();f->cfg[0]=0x123414e4;assert(bw_probe(f->d)==BW_ENOTSUP);assert(!f->stopped);destroy(f);}
+static void test_bad_erom(void){struct fake *f=fixture();w32(f->bp+0xfc,0xffffffff);assert(bw_probe(f->d)==BW_EPROTO);destroy(f);}
+static void test_probe_revision(void){struct fake *f=fixture();w32(f->bp,0x100f4378);assert(bw_probe(f->d)==BW_ENOTSUP);destroy(f);}
+static void test_boot_and_rings(void){struct fake *f=fixture();assert(!start(f));assert(f->d->state==BW_READY&&f->rx_n==255&&f->event_n==8&&f->ctl_n==8);assert(f->d->allocated<BW_POOL_MIN&&f->commands>=9&&f->syncs>100);assert(f->d->rings[3].item==24&&f->d->rings[4].item==40);destroy(f);}
+static void test_firmware_timeout(void){struct fake *f=fixture();f->boot_timeout=1;assert(start(f)==BW_ETIME);assert(f->stopped==1&&f->d->state==BW_FAULT&&f->time<6000000);destroy(f);}
+static void test_shared_pointer(void){struct fake *f=fixture();f->bad_shared=1;assert(start(f)==BW_EPROTO&&f->stopped==1);destroy(f);}
+static void test_protocol_version(void){struct fake *f=fixture();f->version=8;assert(start(f)==BW_ENOTSUP&&f->stopped==1);destroy(f);}
+static void test_ioctl_timeout(void){struct fake *f=fixture();f->no_reply=1;assert(start(f)==BW_ETIME&&f->stopped==1);destroy(f);}
+static void test_ack_required(void){struct fake *f=fixture();f->no_ack=1;assert(start(f)==BW_ETIME&&f->d->request_busy&&f->stopped==1);destroy(f);}
+static void test_wpa2_authorization(void){struct fake *f=fixture();assert(!start(f));join(f);assert(f->d->state==BW_LINK&&f->d->associated&&f->d->keyed);assert(!memcmp(f->d->request.cpu,(uint8_t[BW_CTL_SIZE]){0},BW_CTL_SIZE));destroy(f);}
+static void test_assoc_not_authorized(void){struct fake *f=fixture();f->withhold_key=1;assert(!start(f));join(f);assert(f->d->associated&&!f->d->keyed&&f->d->state==BW_JOINING);uint8_t p[60];frame(p);assert(bw_transmit(f->d,p,60)==BW_ENOLINK);inject_rx(f,0);assert(bw_poll(f->d,64)>=0&&!f->received);f->time+=31000000;assert(bw_poll(f->d,64)==BW_ETIME);destroy(f);}
+static void test_unsupported_supplicant(void){struct fake *f=fixture();f->unsupported_supplicant=1;assert(!start(f));assert(bw_join_wpa2(f->d,(uint8_t *)"test",4,(uint8_t *)"correct-pass",12)==BW_EIO&&f->stopped==1);destroy(f);}
+static void test_receive(void){struct fake *f=fixture();assert(!start(f));join(f);inject_rx(f,0);assert(bw_poll(f->d,64)>=0&&f->received==1&&f->rx_n==255);destroy(f);}
+static void test_rx_bounds(void){struct fake *f=fixture();assert(!start(f));join(f);inject_rx(f,1);assert(bw_poll(f->d,64)==BW_EPROTO&&!f->received&&f->stopped==1);destroy(f);}
+static void test_tx_flow(void){struct fake *f=fixture();assert(!start(f));join(f);uint8_t p[60];frame(p);assert(bw_transmit(f->d,p,60)==BW_ENOSPC);assert(bw_poll(f->d,64)>=0&&f->d->flow_open);assert(!bw_transmit(f->d,p,60));assert(bw_poll(f->d,64)>=0&&f->tx==1&&f->d->tx_frames==1);p[6]=4;assert(bw_transmit(f->d,p,60)==BW_EINVAL);destroy(f);}
+static void test_bad_index(void){struct fake *f=fixture();assert(!start(f));w16(dma(f,f->idx[2],2),UINT16_MAX);assert(bw_poll(f->d,64)==BW_EPROTO&&f->stopped==1);destroy(f);}
+static void test_unknown_packet_id(void){struct fake *f=fixture();assert(!start(f));uint8_t m[40]={0x12};w32(m+4,0xdeadbeef);finish(f,2,m,32);assert(bw_poll(f->d,64)==BW_EPROTO);destroy(f);}
+static void test_bad_credentials(void){struct fake *f=fixture();assert(!start(f));assert(bw_join_wpa2(f->d,(uint8_t *)"test",33,(uint8_t *)"123",3)==BW_EINVAL&&f->d->state==BW_READY);destroy(f);}
+static void test_link_loss(void){struct fake *f=fixture();assert(!start(f));join(f);send_event(f,16,0,0);assert(bw_poll(f->d,64)==BW_ENOLINK&&f->stopped==1);destroy(f);}
+static void test_parser_mutations(void){uint32_t rng=0x98765432;uint8_t b[1024],out[2048];struct bw_otp otp;size_t used;for(unsigned t=0;t<100000;t++){rng^=rng<<13;rng^=rng>>17;rng^=rng<<5;size_t n=rng%sizeof(b);for(size_t i=0;i<n;i++){rng^=rng<<13;rng^=rng>>17;rng^=rng<<5;b[i]=(uint8_t)rng;}(void)bw_nvram_pack(b,n,out,sizeof(out),&used);(void)bw_otp_parse(b,n,&otp);}}
+int main(void){
+ TEST(test_nvram_golden);TEST(test_nvram_reject);TEST(test_otp);TEST(test_otp_bounds);TEST(test_device_gate);TEST(test_bad_erom);TEST(test_probe_revision);
+ TEST(test_boot_and_rings);TEST(test_firmware_timeout);TEST(test_shared_pointer);TEST(test_protocol_version);TEST(test_ioctl_timeout);TEST(test_ack_required);
+ TEST(test_wpa2_authorization);TEST(test_assoc_not_authorized);TEST(test_unsupported_supplicant);TEST(test_receive);TEST(test_rx_bounds);TEST(test_tx_flow);
+ TEST(test_bad_index);TEST(test_unknown_packet_id);TEST(test_bad_credentials);TEST(test_link_loss);TEST(test_parser_mutations);
+ printf("%u groups passed; 100000 parser mutations\n",tests);return 0;
+}

--- a/tests/m1-wifi/verify_build.py
+++ b/tests/m1-wifi/verify_build.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Reject incomplete/wrong-architecture kernel artifacts using only stdlib.
+
+Verifies the final ELF, not a relocatable object or V-to-C generation alone.
+Symbols and call-site checks establish integration, not hardware operation.
+"""
+from __future__ import annotations
+import argparse
+import hashlib
+from pathlib import Path
+import re
+import struct
+
+REQUIRED = {
+    'apple__wifi__initialise', 'apple__wifi__poll',
+    'apple__wifi__WifiDevice_read', 'apple__wifi__WifiDevice_write',
+    'apple__wifi__WifiDevice_ioctl',
+    'brcm_m1_prepare', 'brcm_m1_status', 'brcm_m1_upload', 'brcm_m1_boot',
+    'brcm_m1_join', 'brcm_m1_poll', 'brcm_m1_read', 'brcm_m1_write', 'brcm_m1_stop',
+    'bw_probe', 'bw_start', 'bw_poll', 'bw_join_wpa2',
+}
+
+
+def require(ok: bool, message: str) -> None:
+    if not ok:
+        raise ValueError(message)
+
+
+def elf_symbols(data: bytes) -> set[str]:
+    require(len(data) >= 64 and data[:7] == b'\x7fELF\x02\x01\x01',
+            'expected a little-endian ELF64 executable')
+    h = struct.unpack_from('<16sHHIQQQIHHHHHH', data)
+    _, kind, machine, version, entry, phoff, shoff, _, ehsize, phsize, phnum, shsize, shnum, _ = h
+    require(kind == 2 and machine == 183 and version == 1 and ehsize == 64,
+            'expected a linked AArch64 ET_EXEC kernel')
+    require(phsize == 56 and phnum > 0 and phoff + phnum * phsize <= len(data),
+            'invalid program-header table')
+    require(shsize == 64 and shnum > 0 and shoff + shnum * shsize <= len(data),
+            'invalid section-header table')
+    executable_entry = False
+    for i in range(phnum):
+        kind, flags, offset, va, _, filesz, memsz, _ = struct.unpack_from('<IIQQQQQQ', data, phoff + i * phsize)
+        require(kind not in (2, 3), 'kernel must not need a dynamic loader')
+        if kind == 1:
+            require(filesz <= memsz and offset + filesz <= len(data), 'invalid PT_LOAD extent')
+            executable_entry |= bool(flags & 1 and va <= entry < va + memsz)
+    require(executable_entry, 'entry point is outside executable load segments')
+    sections = [struct.unpack_from('<IIQQQQIIQQ', data, shoff + i * shsize) for i in range(shnum)]
+    names = set()
+    undefined = set()
+    for s in sections:
+        if s[1] != 2:  # SHT_SYMTAB
+            continue
+        offset, size, link, stride = s[4], s[5], s[6], s[9]
+        require(stride == 24 and size % 24 == 0 and offset + size <= len(data)
+                and link < len(sections), 'invalid symbol table')
+        strings = sections[link]
+        require(strings[1] == 3 and strings[4] + strings[5] <= len(data), 'invalid string table')
+        pool = data[strings[4]:strings[4] + strings[5]]
+        for p in range(offset, offset + size, stride):
+            name, _, _, section, _, _ = struct.unpack_from('<IBBHQQ', data, p)
+            require(name < len(pool), 'symbol name out of bounds')
+            end = pool.find(b'\0', name)
+            require(end >= 0, 'unterminated symbol name')
+            text = pool[name:end].decode('ascii')
+            if text:
+                (names if section else undefined).add(text)
+    require(not undefined, 'unresolved symbols: ' + ', '.join(sorted(undefined)))
+    require(REQUIRED <= names, 'missing linked Wi-Fi symbols: ' + ', '.join(sorted(REQUIRED - names)))
+    return names
+
+
+def body(source: str, name: str) -> str:
+    match = re.search(r'^void ' + re.escape(name) + r'\(void\) \{\n(.*?)^\}', source, re.M | re.S)
+    require(match is not None, 'missing generated function: ' + name)
+    return match.group(1)
+
+
+def verify_hooks(source: str) -> None:
+    init = body(source, 'dev__console__initialise')
+    poll = body(source, 'dev__console__poll_uart_input')
+    require(init.count('apple__wifi__initialise();') == 1, 'missing/duplicate Wi-Fi initialization')
+    require(poll.count('apple__wifi__poll();') == 1, 'missing/duplicate Wi-Fi polling')
+    require(init.index('apple__wifi__initialise();') < init.index('sched__set_uart_poll_callback('),
+            'poll callback installed before Wi-Fi initialization')
+    require('aarch64__virtio_input__poll();' in poll and 'aarch64__uart__getc()' in poll,
+            'existing UART/VirtIO input hooks were lost')
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('kernel', type=Path)
+    p.add_argument('generated_c', type=Path)
+    args = p.parse_args()
+    try:
+        data = args.kernel.read_bytes()
+        names = elf_symbols(data)
+        verify_hooks(args.generated_c.read_text())
+    except (OSError, ValueError, struct.error) as e:
+        p.exit(1, f'FAIL: {e}\n')
+    print(f'PASS linked AArch64 static kernel; {len(REQUIRED)} required Wi-Fi symbols; {len(names)} defined symbols')
+    print('PASS initialization and polling connected; UART/VirtIO preserved')
+    print(f'SHA256 {hashlib.sha256(data).hexdigest()}  {args.kernel.name}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/m1-wifi/verify_test.py
+++ b/tests/m1-wifi/verify_test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Exercise the build verifier against the actual linked kernel and bad copies."""
+from pathlib import Path
+import struct
+import sys
+import unittest
+from verify_build import elf_symbols, verify_hooks
+
+elf = Path(sys.argv.pop(1)).read_bytes()
+source = Path(sys.argv.pop(1)).read_text()
+
+
+class BuildVerifierTests(unittest.TestCase):
+    def reject_field(self, offset, fmt, value):
+        changed = bytearray(elf)
+        struct.pack_into(fmt, changed, offset, value)
+        with self.assertRaises(ValueError):
+            elf_symbols(changed)
+
+    def test_actual_kernel(self):
+        elf_symbols(elf)
+        verify_hooks(source)
+
+    def test_truncated(self):
+        for length in (0, 63, len(elf) // 2):
+            with self.assertRaises(ValueError):
+                elf_symbols(elf[:length])
+
+    def test_wrong_machine(self):
+        self.reject_field(18, '<H', 62)
+
+    def test_relocatable_object(self):
+        self.reject_field(16, '<H', 1)
+
+    def test_missing_symbols(self):
+        changed = bytearray(elf)
+        offset = struct.unpack_from('<Q', elf, 40)[0]
+        count = struct.unpack_from('<H', elf, 60)[0]
+        for i in range(count):
+            if struct.unpack_from('<I', elf, offset + i * 64 + 4)[0] == 2:
+                struct.pack_into('<I', changed, offset + i * 64 + 4, 0)
+        with self.assertRaisesRegex(ValueError, 'missing linked Wi-Fi symbols'):
+            elf_symbols(changed)
+
+    def test_dynamic_loader(self):
+        offset = struct.unpack_from('<Q', elf, 32)[0]
+        self.reject_field(offset, '<I', 3)
+
+    def test_bad_entry(self):
+        self.reject_field(24, '<Q', 0)
+
+    def test_missing_init(self):
+        with self.assertRaisesRegex(ValueError, 'initialization'):
+            verify_hooks(source.replace('apple__wifi__initialise();', ''))
+
+    def test_missing_poll(self):
+        with self.assertRaisesRegex(ValueError, 'polling'):
+            verify_hooks(source.replace('apple__wifi__poll();', ''))
+
+    def test_duplicate_poll(self):
+        with self.assertRaisesRegex(ValueError, 'polling'):
+            verify_hooks(source.replace('apple__wifi__poll();', 'apple__wifi__poll(); apple__wifi__poll();'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/m1-wifi/get-v.sh
+++ b/tools/m1-wifi/get-v.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Bootstrap the exact V1 compiler used for the Wi-Fi build milestone.
+# Refuse an existing destination; never reset/clean a user's compiler checkout.
+set -eu
+DEST=${1:-build-tools/v-m1-wifi}
+HOST_CC=${HOST_CC:-clang}
+if [ -e "$DEST" ]; then
+    echo "Destination already exists: $DEST (set V to its v executable instead)" >&2
+    exit 1
+fi
+mkdir -p "$DEST"
+DEST=$(CDPATH= cd -- "$DEST" && pwd)
+git -C "$DEST" init
+git -C "$DEST" remote add origin https://github.com/vlang/v.git
+git -C "$DEST" fetch --depth=1 origin 71437d263bfc57f99e27588781f34bfc91746910
+git -C "$DEST" checkout --detach FETCH_HEAD
+test "$(git -C "$DEST" rev-parse HEAD)" = 71437d263bfc57f99e27588781f34bfc91746910
+git -C "$DEST" init vc
+git -C "$DEST/vc" remote add origin https://github.com/vlang/vc.git
+git -C "$DEST/vc" fetch --depth=1 origin 99e94ae6099edabce1c6d621eca4c4904e3c2324
+git -C "$DEST/vc" checkout --detach FETCH_HEAD
+test "$(git -C "$DEST/vc" rev-parse HEAD)" = 99e94ae6099edabce1c6d621eca4c4904e3c2324
+VFLAGS='-old-compiler -gc none' make -C "$DEST" local=1 CC="$HOST_CC"
+"$DEST/v" version
+printf 'Compiler ready: %s/v\n' "$DEST"

--- a/tools/m1-wifi/package.py
+++ b/tools/m1-wifi/package.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Package explicitly selected, locally extracted Apple firmware, not downloads.
+The manifest binds the selection to a saved device status. It is not proof that
+selected firmware/calibration files are appropriate: use the matching extracted
+files for this board/module. No vendor firmware is distributed with the driver.
+"""
+from __future__ import annotations
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import struct
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--status', type=Path, required=True, help='wifi-ctl status-raw output')
+    p.add_argument('--firmware', type=Path, required=True)
+    p.add_argument('--nvram', type=Path, required=True)
+    p.add_argument('--clm', type=Path, required=True)
+    p.add_argument('--txcap', type=Path, required=True)
+    p.add_argument('--output', type=Path, required=True)
+    a = p.parse_args()
+    status = a.status.read_bytes()
+    if len(status) != 256 or struct.unpack_from('<I', status)[0] != 1:
+        p.error('status must be a 256-byte successful chip-probe response')
+    revision = struct.unpack_from('<I', status, 8)[0]
+    if revision not in (3, 5) or status[120:152].split(b'\0', 1)[0] != b'apple,shikoku':
+        p.error('unsupported chip revision or board')
+    manifest = bytearray(128)
+    struct.pack_into('<I', manifest, 0, revision)
+    for dst, src, length in ((8,40,16),(24,56,16),(40,72,16),(56,104,16),(72,120,32)):
+        value = status[src:src+length]
+        if not value[0] or b'\0' not in value:
+            p.error('incomplete OTP/board identity')
+        manifest[dst:dst+length] = value
+    parts = []
+    for src, name, limit in ((a.firmware,'firmware.bin',4*1024*1024),(a.nvram,'nvram.txt',65536),
+                             (a.clm,'clm.blob',1024*1024),(a.txcap,'txcap.blob',1024*1024)):
+        size = src.stat().st_size
+        if not src.is_file() or not 0 < size <= limit:
+            p.error(f'invalid file size: {src}')
+        data = src.read_bytes()
+        if len(data) != size:
+            p.error(f'file changed while reading: {src}')
+        if name == 'firmware.bin' and (len(data) < 0x74 or data[0x6c:0x70] != b'RAMS'):
+            p.error('firmware has no expected RAMS header')
+        if name == 'nvram.txt':
+            if b'\0' in data:
+                p.error('provide textual board NVRAM, not a packed binary')
+            data.decode('ascii')
+        parts.append((name, data, str(src)))
+    a.output.mkdir(parents=True, exist_ok=False)
+    (a.output/'manifest.bin').write_bytes(manifest)
+    records = {}
+    for name, data, source in parts:
+        (a.output/name).write_bytes(data)
+        records[name] = {'source':source,'sha256':hashlib.sha256(data).hexdigest(),'bytes':len(data)}
+    (a.output/'provenance.json').write_text(json.dumps(records,indent=2)+'\n')
+    print(f'Wrote {a.output}; selected firmware must match this machine’s board/module.')
+
+if __name__ == '__main__':
+    main()

--- a/tools/m1-wifi/wifi-ctl.c
+++ b/tools/m1-wifi/wifi-ctl.c
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: ISC
+ * Root-only loader/control utility for the experimental Vinix raw interface.
+ * No passphrase in argv, environment, configuration files, or diagnostic logs.
+ */
+#define _POSIX_C_SOURCE 200809L
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <termios.h>
+#include <time.h>
+#include <unistd.h>
+#include "brcm_m1.h"
+static int tty=-1, changed;
+static struct termios saved;
+static uint8_t password[64];
+static void wipe(void *p,size_t n){volatile uint8_t *q=p;while(n--)*q++=0;}
+static void restore(void){if(changed&&tty>=0)(void)tcsetattr(tty,TCSANOW,&saved);changed=0;wipe(password,sizeof(password));}
+static void interrupted(int sig){restore();_exit(128+sig);}
+static uint32_t le32(const uint8_t *p){return p[0]|(uint32_t)p[1]<<8|(uint32_t)p[2]<<16|(uint32_t)p[3]<<24;}
+static uint64_t le64(const uint8_t *p){return le32(p)|(uint64_t)le32(p+4)<<32;}
+static void put32(uint8_t *p,uint32_t x){for(unsigned i=0;i<4;i++)p[i]=(uint8_t)(x>>(8*i));}
+static void die(const char *what){perror(what);exit(1);}
+static void pause_ms(unsigned ms){struct timespec t={(time_t)(ms/1000),(long)(ms%1000)*1000000};while(nanosleep(&t,&t)<0&&errno==EINTR){} }
+static void status(int fd,uint8_t out[BW_STATUS_SIZE]){memset(out,0,BW_STATUS_SIZE);if(ioctl(fd,BW_IOCTL_STATUS,out)<0)die("Wi-Fi status");}
+static void show(int fd){
+    uint8_t s[BW_STATUS_SIZE];status(fd,s);
+    static const char *const names[]={"off","chip detected","booting","firmware ready","authenticating","authenticated link","stopped"};
+    unsigned st=le32(s);printf("state: %s; error: %d; chip revision: %u; DART error: 0x%08x\n",st<7?names[st]:"invalid",(int32_t)le32(s+4),le32(s+8),le32(s+12));
+    printf("MAC: %02x:%02x:%02x:%02x:%02x:%02x\n",s[32],s[33],s[34],s[35],s[36],s[37]);
+    printf("module: %.15s; vendor: %.15s; module revision: %.15s; antenna: %.15s; board: %.31s\n",s+40,s+56,s+72,s+104,s+120);
+    printf("RX: %llu; TX: %llu; queue drops: %llu\n",(unsigned long long)le64(s+16),(unsigned long long)le64(s+24),(unsigned long long)le64(s+152));
+}
+static size_t read_password(void){
+    tty=open("/dev/tty",O_RDWR|O_CLOEXEC);if(tty<0)tty=dup(STDIN_FILENO);if(tty<0)die("terminal");
+    if(tcgetattr(tty,&saved)<0)die("cannot disable password echo");
+    struct termios settings=saved;settings.c_lflag&=(tcflag_t)~ECHO;
+    if(tcsetattr(tty,TCSANOW,&settings)<0)die("password terminal");changed=1;
+    fprintf(stderr,"WPA2 passphrase: ");fflush(stderr);size_t n=0;int too_long=0;
+    for(;;){uint8_t c;ssize_t k=read(tty,&c,1);if(k<0&&errno==EINTR)continue;if(k!=1){restore();fprintf(stderr,"\nPassword input failed.\n");exit(1);}if(c=='\r'||c=='\n')break;if(n<sizeof(password))password[n++]=c;else too_long=1;}
+    (void)tcsetattr(tty,TCSANOW,&saved);changed=0;close(tty);tty=-1;fprintf(stderr,"\n");
+    if(too_long||n<8||n>63){fprintf(stderr,"Use an 8–63 character WPA2 passphrase.\n");exit(1);}return n;
+}
+static void path_join(char *out,size_t size,const char *dir,const char *name){int n=snprintf(out,size,"%s/%s",dir,name);if(n<0||(size_t)n>=size){errno=ENAMETOOLONG;die("firmware path");}}
+static void load(int fd,const char *dir){
+    static const char *const names[]={"firmware.bin","nvram.txt","clm.blob","txcap.blob"};
+    static const size_t limits[]={4u*1024u*1024u,65536,1024u*1024u,1024u*1024u};
+    char path[4096];uint8_t manifest[128];path_join(path,sizeof(path),dir,"manifest.bin");
+    FILE *mf=fopen(path,"rb");if(!mf)die("manifest");if(fread(manifest,1,128,mf)!=128||fgetc(mf)!=EOF){fprintf(stderr,"Invalid manifest length.\n");exit(1);}fclose(mf);
+    uint8_t current[256];status(fd,current);
+    if(le32(current)!=1||le32(manifest)!=le32(current+8)||memcmp(manifest+8,current+40,16)||memcmp(manifest+24,current+56,16)||memcmp(manifest+40,current+72,16)||memcmp(manifest+56,current+104,16)||memcmp(manifest+72,current+120,32)){fprintf(stderr,"Manifest does not match the detected chip/board/module; refusing upload.\n");exit(1);}
+    /* Validate all four files before changing the kernel's one-shot upload. */
+    FILE *files[4];uint32_t totals[4];
+    for(unsigned i=0;i<4;i++){path_join(path,sizeof(path),dir,names[i]);files[i]=fopen(path,"rb");if(!files[i])die(names[i]);struct stat st;if(fstat(fileno(files[i]),&st)<0)die("firmware stat");if(!S_ISREG(st.st_mode)||st.st_size<=0||(uint64_t)st.st_size>limits[i]){fprintf(stderr,"Invalid size for %s.\n",names[i]);exit(1);}totals[i]=(uint32_t)st.st_size;}
+    for(unsigned i=0;i<4;i++){
+        uint8_t chunk[BW_UPLOAD_SIZE];uint32_t off=0;
+        while(off<totals[i]){memset(chunk,0,sizeof(chunk));uint32_t n=totals[i]-off;if(n>4096)n=4096;put32(chunk,i);put32(chunk+4,totals[i]);put32(chunk+8,off);put32(chunk+12,n);
+            if(fread(chunk+16,1,n,files[i])!=n)die("firmware read");if(ioctl(fd,BW_IOCTL_UPLOAD,chunk)<0)die("firmware upload");off+=n;
+        }
+        if(fgetc(files[i])!=EOF){fprintf(stderr,"Firmware changed during upload; reboot before retrying.\n");exit(1);}fclose(files[i]);
+    }
+    if(ioctl(fd,BW_IOCTL_BOOT,manifest)<0)die("firmware boot");show(fd);
+}
+int main(int argc,char **argv){
+    atexit(restore);signal(SIGINT,interrupted);signal(SIGTERM,interrupted);signal(SIGHUP,interrupted);
+    if(argc<2){fprintf(stderr,"Usage: %s status | status-raw FILE | load DIRECTORY | join SSID | stop\n",argv[0]);return 2;}
+    int fd=open("/dev/wlan0",O_RDWR|O_NONBLOCK|O_CLOEXEC);if(fd<0)die("/dev/wlan0 (requires vinix.apple_wifi=1 and a supported J313 DT)");
+    if(!strcmp(argv[1],"status")&&argc==2)show(fd);
+    else if(!strcmp(argv[1],"status-raw")&&argc==3){uint8_t s[256];status(fd,s);FILE *out=fopen(argv[2],"wb");if(!out)die("status output");if(fwrite(s,1,sizeof(s),out)!=sizeof(s)||fclose(out))die("status write");}
+    else if(!strcmp(argv[1],"load")&&argc==3)load(fd,argv[2]);
+    else if(!strcmp(argv[1],"join")&&argc==3){
+        size_t sn=strlen(argv[2]);if(!sn||sn>32){fprintf(stderr,"SSID must contain 1–32 bytes.\n");return 2;}
+        size_t pn=read_password();uint8_t q[BW_JOIN_SIZE]={0};put32(q,(uint32_t)sn);put32(q+4,(uint32_t)pn);memcpy(q+8,argv[2],sn);memcpy(q+40,password,pn);
+        int rc=ioctl(fd,BW_IOCTL_JOIN,q);int error=errno;wipe(q,sizeof(q));wipe(password,sizeof(password));errno=error;if(rc<0)die("WPA2 join");
+        for(unsigned i=0;i<310;i++){uint8_t s[256];status(fd,s);if(le32(s)==5){show(fd);printf("Layer-2 link authenticated. This driver does not provide an IP stack.\n");close(fd);return 0;}if(le32(s)==6){show(fd);close(fd);return 1;}pause_ms(100);}fprintf(stderr,"Authentication deadline exceeded.\n");close(fd);return 1;
+    }else if(!strcmp(argv[1],"stop")&&argc==2){if(ioctl(fd,BW_IOCTL_STOP,0)<0)die("stop");show(fd);}
+    else{fprintf(stderr,"Unknown command or argument count.\n");close(fd);return 2;}
+    close(fd);return 0;
+}


### PR DESCRIPTION
## Scope
Complete the **integrated ARM64 build milestone**, not a claim of working Wi-Fi or Internet access. Based on current master `d87e6fea15759f943072611ef357c2170e97f21b`; the new head is `1610868315cf6ef040ff6a732ec3f340ed1e93bf`.

The experimental BCM4378 transport, J313 PCIe/DART adapter and `/dev/wlan0` control/raw-Ethernet interface are now included in the real kernel build. Console initialization and polling are connected without removing UART, VirtIO or SPI-keyboard handling. Probing remains opt-in with `vinix.apple_wifi=1`; no proprietary firmware is included.

Fixes include typed user-copy addresses, unavailable freestanding C dependencies and host-test header search paths. A separate prerequisite commit contains four minimal V compatibility fixes in the existing ANS wrappers exposed by building current master; no storage features were removed or stubbed.

## Validation completed locally
- Clean debug AND production ARM64 kernel V-to-C generation, C/assembly compilation and final `ld.lld` link succeed.
- Both results are static AArch64 ET_EXEC images with no undefined symbols; all 18 required Wi-Fi symbols survive linker garbage collection, and real initialization/polling call sites are verified.
- 24 protocol test groups plus 7 simulated-platform policy groups pass with Clang ASan/UBSan and optimized GCC, including 100,000 parser mutations.
- All 10 positive/negative build-verifier tests pass against the actual linked production image.
- All 17 SPI-keyboard regression groups pass.
- Both production driver C components compile against kernel freestanding headers using `-Wall -Wextra -Werror`; the control utility host build also passes.
- The complete uploaded kernel subtree `82d45547b734ea3672875494a6b3030b19c778fd`, test subtree and tool subtree match the tested local sources. Existing unrelated master content is preserved.

Local kernel SHA-256:
```
3e133fae22de589178c5bf4f781478022f2d6434501d997bf8c4e5d7276787ea  vinix-aarch64-debug.elf
de592ff17569ccbf47cece6a52e85e3136aa67edb37134820884d21c6c59c7a6  vinix-aarch64-production.elf
```

Toolchain: pinned V1 `71437d263bfc57f99e27588781f34bfc91746910`, bootstrap VC `99e94ae6099edabce1c6d621eca4c4904e3c2324`; local Clang/LLD 17. Existing kernel/V notices and third-party warnings remain. Debug hashes may differ across toolchain versions or absolute build paths.

## Reproduce
In a disposable Linux checkout with Clang, LLD, GCC, make, git, curl and Python 3:
```sh
sh tools/m1-wifi/get-v.sh /tmp/vinix-wifi-v
(cd kernel && ./get-deps)
CC=clang SANITIZE=1 sh tests/m1-wifi/run.sh
CC=gcc SANITIZE=0 sh tests/m1-wifi/run.sh
CC=clang sh tests/apple-spi-keyboard/run.sh
V=/tmp/vinix-wifi-v/v JOBS=2 sh tests/m1-wifi/build.sh
```
The build script saves full logs, verification output, both ELF images and checksums under `tests/m1-wifi/out/`. The added GitHub Actions workflow runs these checks and uploads artifacts; its result is separate from the completed local validation.

## Still unverified / not implemented
Physical M1 boot, firmware startup, WPA2 authentication and packet transfer remain untested. There is no IPv4/IPv6 stack, DHCP/DNS integration or AF_INET socket implementation. Target userspace execution of wifi-ctl is also unverified. These are kernel-only build artifacts, not a completed boot image or hardware qualification. Keep a known-working boot entry. Full limitations and bring-up instructions are in `tests/m1-wifi/README.md`.