### PR TITLE
amd64: validate kill selectors and support process groups

### DIFF
--- a/kernel/modules/userland/userland.v
+++ b/kernel/modules/userland/userland.v
@@ -432,21 +432,53 @@ pub fn sendsig(_thread &proc.Thread, signal u8) {
 	sched.enqueue_thread(t, true)
 }
 
+// Validate process/group selectors before accessing the process table. BusyBox
+// uses kill(0, SIGTTIN) during job-control setup, and kill(pid, 0) to probe PIDs.
 pub fn syscall_kill(_ voidptr, pid int, signal int) (u64, u64) {
-	mut current_thread := proc.current_thread()
-	mut process := current_thread.process
-
-	C.printf(c'\n\e[32m%s\e[m: kill(%d, %d)\n', process.name.str, pid, signal)
-	defer {
-		C.printf(c'\e[32m%s\e[m: returning\n', process.name.str)
+	if signal < 0 || signal >= 64 {
+		return errno.err, errno.einval
 	}
-
-	if signal > 0 {
-		sendsig(processes[pid].threads[0], u8(signal))
-	} else {
-		panic('sendsig: Values of signal <= 0 not supported')
+	current := proc.current_thread().process
+	group := if pid == 0 { i64(current.pgid) } else { -i64(pid) }
+	mut found := false
+	mut allowed := false
+	proc.lock_table()
+	defer { proc.unlock_table() }
+	for i := 1; i < proc.max_pid; i++ {
+		mut target := proc.process_at(i)
+		if target == unsafe { nil } {
+			continue
+		}
+		if pid > 0 && target.pid != pid {
+			continue
+		}
+		if pid == -1 && (target.pid == 1 || target.pid == current.pid) {
+			continue
+		}
+		if pid <= 0 && pid != -1 && i64(target.pgid) != group {
+			continue
+		}
+		found = true
+		if current.euid != 0 && current.uid != target.uid && current.uid != target.suid
+			&& current.euid != target.uid && current.euid != target.suid
+			&& !(signal == sigcont && current.sid == target.sid) {
+			continue
+		}
+		allowed = true
+		if signal != 0 && !target.exiting {
+			target.threads_lock.acquire()
+			if target.threads.len > 0 {
+				sendsig(target.threads[0], u8(signal))
+			}
+			target.threads_lock.release()
+		}
 	}
-
+	if !found {
+		return errno.err, errno.esrch
+	}
+	if !allowed {
+		return errno.err, errno.eperm
+	}
 	return 0, 0
 }
 
@@ -552,6 +584,11 @@ pub fn syscall_exit(_ voidptr, status int) {
 	defer {
 		C.printf(c'\e[32m%s\e[m: returning\n', current_process.name.str)
 	}
+
+	// Keep kill from waking a thread after its process starts teardown.
+	proc.lock_table()
+	current_process.exiting = true
+	proc.unlock_table()
 
 	// A framebuffer owner can exit without issuing a console ioctl. Restore
 	// the saved text console before its address space and descriptors vanish.

--- a/tests/amd64-kill/README.md
+++ b/tests/amd64-kill/README.md
@@ -1,0 +1,16 @@
+# amd64 kill guest regression
+
+Compile with an x86_64 musl toolchain:
+
+```sh
+musl-gcc -static -O2 -Wall -Wextra -Werror tests/amd64-kill/test.c -o init
+mkdir -p test-root/sbin
+cp init test-root/sbin/init
+tar --format=ustar -cf test-initramfs.tar -C test-root .
+VINIX_AMD64_INITRAMFS="$PWD/test-initramfs.tar" \
+VINIX_AMD64_ISO="$PWD/test-kill.iso" ./build-support/build-amd64-iso.sh
+```
+
+Build the amd64 kernel first (`./build-amd64.sh --no-userland --no-iso`). Boot the diagnostic ISO in an isolated QEMU/KVM x86_64 guest with UEFI, VGA, HPET, and COM1 serial capture. The init forks a test worker and prints `TEST RESULT: PASS` or `FAIL` on COM1. It then sleeps; terminate only the test VM from the host. Use a host-side timeout to detect a kernel crash or blocked syscall. The process-group test re-execs `/sbin/init`, so retain that installation path. Do not run these guest tests on the host.
+
+The positive-signal checks verify PID/group selection through interruption of a wait. They do not claim Linux signal-handler dispatch: amd64 currently requires the native `sigentry`, which the Linux ABI does not install. A musl `sigaction(SIGUSR1, ...)` followed by `kill(getpid(), SIGUSR1)` queues the signal but does not invoke the handler on the tested upstream revision. Completing Linux signal frames/dispatch is a separate change. Credential denial cases cannot be exercised from this Linux ABI because amd64 does not expose the credential-changing syscalls yet.

--- a/tests/amd64-kill/test.c
+++ b/tests/amd64-kill/test.c
@@ -1,0 +1,63 @@
+/* Guest regression test: static Linux/musl x86_64 executable.
+ * Can run as /sbin/init in an isolated Vinix VM or as a normal guest program. */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+#define CHECK(x) do { if (!(x)) { printf("FAIL line %d: %s errno=%d\n", __LINE__, #x, errno); return 1; } } while (0)
+static int reap(pid_t child) {
+    int status = -1;
+    CHECK(waitpid(child, &status, 0) == child);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    return 0;
+}
+static int exec_child(int argc, char **argv) { (void)argc; (void)argv; return 1; }
+static int run_test(void) {
+    CHECK(setsid()==getpid()); /* isolate actual group signals from init */
+    CHECK(kill(getpid(),0)==0);CHECK(kill(0,0)==0);CHECK(kill(-getpid(),0)==0);
+    errno=0;CHECK(kill(INT_MAX,0)==-1 && errno==ESRCH);
+    errno=0;CHECK(kill(INT_MIN,0)==-1 && errno==ESRCH);
+    errno=0;CHECK(kill(getpid(),-1)==-1 && errno==EINVAL);
+    errno=0;CHECK(kill(getpid(),64)==-1 && errno==EINVAL);
+    /* Linux callback dispatch is not wired to amd64 sigentry yet. Check
+     * that the selected thread is queued and its wait is interrupted. */
+    pid_t selectors[]={getpid(),0,-getpid()};
+    for (unsigned i=0;i<sizeof(selectors)/sizeof(selectors[0]);i++) {
+        CHECK(kill(selectors[i],SIGUSR1)==0);
+        struct timespec delay={0,10000000};errno=0;
+        CHECK(nanosleep(&delay,NULL)==-1 && errno==EINTR);
+    }
+    int gate[2];CHECK(pipe(gate)==0);pid_t child=fork();CHECK(child>=0);
+    if(child==0){char c; if(read(gate[0],&c,1)!=1)_exit(1);_exit(0);}
+    CHECK(kill(child,0)==0);CHECK(kill(-1,0)==0);
+    CHECK(write(gate[1],"x",1)==1);
+    usleep(50000); /* leave a zombie before waitpid */
+    CHECK(kill(child,0)==0);CHECK(kill(child,SIGUSR1)==0);
+    CHECK(reap(child)==0);errno=0;CHECK(kill(child,0)==-1 && errno==ESRCH);
+    close(gate[0]);close(gate[1]);
+    puts("TEST kill: signal-zero, PID/group wakeups, invalid selectors and zombies passed");
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    setbuf(stdout, NULL);
+    if (argc > 1) return exec_child(argc, argv);
+    if (getpid() != 1) return run_test();
+    int serial = open("/dev/com1", O_WRONLY);
+    if (serial >= 0) { dup2(serial, 1); dup2(serial, 2); close(serial); }
+    puts("TEST START");
+    pid_t worker = fork();
+    if (worker == 0) _exit(run_test());
+    int failed = worker < 0 || reap(worker) != 0;
+    printf("TEST RESULT: %s\n", failed ? "FAIL" : "PASS");
+    for (;;) sleep(1);
+}


### PR DESCRIPTION
On amd64, `kill` indexes `processes[pid].threads[0]` without validating the PID and panics for signal 0. BusyBox ash can call `kill(0, SIGTTIN)` while setting up terminal job control; during desktop testing this produced a kernel NULL-pointer fault in `syscall_kill`.

Resolve positive PIDs and the `0`, `-1`, and negative process-group selectors under the process-table lock. Widen before negating a PID so `INT_MIN` is safe. Validate the signal range supported by the amd64 bitmap, implement signal-zero existence/permission probes, apply UID/session permission checks, and avoid accessing an empty thread list. Mark amd64 processes as exiting before teardown so a signal to an unreaped zombie does not requeue its dying thread.

Validation on upstream `3720d0f`:

- The same guest test on unmodified upstream `3720d0f` panics at the first signal-zero probe: `sendsig: Values of signal <= 0 not supported`.
- Built amd64 production and debug kernels using V `64604901c85377322d9d65455355986f30056513` and Clang/LLVM 18.
- Ran `tests/amd64-kill/` in an isolated QEMU/KVM guest with this PR alone: PID/group signal-zero probes, positive-signal wait interruption for self/current-group/explicit-group selectors, invalid PID/signal values, `INT_MIN`, `kill(-1, 0)`, and probes/signals to an unreaped child followed by an `ESRCH` check after reaping.
- Tested native desktop terminal startup with the complementary console, poll, and process-group changes applied.

Scope: this fixes target selection and safe queuing through the existing `sendsig` path. The Linux ABI currently does not install the native amd64 `sigentry`, so musl signal-handler callbacks are not delivered; the test checks interrupted waits rather than claiming full Linux callback delivery. Non-root denial paths were reviewed but not exercised: the amd64 Linux table does not expose credential-changing syscalls yet. Full Linux signal frames, capability semantics, and complete job control are outside this change.

Related independent fixes for the amd64 native desktop: #174, #175, #176. Each branch targets master directly and can be reviewed separately.
