### PR TITLE
amd64: honor O_NONBLOCK when reading the console

### DIFF
--- a/kernel/modules/dev/console/console.v
+++ b/kernel/modules/dev/console/console.v
@@ -523,10 +523,19 @@ fn (mut this Console) mmap(_handle voidptr, _page u64, _flags int) voidptr {
 
 fn (mut this Console) read(_handle voidptr, void_buf voidptr, _loc u64, count u64) ?i64 {
 	latest_thread = proc.current_thread()
+	if count == 0 {
+		return 0
+	}
+	handle := unsafe { &file.Handle(_handle) }
+	nonblocking := handle != unsafe { nil } && handle.flags & resource.o_nonblock != 0
 
 	mut buf := unsafe { &u8(void_buf) }
 
 	for console_read_lock.test_and_acquire() == false {
+		if nonblocking {
+			errno.set(errno.ewouldblock)
+			return none
+		}
 		mut events := [&console_event]
 		event.await(mut events, true) or {
 			unsafe { events.free() }
@@ -555,6 +564,13 @@ fn (mut this Console) read(_handle voidptr, void_buf voidptr, _loc u64, count u6
 			wait = false
 		} else {
 			if wait == true {
+				// The desktop polls this descriptor each frame. Do not wait
+				// for a keystroke when the caller requested O_NONBLOCK.
+				if nonblocking {
+					console_read_lock.release()
+					errno.set(errno.ewouldblock)
+					return none
+				}
 				console_read_lock.release()
 				for {
 					mut events := [&console_event]

--- a/tests/amd64-console/README.md
+++ b/tests/amd64-console/README.md
@@ -1,0 +1,14 @@
+# amd64 console guest regression
+
+Compile with an x86_64 musl toolchain:
+
+```sh
+musl-gcc -static -O2 -Wall -Wextra -Werror tests/amd64-console/test.c -o init
+mkdir -p test-root/sbin
+cp init test-root/sbin/init
+tar --format=ustar -cf test-initramfs.tar -C test-root .
+VINIX_AMD64_INITRAMFS="$PWD/test-initramfs.tar" \
+VINIX_AMD64_ISO="$PWD/test-console.iso" ./build-support/build-amd64-iso.sh
+```
+
+Build the amd64 kernel first (`./build-amd64.sh --no-userland --no-iso`). Boot the diagnostic ISO in an isolated QEMU/KVM x86_64 guest with UEFI, VGA, HPET, and COM1 serial capture. The init forks a test worker and prints `TEST RESULT: PASS` or `FAIL` on COM1. It then sleeps; terminate only the test VM from the host. Use a host-side timeout to detect a kernel crash or blocked syscall. The process-group test re-execs `/sbin/init`, so retain that installation path. Do not run these guest tests on the host.

--- a/tests/amd64-console/test.c
+++ b/tests/amd64-console/test.c
@@ -1,0 +1,53 @@
+/* Guest regression test: static Linux/musl x86_64 executable.
+ * Can run as /sbin/init in an isolated Vinix VM or as a normal guest program. */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+#define CHECK(x) do { if (!(x)) { printf("FAIL line %d: %s errno=%d\n", __LINE__, #x, errno); return 1; } } while (0)
+static int reap(pid_t child) {
+    int status = -1;
+    CHECK(waitpid(child, &status, 0) == child);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    return 0;
+}
+static int exec_child(int argc, char **argv) { (void)argc; (void)argv; return 1; }
+static int run_test(void) {
+    int fd = open("/dev/console", O_RDONLY | O_NONBLOCK);
+    CHECK(fd >= 0);
+    char data[16];
+    CHECK(read(fd, data, 0) == 0);
+    errno = 0;
+    CHECK(read(fd, data, sizeof(data)) == -1 && errno == EAGAIN);
+    CHECK(fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) & ~O_NONBLOCK) == 0);
+    CHECK(read(fd, data, 0) == 0);
+    CHECK(fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK) == 0);
+    errno = 0;
+    CHECK(read(fd, data, 1) == -1 && errno == EAGAIN);
+    CHECK(close(fd) == 0);
+    puts("TEST console: zero-length and nonblocking reads passed");
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    setbuf(stdout, NULL);
+    if (argc > 1) return exec_child(argc, argv);
+    if (getpid() != 1) return run_test();
+    int serial = open("/dev/com1", O_WRONLY);
+    if (serial >= 0) { dup2(serial, 1); dup2(serial, 2); close(serial); }
+    puts("TEST START");
+    pid_t worker = fork();
+    if (worker == 0) _exit(run_test());
+    int failed = worker < 0 || reap(worker) != 0;
+    printf("TEST RESULT: %s\n", failed ? "FAIL" : "PASS");
+    for (;;) sleep(1);
+}


### PR DESCRIPTION
Opening the native amd64 desktop can appear to hang after initramfs unpacking. The desktop reads `/dev/console` with `O_NONBLOCK`, but the amd64 console waits for keyboard input regardless of that flag. A debugger showed `vinix-desktop` blocked in `Console.read` while init was waiting for the desktop process.

Honor the open-file handle's `O_NONBLOCK` flag both when acquiring the read lock and when no input is available. Return `EWOULDBLOCK` before consuming any bytes, preserve partial reads, and return immediately for zero-length reads. This follows the nonblocking behavior already present in the ARM64 console without changing blocking reads.

Validation on upstream `3720d0f`:

- The same guest test on unmodified upstream `3720d0f` reaches its start marker and blocks on the empty `O_NONBLOCK` read until the 45-second host timeout.
- Built the amd64 kernel with `PROD=true` and `PROD=false` using V `64604901c85377322d9d65455355986f30056513` and Clang/LLVM 18.
- Booted this independent branch in QEMU/KVM (x86_64, Q35, OVMF, VGA, HPET, 2 vCPUs, 2 GiB RAM). The included guest regression passed in both builds, including empty nonblocking reads, zero-length reads, and toggling `O_NONBLOCK` through `fcntl`.
- With the complementary terminal syscall fixes applied, the native desktop boots and accepts mouse/keyboard input in virt-manager. This PR addresses the initial console wait only.

The regression test and diagnostic-initramfs instructions are in `tests/amd64-console/`. No generated images or binaries are included.

Related independent fixes for the amd64 native desktop: #175, #176, #177. Each branch targets master directly and can be reviewed separately.
