### PR TITLE
amd64: implement Linux poll with safe ppoll waits

### DIFF
--- a/kernel/modules/file/file.v
+++ b/kernel/modules/file/file.v
@@ -111,10 +111,6 @@ fn poll_revents(status int, requested i16) i16 {
 fn ppoll(fds &PollFD, nfds u64, tmo_p &time.TimeSpec, sigmask &u64) (u64, u64) {
 	mut t := proc.current_thread()
 
-	if nfds == 0 {
-		return 0, 0
-	}
-
 	oldmask := t.masked_signals
 	if voidptr(sigmask) != unsafe { nil } {
 		t.masked_signals = *sigmask
@@ -169,11 +165,23 @@ fn ppoll(fds &PollFD, nfds u64, tmo_p &time.TimeSpec, sigmask &u64) (u64, u64) {
 
 		fdlist << fd
 		fdnums << i
-		events << &resource_.event
+		resource_event := &resource_.event
+		if resource_event !in events {
+			events << resource_event
+		}
 	}
 
 	if ret != 0 {
 		return ret, 0
+	}
+	if tmo_p != unsafe { nil } && tmo_p.tv_sec == 0 && tmo_p.tv_nsec == 0 {
+		return 0, 0
+	}
+
+	// event.await has a fixed-size per-thread listener array.
+	needed_events := events.len + if tmo_p != unsafe { nil } { 1 } else { 0 }
+	if needed_events > proc.max_events {
+		return errno.err, errno.einval
 	}
 
 	mut timer := &time.Timer(unsafe { nil })
@@ -202,14 +210,18 @@ fn ppoll(fds &PollFD, nfds u64, tmo_p &time.TimeSpec, sigmask &u64) (u64, u64) {
 			}
 		}
 
-		status := fdlist[which].handle.resource.status
-
-		mut fdd := unsafe { &fds[fdnums[which]] }
-
-		revents := poll_revents(status, fdd.events)
-		if revents != 0 {
-			fdd.revents = revents
-			ret++
+		// One resource may back several descriptors. Recheck every entry,
+		// both to count all ready FDs and to tolerate stale event wakeups.
+		for i, fd in fdlist {
+			status := fd.handle.resource.status
+			mut fdd := unsafe { &fds[fdnums[i]] }
+			revents := poll_revents(status, fdd.events)
+			if revents != 0 {
+				fdd.revents = revents
+				ret++
+			}
+		}
+		if ret != 0 {
 			break
 		}
 	}
@@ -264,6 +276,40 @@ pub fn syscall_ppoll(_ voidptr, user_fds u64, nfds u64, user_timeout u64, user_s
 	}
 	if nfds != 0
 		&& !usercopy.copy_to_pagemap(pagemap, user_fds, unsafe { voidptr(&pollfds[0]) }, nfds * sizeof(PollFD)) {
+		return errno.err, errno.efault
+	}
+	return ret, 0
+}
+
+// Linux poll uses a millisecond timeout rather than a userspace timespec.
+pub fn syscall_poll(_ voidptr, user_fds u64, nfds u64, timeout_ms int) (u64, u64) {
+	if nfds > 4096 {
+		return errno.err, errno.einval
+	}
+	pagemap := proc.current_thread().process.pagemap
+	mut pollfds := []PollFD{len: int(nfds)}
+	defer {
+		unsafe { pollfds.free() }
+	}
+	mut fds_ptr := &PollFD(unsafe { nil })
+	if nfds != 0 {
+		fds_ptr = unsafe { &pollfds[0] }
+		if !usercopy.copy_from_user(voidptr(fds_ptr), user_fds, nfds * sizeof(PollFD)) {
+			return errno.err, errno.efault
+		}
+	}
+	mut timeout := time.TimeSpec{}
+	mut timeout_ptr := &time.TimeSpec(unsafe { nil })
+	if timeout_ms >= 0 {
+		timeout.tv_sec = timeout_ms / 1000
+		timeout.tv_nsec = (timeout_ms % 1000) * 1000000
+		timeout_ptr = &timeout
+	}
+	ret, err := ppoll(fds_ptr, nfds, timeout_ptr, unsafe { nil })
+	if err != 0 {
+		return ret, err
+	}
+	if nfds != 0 && !usercopy.copy_to_pagemap(pagemap, user_fds, voidptr(fds_ptr), nfds * sizeof(PollFD)) {
 		return errno.err, errno.efault
 	}
 	return ret, 0

--- a/kernel/modules/syscall/table/linux_table_amd64.v
+++ b/kernel/modules/syscall/table/linux_table_amd64.v
@@ -433,6 +433,7 @@ pub fn init_linux_syscall_table() {
 	linux_syscall_table[4] = voidptr(syscall_linux_stat)
 	linux_syscall_table[5] = voidptr(fs.syscall_fstat)
 	linux_syscall_table[6] = voidptr(syscall_linux_lstat)
+	linux_syscall_table[7] = voidptr(file.syscall_poll)
 	linux_syscall_table[8] = voidptr(fs.syscall_seek)
 	linux_syscall_table[9] = voidptr(syscall_linux_mmap)
 	linux_syscall_table[10] = voidptr(mmap.syscall_mprotect)

--- a/tests/amd64-poll/README.md
+++ b/tests/amd64-poll/README.md
@@ -1,0 +1,14 @@
+# amd64 poll guest regression
+
+Compile with an x86_64 musl toolchain:
+
+```sh
+musl-gcc -static -O2 -Wall -Wextra -Werror tests/amd64-poll/test.c -o init
+mkdir -p test-root/sbin
+cp init test-root/sbin/init
+tar --format=ustar -cf test-initramfs.tar -C test-root .
+VINIX_AMD64_INITRAMFS="$PWD/test-initramfs.tar" \
+VINIX_AMD64_ISO="$PWD/test-poll.iso" ./build-support/build-amd64-iso.sh
+```
+
+Build the amd64 kernel first (`./build-amd64.sh --no-userland --no-iso`). Boot the diagnostic ISO in an isolated QEMU/KVM x86_64 guest with UEFI, VGA, HPET, and COM1 serial capture. The init forks a test worker and prints `TEST RESULT: PASS` or `FAIL` on COM1. It then sleeps; terminate only the test VM from the host. Use a host-side timeout to detect a kernel crash or blocked syscall. The process-group test re-execs `/sbin/init`, so retain that installation path. Do not run these guest tests on the host.

--- a/tests/amd64-poll/test.c
+++ b/tests/amd64-poll/test.c
@@ -1,0 +1,76 @@
+/* Guest regression test: static Linux/musl x86_64 executable.
+ * Can run as /sbin/init in an isolated Vinix VM or as a normal guest program. */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+#define CHECK(x) do { if (!(x)) { printf("FAIL line %d: %s errno=%d\n", __LINE__, #x, errno); return 1; } } while (0)
+static int reap(pid_t child) {
+    int status = -1;
+    CHECK(waitpid(child, &status, 0) == child);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    return 0;
+}
+static int exec_child(int argc, char **argv) { (void)argc; (void)argv; return 1; }
+static long elapsed_ms(struct timespec a, struct timespec b) {
+    return (b.tv_sec-a.tv_sec)*1000 + (b.tv_nsec-a.tv_nsec)/1000000;
+}
+static int run_test(void) {
+    CHECK(poll(NULL, 0, 0) == 0);
+    struct timespec a, b;
+    CHECK(clock_gettime(CLOCK_MONOTONIC, &a) == 0);
+    CHECK(poll(NULL, 0, 40) == 0);
+    CHECK(clock_gettime(CLOCK_MONOTONIC, &b) == 0);
+    CHECK(elapsed_ms(a,b) >= 30);
+    struct pollfd f = {.fd=-1, .events=POLLIN, .revents=123};
+    CHECK(poll(&f, 1, 0) == 0 && f.revents == 0);
+    f.fd=INT_MAX;
+    CHECK(poll(&f, 1, 0) == 1 && (f.revents & POLLNVAL));
+    errno=0;
+    CHECK(syscall(SYS_poll, (void *)1, 1, 0) == -1 && errno == EFAULT);
+    errno=0;
+    CHECK(syscall(SYS_poll, NULL, 4097, 0) == -1 && errno == EINVAL);
+    int p[2]; CHECK(pipe(p) == 0);
+    struct pollfd pair[2] = {{.fd=p[0], .events=POLLIN}, {.fd=p[0], .events=POLLIN}};
+    CHECK(poll(pair, 2, 0) == 0);
+    CHECK(poll(pair, 2, 10) == 0); /* duplicate event must not deadlock */
+    pid_t child=fork(); CHECK(child>=0);
+    if (child==0) { usleep(50000); _exit(write(p[1], "x", 1)==1 ? 0 : 1); }
+    CHECK(poll(pair, 2, -1) == 2);
+    CHECK((pair[0].revents & POLLIN) && (pair[1].revents & POLLIN));
+    CHECK(reap(child) == 0);
+    char c; CHECK(read(p[0], &c, 1) == 1 && c == 'x');
+    close(p[1]); f.fd=p[0]; f.events=0;
+    CHECK(poll(&f, 1, 0) == 1 && (f.revents & POLLHUP));
+    close(p[0]);
+    int pipes[33][2]; struct pollfd many[33];
+    for(int i=0;i<33;i++){ CHECK(pipe(pipes[i])==0); many[i]=(struct pollfd){.fd=pipes[i][0],.events=POLLIN}; }
+    CHECK(poll(many,33,0)==0);
+    errno=0; CHECK(poll(many,33,1)==-1 && errno==EINVAL);
+    for(int i=0;i<33;i++){close(pipes[i][0]);close(pipes[i][1]);}
+    puts("TEST poll: timeouts, readiness, duplicate FDs, HUP and invalid inputs passed");
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    setbuf(stdout, NULL);
+    if (argc > 1) return exec_child(argc, argv);
+    if (getpid() != 1) return run_test();
+    int serial = open("/dev/com1", O_WRONLY);
+    if (serial >= 0) { dup2(serial, 1); dup2(serial, 2); close(serial); }
+    puts("TEST START");
+    pid_t worker = fork();
+    if (worker == 0) _exit(run_test());
+    int failed = worker < 0 || reap(worker) != 0;
+    printf("TEST RESULT: %s\n", failed ? "FAIL" : "PASS");
+    for (;;) sleep(1);
+}


### PR DESCRIPTION
The amd64 Linux syscall table has no `poll` entry. BusyBox's interactive shell in the native desktop terminal prints `sh: poll: Function not implemented` around each prompt.

Map syscall 7 to a millisecond-timeout wrapper around the existing `ppoll` implementation. Copy the userspace poll array into kernel memory before a possible wait, propagate errors, and copy results back through the captured process pagemap.

The shared wait path also needs to honor zero-timeout probes and descriptor-free timed waits. Deduplicate resource events before locking/listening, rescan every pollfd after a wakeup so duplicate descriptors are all reported, and reject waits exceeding the scheduler's fixed listener capacity rather than panicking. The existing 4096-entry input bound is retained; a blocking wait can currently attach at most `proc.max_events` (32) distinct events, including its timeout event.

Validation on upstream `3720d0f`:

- The same guest test fails on unmodified upstream `3720d0f` at `poll(NULL, 0, 0)` with `ENOSYS` (38).
- Built amd64 production and debug kernels with V `64604901c85377322d9d65455355986f30056513` and Clang/LLVM 18.
- Ran the included isolated guest regression under QEMU/KVM with this PR alone: zero/finite/infinite timeouts, delayed pipe readiness, duplicate descriptors before and after wakeup, unconditional HUP reporting, invalid descriptors/userspace pointers, and listener-capacity rejection.
- The native desktop's BusyBox terminal no longer prints the missing-poll error when combined with the separate console and process-group fixes.

`tests/amd64-poll/` includes the test and reproduction instructions. The shared `ppoll` changes are compiled/tested here on amd64; ARM64 runtime validation has not been performed. This does not attempt to remove the scheduler's event-capacity limit or implement complete Linux signal delivery.

Related independent fixes for the amd64 native desktop: #174, #176, #177. Each branch targets master directly and can be reviewed separately.
