### PR TITLE
amd64: implement Linux process-group syscalls

### DIFF
--- a/kernel/modules/proc/proc.v
+++ b/kernel/modules/proc/proc.v
@@ -49,6 +49,9 @@ pub mut:
 	// Linux convention used by unmodified Alpine binaries. exec sets this from
 	// the ELF interpreter; fork inherits it with the rest of the process ABI.
 	linux_abi bool
+	// Reset by fork; set when amd64 exec commits a replacement image.
+	// Protected by the process-table lock for parent setpgid checks.
+	execed_since_fork bool
 
 	// Credentials: the real, effective and saved sets POSIX names, plus the
 	// supplementary groups. Everything starts as root and is inherited across

--- a/kernel/modules/syscall/table/linux_table_amd64.v
+++ b/kernel/modules/syscall/table/linux_table_amd64.v
@@ -421,6 +421,59 @@ fn syscall_linux_getdents64(gpr_state voidptr, fdnum int, dirp u64, count u64) (
 	return offset, 0
 }
 
+// Interactive shells compare their process group with the PTY foreground group.
+fn syscall_linux_getpgrp(_ voidptr) (u64, u64) {
+	return u64(proc.current_thread().process.pgid), 0
+}
+
+fn syscall_linux_getpgid(_ voidptr, pid int) (u64, u64) {
+	if pid == 0 {
+		return u64(proc.current_thread().process.pgid), 0
+	}
+	proc.lock_table()
+	defer { proc.unlock_table() }
+	target := proc.process_at(pid)
+	if target == unsafe { nil } {
+		return errno.err, errno.esrch
+	}
+	return u64(target.pgid), 0
+}
+
+fn syscall_linux_setpgid(_ voidptr, pid int, pgid int) (u64, u64) {
+	if pid < 0 || pgid < 0 {
+		return errno.err, errno.einval
+	}
+	current := proc.current_thread().process
+	proc.lock_table()
+	defer { proc.unlock_table() }
+	mut target := proc.process_at(if pid == 0 { current.pid } else { pid })
+	if target == unsafe { nil } || (target.pid != current.pid && target.ppid != current.pid) {
+		return errno.err, errno.esrch
+	}
+	if target.pid != current.pid && target.execed_since_fork {
+		return errno.err, errno.eacces
+	}
+	if target.sid != current.sid || target.sid == target.pid {
+		return errno.err, errno.eperm
+	}
+	group := if pgid == 0 { target.pid } else { pgid }
+	if group != target.pid {
+		mut found := false
+		for i := 1; i < proc.max_pid; i++ {
+			member := proc.process_at(i)
+			if member != unsafe { nil } && member.pgid == group && member.sid == target.sid {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return errno.err, errno.eperm
+		}
+	}
+	target.pgid = group
+	return 0, 0
+}
+
 pub fn init_linux_syscall_table() {
 	for i := 0; i < linux_syscall_max; i++ {
 		linux_syscall_table[i] = voidptr(syscall_linux_vacant)
@@ -493,8 +546,11 @@ pub fn init_linux_syscall_table() {
 	linux_syscall_table[104] = voidptr(syscall_linux_getgid)
 	linux_syscall_table[107] = voidptr(syscall_linux_geteuid)
 	linux_syscall_table[108] = voidptr(syscall_linux_getegid)
+	linux_syscall_table[109] = voidptr(syscall_linux_setpgid)
 	linux_syscall_table[110] = voidptr(userland.syscall_getppid)
+	linux_syscall_table[111] = voidptr(syscall_linux_getpgrp)
 	linux_syscall_table[112] = voidptr(userland.syscall_setsid)
+	linux_syscall_table[121] = voidptr(syscall_linux_getpgid)
 	linux_syscall_table[137] = voidptr(fs.syscall_statfs)
 	linux_syscall_table[158] = voidptr(syscall_linux_arch_prctl)
 	linux_syscall_table[186] = voidptr(syscall_linux_gettid)

--- a/kernel/modules/userland/userland.v
+++ b/kernel/modules/userland/userland.v
@@ -755,6 +755,11 @@ pub fn start_program(execve bool, dir &fs.VFSNode, path string, argv []string, e
 		mut t := proc.current_thread()
 		mut process := t.process
 
+		// Serialize the successful exec transition with parent setpgid.
+		proc.lock_table()
+		process.execed_since_fork = true
+		proc.unlock_table()
+
 		mut old_pagemap := process.pagemap
 
 		process.pagemap = new_pagemap

--- a/tests/amd64-pgrp/README.md
+++ b/tests/amd64-pgrp/README.md
@@ -1,0 +1,14 @@
+# amd64 pgrp guest regression
+
+Compile with an x86_64 musl toolchain:
+
+```sh
+musl-gcc -static -O2 -Wall -Wextra -Werror tests/amd64-pgrp/test.c -o init
+mkdir -p test-root/sbin
+cp init test-root/sbin/init
+tar --format=ustar -cf test-initramfs.tar -C test-root .
+VINIX_AMD64_INITRAMFS="$PWD/test-initramfs.tar" \
+VINIX_AMD64_ISO="$PWD/test-pgrp.iso" ./build-support/build-amd64-iso.sh
+```
+
+Build the amd64 kernel first (`./build-amd64.sh --no-userland --no-iso`). Boot the diagnostic ISO in an isolated QEMU/KVM x86_64 guest with UEFI, VGA, HPET, and COM1 serial capture. The init forks a test worker and prints `TEST RESULT: PASS` or `FAIL` on COM1. It then sleeps; terminate only the test VM from the host. Use a host-side timeout to detect a kernel crash or blocked syscall. The process-group test re-execs `/sbin/init`, so retain that installation path. Do not run these guest tests on the host.

--- a/tests/amd64-pgrp/test.c
+++ b/tests/amd64-pgrp/test.c
@@ -1,0 +1,81 @@
+/* Guest regression test: static Linux/musl x86_64 executable.
+ * Can run as /sbin/init in an isolated Vinix VM or as a normal guest program. */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+#define CHECK(x) do { if (!(x)) { printf("FAIL line %d: %s errno=%d\n", __LINE__, #x, errno); return 1; } } while (0)
+static int reap(pid_t child) {
+    int status = -1;
+    CHECK(waitpid(child, &status, 0) == child);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    return 0;
+}
+static int exec_child(int argc, char **argv) {
+    CHECK(argc == 4);
+    int ready=atoi(argv[2]), gate=atoi(argv[3]);
+    CHECK(write(ready,"x",1)==1);
+    char c; CHECK(read(gate,&c,1)==1);
+    /* A process may still set its own group after exec. */
+    CHECK(setpgid(0,0)==0 && getpgrp()==getpid());
+    int sync[2]; CHECK(pipe(sync)==0);
+    pid_t child=fork(); CHECK(child>=0);
+    if(child==0){ char c; if(read(sync[0],&c,1)!=1)_exit(1);_exit(getpgrp()==getpid()?0:1); }
+    /* The child must not inherit our successful-exec marker. */
+    CHECK(setpgid(child,child)==0); CHECK(write(sync[1],"x",1)==1);
+    CHECK(reap(child)==0); close(sync[0]); close(sync[1]);
+    return 0;
+}
+static int run_test(void) {
+    CHECK(getpgrp() > 0); CHECK(getpgrp() == getpgid(0)); CHECK(getpgid(getpid()) == getpgrp());
+    errno=0; CHECK(getpgid(INT_MAX)==-1 && errno==ESRCH);
+    errno=0; CHECK(getpgid(-1)==-1 && errno==ESRCH);
+    errno=0; CHECK(setpgid(-1,0)==-1 && errno==EINVAL);
+    errno=0; CHECK(setpgid(0,-1)==-1 && errno==EINVAL);
+    errno=0; CHECK(setpgid(0,INT_MAX)==-1 && errno==EPERM);
+    errno=0; CHECK(setpgid(getppid(),0)==-1 && errno==ESRCH);
+    int ready[2], gate[2]; CHECK(pipe(ready)==0 && pipe(gate)==0);
+    pid_t child=fork(); CHECK(child>=0);
+    if(child==0){
+        char a[24], b[24]; snprintf(a,sizeof(a),"%d",ready[1]);snprintf(b,sizeof(b),"%d",gate[0]);
+        char *args[]={"/sbin/init","exec",a,b,NULL};execv(args[0],args);_exit(1);
+    }
+    char c; CHECK(read(ready[0],&c,1)==1);
+    errno=0; CHECK(setpgid(child,child)==-1 && errno==EACCES);
+    CHECK(write(gate[1],"x",1)==1); CHECK(reap(child)==0);
+    close(ready[0]);close(ready[1]);close(gate[0]);close(gate[1]);
+    /* Fork resets the exec marker, so the parent can assign a new group. */
+    CHECK(pipe(gate)==0);child=fork();CHECK(child>=0);
+    if(child==0){ char c; if(read(gate[0],&c,1)!=1)_exit(1);_exit(getpgrp()==getpid()?0:1); }
+    CHECK(setpgid(child,0)==0); CHECK(getpgid(child)==child);
+    CHECK(setpgid(0,child)==0); CHECK(getpgrp()==child);
+    CHECK(write(gate[1],"x",1)==1); CHECK(reap(child)==0);
+    close(gate[0]);close(gate[1]);
+    CHECK(setsid()==getpid());
+    errno=0;CHECK(setpgid(0,0)==-1 && errno==EPERM);
+    puts("TEST pgrp: queries, parent/child groups, sessions and exec checks passed");
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    setbuf(stdout, NULL);
+    if (argc > 1) return exec_child(argc, argv);
+    if (getpid() != 1) return run_test();
+    int serial = open("/dev/com1", O_WRONLY);
+    if (serial >= 0) { dup2(serial, 1); dup2(serial, 2); close(serial); }
+    puts("TEST START");
+    pid_t worker = fork();
+    if (worker == 0) _exit(run_test());
+    int failed = worker < 0 || reap(worker) != 0;
+    printf("TEST RESULT: %s\n", failed ? "FAIL" : "PASS");
+    for (;;) sleep(1);
+}


### PR DESCRIPTION
The amd64 Linux ABI lacks `getpgrp`, `getpgid`, and `setpgid`. BusyBox ash needs these calls to compare its process group with the PTY foreground group and initialize an interactive desktop terminal.

Add syscall entries 109, 111, and 121 using the process group's existing `pgid`/`sid` fields. Validate PID/group selectors, restrict changes to the caller or its children, enforce session/group constraints, and protect table lookups with the process-table lock.

Track successful amd64 exec transitions with a per-process flag so a parent cannot change an already-execed child's group (`EACCES`). A newly forked process starts with that flag clear; a process can still change its own group after exec. This matches the relevant [setpgid API rules](https://man7.org/linux/man-pages/man2/setpgid.2.html).

Validation on upstream `3720d0f`:

- The same guest test fails on unmodified upstream `3720d0f` at its first positive process-group-ID check.
- Built amd64 production and debug kernels using V `64604901c85377322d9d65455355986f30056513` and Clang/LLVM 18.
- Ran the included regression in an isolated QEMU/KVM guest with this PR alone: group queries, invalid selectors, nonexistent groups, parent/child group changes, joining an existing group, session-leader rejection, parent rejection after child exec, self changes after exec, and resetting the exec marker on fork.
- Interactive desktop shell startup was tested with the separate console, poll, and kill fixes applied together.

`tests/amd64-pgrp/` contains the guest test and instructions. This enables these three calls; it does not claim complete POSIX job control (for example, group-selecting `waitpid` and full Linux signal dispatch remain separate work). The ARM64 syscall implementation is unchanged.

Related independent fixes for the amd64 native desktop: #174, #175, #177. Each branch targets master directly and can be reviewed separately.
