### PR TITLE
memory: reclaimable bitmap slabs and checked heap arithmetic (draft)

### DIFF
--- a/kernel/modules/klock/klock_amd64.v
+++ b/kernel/modules/klock/klock_amd64.v
@@ -24,8 +24,11 @@ pub fn (mut l Lock) acquire() {
 }
 
 pub fn (mut l Lock) release() {
+	// Snapshot before unlocking: another CPU can then overwrite l.ints.
+	// Keep the same ordering as the ARM64 implementation.
+	ints := l.ints
 	katomic.store(mut &l.l, false)
-	cpu.interrupt_toggle(l.ints)
+	cpu.interrupt_toggle(ints)
 }
 
 pub fn (mut l Lock) test_and_acquire() bool {

--- a/kernel/modules/memory/heap_selftest.v
+++ b/kernel/modules/memory/heap_selftest.v
@@ -1,0 +1,96 @@
+@[manualfree]
+module memory
+
+import lib
+
+// Boot-time tests of the actual allocator, enabled with -d heap_selftest.
+// Run before SMP startup; free-page snapshots assume no concurrent clients.
+fn heap_test_require(ok bool) {
+	if !ok {
+		lib.kpanic(unsafe { nil }, c'Heap self-test failed')
+	}
+}
+
+fn heap_test_bytes(ptr voidptr, size u64, value u8) {
+	unsafe {
+		bytes := &u8(ptr)
+		for i := u64(0); i < size; i++ {
+			heap_test_require(bytes[i] == value)
+		}
+	}
+}
+
+fn heap_selftest() {
+	heap_trim()
+	baseline := free_bytes()
+	for mut slab in slabs {
+		capacity := (page_size - slab_data_offset()) / slab.ent_size
+		count := capacity * 2 + 1
+		heap_test_require(count <= 512)
+		mut objects := [512]voidptr{}
+		for i := u64(0); i < count; i++ {
+			ptr := slab.alloc()
+			heap_test_require(ptr != unsafe { nil } && u64(ptr) % slab_alignment == 0)
+			for j := u64(0); j < i; j++ {
+				heap_test_require(objects[int(j)] != ptr)
+			}
+			heap_test_bytes(ptr, slab.ent_size, 0)
+			unsafe { C.memset(ptr, int(i % 251 + 1), slab.ent_size) }
+			objects[int(i)] = ptr
+		}
+		for i := u64(0); i < count; i += 2 {
+			slab.sfree(objects[int(i)])
+		}
+		for i := u64(1); i < count; i += 2 {
+			heap_test_bytes(objects[int(i)], slab.ent_size, u8(i % 251 + 1))
+			slab.sfree(objects[int(i)])
+		}
+		// All but one empty page must have been returned automatically.
+		heap_test_require(free_bytes() == baseline - page_size)
+		heap_test_require(heap_trim() == page_size)
+		heap_test_require(free_bytes() == baseline)
+	}
+
+	// Every slab boundary, including zero and the transition to big_alloc.
+	for mut slab in slabs {
+		for delta := u64(0); delta < 3; delta++ {
+			size := slab.ent_size - 1 + delta
+			ptr := malloc(size)
+			heap_test_require(ptr != unsafe { nil } && u64(ptr) % slab_alignment == 0)
+			heap_test_bytes(ptr, size, 0)
+			free(ptr)
+		}
+	}
+	zero := malloc(0)
+	heap_test_require(zero != unsafe { nil })
+	free(zero)
+	free(unsafe { nil })
+
+	old := malloc(17)
+	unsafe { C.memset(old, 0x5a, 17) }
+	grown := realloc(old, 65)
+	heap_test_require(grown != unsafe { nil })
+	heap_test_bytes(grown, 17, 0x5a)
+	heap_test_require(realloc(grown, u64(-1)) == unsafe { nil })
+	heap_test_bytes(grown, 17, 0x5a)
+	free(grown)
+
+	big := malloc(page_size + 1)
+	unsafe { C.memset(big, 0x6b, page_size + 1) }
+	bigger := realloc(big, 2 * page_size + 1)
+	heap_test_require(bigger != unsafe { nil })
+	heap_test_bytes(bigger, page_size + 1, 0x6b)
+	heap_test_require(realloc(bigger, u64(-1)) == unsafe { nil })
+	heap_test_bytes(bigger, page_size + 1, 0x6b)
+	free(bigger)
+
+	cleared := calloc(7, 13)
+	heap_test_require(cleared != unsafe { nil })
+	heap_test_bytes(cleared, 91, 0)
+	free(cleared)
+	heap_test_require(calloc(u64(1) << 63, 2) == unsafe { nil })
+	heap_test_require(malloc(u64(-1)) == unsafe { nil })
+	heap_trim()
+	heap_test_require(free_bytes() == baseline)
+	C.printf(c'heap: self-test passed\n')
+}

--- a/kernel/modules/memory/physical.v
+++ b/kernel/modules/memory/physical.v
@@ -163,16 +163,25 @@ pub fn pmm_init() {
 	}
 	print_free()
 
-	// Initialise slabs
-	slabs[0].init(8)
-	slabs[1].init(16)
-	slabs[2].init(32)
+	// Size classes are initialized without allocating backing pages.
+	slabs[0].init(16)
+	slabs[1].init(32)
+	slabs[2].init(48)
 	slabs[3].init(64)
-	slabs[4].init(128)
-	slabs[5].init(256)
-	slabs[6].init(512)
-	slabs[7].init(1024)
-	slabs[8].init(2048)
+	slabs[4].init(96)
+	slabs[5].init(128)
+	slabs[6].init(192)
+	slabs[7].init(256)
+	slabs[8].init(384)
+	slabs[9].init(512)
+	slabs[10].init(768)
+	slabs[11].init(1024)
+	slabs[12].init(1536)
+	slabs[13].init(2048)
+
+	$if heap_selftest ? {
+		heap_selftest()
+	}
 }
 
 fn inner_alloc(count u64, limit u64) voidptr {
@@ -345,83 +354,8 @@ pub fn pmm_free(ptr voidptr, count u64) {
 	free_pages += count
 }
 
-pub struct Slab {
-mut:
-	@lock      klock.Lock
-	first_free u64
-	ent_size   u64
-}
-
-struct SlabHeader {
-mut:
-	slab &Slab
-}
-
-pub fn (mut this Slab) init(ent_size u64) {
-	this.ent_size = ent_size
-	this.first_free = u64(pmm_alloc_nozero(1))
-	this.first_free += higher_half
-
-	avl_size := page_size - lib.align_up(sizeof(SlabHeader), ent_size)
-	mut slabptr := unsafe { &SlabHeader(this.first_free) }
-	unsafe {
-		(*slabptr).slab = this
-	}
-	this.first_free += lib.align_up(sizeof(SlabHeader), ent_size)
-
-	mut arr := unsafe { &u64(this.first_free) }
-	max := avl_size / ent_size - 1
-	fact := ent_size / 8
-	for i := u64(0); i < max; i++ {
-		unsafe {
-			arr[i * fact] = u64(&arr[(i + 1) * fact])
-		}
-	}
-
-	unsafe {
-		arr[max * fact] = u64(0)
-	}
-}
-
-pub fn (mut this Slab) alloc() voidptr {
-	this.@lock.acquire()
-	defer {
-		this.@lock.release()
-	}
-
-	if this.first_free == 0 {
-		this.init(this.ent_size)
-	}
-
-	mut old_free := unsafe { &u64(this.first_free) }
-	this.first_free = *old_free
-
-	unsafe { C.memset(voidptr(old_free), 0, this.ent_size) }
-
-	return voidptr(old_free)
-}
-
-pub fn (mut this Slab) sfree(ptr voidptr) {
-	this.@lock.acquire()
-	defer {
-		this.@lock.release()
-	}
-
-	if ptr == unsafe { nil } {
-		return
-	}
-
-	unsafe { C.memset(ptr, 0xaa, this.ent_size) }
-
-	mut new_head := unsafe { &u64(ptr) }
-	unsafe {
-		*new_head = this.first_free
-	}
-	this.first_free = u64(new_head)
-}
-
 __global (
-	slabs [9]Slab
+	slabs [14]Slab
 )
 
 struct MallocMetadata {
@@ -436,13 +370,17 @@ pub fn free(ptr voidptr) {
 		return
 	}
 
-	if u64(ptr) & u64(0xfff) == 0 {
+	if u64(ptr) & (page_size - 1) == 0 {
 		big_free(ptr)
 		return
 	}
 
-	mut slab_hdr := unsafe { &SlabHeader(u64(ptr) & ~u64(0xfff)) }
+	mut slab_hdr := unsafe { &SlabHeader(u64(ptr) & ~(page_size - 1)) }
 
+	if slab_hdr.magic != slab_magic {
+		lib.kpanic(unsafe { nil }, c'Slab: invalid free')
+		return
+	}
 	slab_hdr.slab.sfree(ptr)
 }
 
@@ -470,6 +408,10 @@ pub fn malloc(size u64) voidptr {
 }
 
 fn big_alloc(size u64) voidptr {
+	// Include the metadata page without overflowing rounding or byte counts.
+	if size > (u64(-1) / page_size - 1) * page_size {
+		return unsafe { nil }
+	}
 	page_count := lib.div_roundup(size, page_size)
 
 	ptr := pmm_alloc(page_count + 1)
@@ -492,15 +434,22 @@ pub fn realloc(ptr voidptr, new_size u64) voidptr {
 		return malloc(new_size)
 	}
 
-	if u64(ptr) & u64(0xfff) == 0 {
+	if u64(ptr) & (page_size - 1) == 0 {
 		return big_realloc(ptr, new_size)
 	}
 
-	slab_hdr := unsafe { &SlabHeader(u64(ptr) & ~u64(0xfff)) }
+	slab_hdr := unsafe { &SlabHeader(u64(ptr) & ~(page_size - 1)) }
+	if slab_hdr.magic != slab_magic {
+		lib.kpanic(unsafe { nil }, c'Slab: invalid realloc')
+		return unsafe { nil }
+	}
 	mut slab := slab_hdr.slab
 
 	if new_size > slab.ent_size {
 		mut new_ptr := malloc(new_size)
+		if new_ptr == unsafe { nil } {
+			return unsafe { nil }
+		}
 		unsafe { C.memcpy(new_ptr, ptr, slab.ent_size) }
 		slab.sfree(ptr)
 		return new_ptr
@@ -510,6 +459,9 @@ pub fn realloc(ptr voidptr, new_size u64) voidptr {
 }
 
 fn big_realloc(ptr voidptr, new_size u64) voidptr {
+	if new_size > (u64(-1) / page_size - 1) * page_size {
+		return unsafe { nil }
+	}
 	mut metadata := unsafe { &MallocMetadata(u64(ptr) - page_size) }
 
 	if lib.div_roundup(metadata.size, page_size) == lib.div_roundup(new_size, page_size) {
@@ -535,5 +487,8 @@ fn big_realloc(ptr voidptr, new_size u64) voidptr {
 
 @[export: 'calloc']
 pub fn calloc(a u64, b u64) voidptr {
+	if b != 0 && a > u64(-1) / b {
+		return unsafe { nil }
+	}
 	return unsafe { malloc(a * b) }
 }

--- a/kernel/modules/memory/slab.v
+++ b/kernel/modules/memory/slab.v
@@ -1,0 +1,246 @@
+@[has_globals; manualfree]
+module memory
+
+import klock
+import lib
+
+// Independent implementation for Vinix; no XNU implementation is copied.
+// Each size class has a list of nonempty, nonfull pages and at most one
+// empty spare page. Full pages are reached through their objects' headers.
+// Allocation bits live in the header, never in freed object payloads.
+// Headers remain in the same writable page: this is NOT metadata isolation
+// or XNU's virtual-address/type sequestering.
+const slab_magic = u64(0x56494e4958534c42)
+const slab_alignment = u64(16)
+
+pub struct Slab {
+mut:
+	@lock    klock.Lock
+	ent_size u64
+	partial  u64
+	spare    u64
+}
+
+struct SlabHeader {
+mut:
+	slab     &Slab = unsafe { nil }
+	magic    u64
+	prev     u64
+	next     u64
+	capacity u64
+	in_use   u64
+	// 1 = allocated or unavailable tail slot; 0 = available.
+	used     [4]u64
+}
+
+fn slab_data_offset() u64 {
+	return lib.align_up(u64(sizeof(SlabHeader)), slab_alignment)
+}
+
+// Initialization is boot-only. Slab instances must not move after use.
+// Pages are acquired lazily, without recursing through malloc.
+pub fn (mut this Slab) init(ent_size u64) {
+	if ent_size == 0 || ent_size > page_size / 2 || this.ent_size != 0 {
+		lib.kpanic(unsafe { nil }, c'Slab: invalid initialization')
+		return
+	}
+	this.ent_size = lib.align_up(ent_size, slab_alignment)
+	capacity := (page_size - slab_data_offset()) / this.ent_size
+	if capacity == 0 || capacity > 256 {
+		lib.kpanic(unsafe { nil }, c'Slab: unsupported page geometry')
+	}
+}
+
+// All list and bitmap operations require this.@lock.
+fn (mut this Slab) add_partial(mut hdr SlabHeader) {
+	hdr.prev = 0
+	hdr.next = this.partial
+	if this.partial != 0 {
+		mut next := unsafe { &SlabHeader(this.partial) }
+		next.prev = u64(hdr)
+	}
+	this.partial = u64(hdr)
+}
+
+fn (mut this Slab) remove_partial(mut hdr SlabHeader) {
+	if hdr.prev == 0 {
+		this.partial = hdr.next
+	} else {
+		mut prev := unsafe { &SlabHeader(hdr.prev) }
+		prev.next = hdr.next
+	}
+	if hdr.next != 0 {
+		mut next := unsafe { &SlabHeader(hdr.next) }
+		next.prev = hdr.prev
+	}
+	hdr.prev = 0
+	hdr.next = 0
+}
+
+// The argument must contain a zero bit. Bounded binary bit search, in V.
+fn slab_first_zero(word u64) u64 {
+	mut bits := ~word
+	mut index := u64(0)
+	if bits & u64(0xffffffff) == 0 {
+		index += 32
+		bits >>= 32
+	}
+	if bits & u64(0xffff) == 0 {
+		index += 16
+		bits >>= 16
+	}
+	if bits & u64(0xff) == 0 {
+		index += 8
+		bits >>= 8
+	}
+	if bits & u64(0xf) == 0 {
+		index += 4
+		bits >>= 4
+	}
+	if bits & u64(3) == 0 {
+		index += 2
+		bits >>= 2
+	}
+	if bits & u64(1) == 0 {
+		index++
+	}
+	return index
+}
+
+fn (mut this Slab) grow() {
+	base := u64(pmm_alloc_nozero(1)) + higher_half
+	mut hdr := unsafe { &SlabHeader(base) }
+	unsafe {
+		C.memset(voidptr(hdr), 0, sizeof(SlabHeader))
+		hdr.slab = this
+	}
+	hdr.magic = slab_magic
+	hdr.capacity = (page_size - slab_data_offset()) / this.ent_size
+	for i := 0; i < 4; i++ {
+		hdr.used[i] = u64(-1)
+	}
+	for i := u64(0); i < hdr.capacity; i++ {
+		hdr.used[int(i / 64)] &= ~(u64(1) << (i % 64))
+	}
+	this.add_partial(mut hdr)
+}
+
+pub fn (mut this Slab) alloc() voidptr {
+	this.@lock.acquire()
+	if this.ent_size == 0 {
+		this.@lock.release()
+		lib.kpanic(unsafe { nil }, c'Slab: allocation before initialization')
+		return unsafe { nil }
+	}
+	if this.partial == 0 {
+		if this.spare != 0 {
+			mut spare := unsafe { &SlabHeader(this.spare) }
+			this.spare = 0
+			this.add_partial(mut spare)
+		} else {
+			// Existing lock order: slab -> PMM. The PMM does not use malloc.
+			this.grow()
+		}
+	}
+	mut hdr := unsafe { &SlabHeader(this.partial) }
+	mut slot := u64(256)
+	for i := 0; i < 4; i++ {
+		if hdr.used[i] != u64(-1) {
+			bit := slab_first_zero(hdr.used[i])
+			hdr.used[i] |= u64(1) << bit
+			slot = u64(i) * 64 + bit
+			break
+		}
+	}
+	if slot >= hdr.capacity {
+		this.@lock.release()
+		lib.kpanic(unsafe { nil }, c'Slab: corrupt allocation bitmap')
+		return unsafe { nil }
+	}
+	hdr.in_use++
+	if hdr.in_use == hdr.capacity {
+		this.remove_partial(mut hdr)
+	}
+	size := this.ent_size
+	ptr := voidptr(u64(hdr) + slab_data_offset() + slot * size)
+	this.@lock.release()
+
+	// The reserved slot keeps its page live. Zeroing need not hold the lock.
+	unsafe { C.memset(ptr, 0, size) }
+	return ptr
+}
+
+pub fn (mut this Slab) sfree(ptr voidptr) {
+	if ptr == unsafe { nil } {
+		return
+	}
+	this.@lock.acquire()
+	mut hdr := unsafe { &SlabHeader(u64(ptr) & ~(page_size - 1)) }
+	offset := u64(ptr) & (page_size - 1)
+	start := slab_data_offset()
+	if hdr.magic != slab_magic || hdr.slab != this || this.ent_size == 0 || offset < start {
+		this.@lock.release()
+		lib.kpanic(unsafe { nil }, c'Slab: invalid free header')
+		return
+	}
+	slot := (offset - start) / this.ent_size
+	if (offset - start) % this.ent_size != 0 || slot >= hdr.capacity {
+		this.@lock.release()
+		lib.kpanic(unsafe { nil }, c'Slab: invalid free alignment')
+		return
+	}
+	word := int(slot / 64)
+	bit := u64(1) << (slot % 64)
+	if hdr.used[word] & bit == 0 || hdr.in_use == 0 {
+		this.@lock.release()
+		lib.kpanic(unsafe { nil }, c'Slab: double free')
+		return
+	}
+	was_full := hdr.in_use == hdr.capacity
+	// Poison before publishing the slot as free.
+	unsafe { C.memset(ptr, 0xaa, this.ent_size) }
+	hdr.used[word] &= ~bit
+	hdr.in_use--
+	mut release_page := u64(0)
+	if hdr.in_use == 0 {
+		if !was_full {
+			this.remove_partial(mut hdr)
+		}
+		if this.spare == 0 {
+			this.spare = u64(hdr)
+		} else {
+			release_page = u64(hdr)
+			hdr.magic = 0
+		}
+	} else if was_full {
+		this.add_partial(mut hdr)
+	}
+	this.@lock.release()
+	if release_page != 0 {
+		// Detached and empty: no valid outstanding object can reference it.
+		pmm_free(voidptr(release_page - higher_half), 1)
+	}
+}
+
+// Return empty spare pages explicitly; excess empty pages are already
+// returned by sfree. Does not compact partially occupied pages. May be
+// called concurrently, but never while holding a slab or PMM lock.
+// Returns bytes released by this call, not a global free-memory snapshot.
+pub fn heap_trim() u64 {
+	mut released := u64(0)
+	for mut slab in slabs {
+		slab.@lock.acquire()
+		base := slab.spare
+		slab.spare = 0
+		if base != 0 {
+			mut hdr := unsafe { &SlabHeader(base) }
+			hdr.magic = 0
+		}
+		slab.@lock.release()
+		if base != 0 {
+			pmm_free(voidptr(base - higher_half), 1)
+			released += page_size
+		}
+	}
+	return released
+}

--- a/tests/memory/README.md
+++ b/tests/memory/README.md
@@ -1,0 +1,146 @@
+# Reclaimable Vinix heap: draft implementation and comparison
+
+## Status and provenance
+
+Prepared 2026-09-11 against Vinix commit
+`7c085707f535e498ff2ce9a6447d8a5b59844388`. The original `physical.v` and
+`klock_amd64.v` blobs were reconstructed from the GitHub connector and checked
+against Git blob hashes `f8b11f618825eefa39a32bc33e5b2e8af43a3e99` and
+`9dfd1a9c85549b011a9fe286b13ef0c2b4a7855e` respectively.
+
+This is an independent V implementation of familiar slab techniques, NOT a
+C-to-V translation of Apple's allocator. No XNU implementation is copied.
+XNU's inspected `zalloc.c` carries APSL 2.0 terms; Vinix carries GPL v2.
+Source translation must not be treated as permission to discard the original
+license. A literal import needs licensing review and suitable permissions.
+
+**Draft, not production-validated:** ten Python model/source-check tests passed,
+including 100,000 mixed-size operations. `git diff --check` passed. No V compiler
+or QEMU was installed in the authoring environment; the V kernel was not compiled
+or booted there. The Python model is not execution of the V implementation and
+is not an SMP, weak-memory-ordering, or interrupt-safety test. The supplied V boot
+self-test has not been run there. No latency or throughput result is claimed.
+
+## Comparison with XNU
+
+Reference: Apple's public XNU commit
+`f6217f891ac0bb64f3d375211650a4c1ff8ca1ea` (import named `xnu-12377.1.9`). This
+pins the inspected source; it is not a claim that every Apple shipping kernel
+uses exactly that revision or configuration.
+
+Vinix currently allocates physical pages with a globally locked bitmap scan.
+Its heap uses nine classes, 8 through 2048 bytes in powers of two. Each class
+has one lock and an intrusive free-object chain. Slab pages never return to the
+PMM. Larger heap objects use contiguous physical pages plus a whole metadata
+page. Page allocations, kernel virtual mappings, and heap objects are distinct
+layers; replacing the small-object heap does not replace the other two.
+
+XNU's zone layer tracks allocation state and page/chunk occupancy, can reclaim
+empty backing, and offers per-CPU magazines, depots, and batched circulation.
+Its cache design explicitly depends on preemption control. General allocations
+also involve kalloc heaps and, on the relevant paths, type-based segregation.
+VM-backed allocations use Mach VM facilities rather than Vinix's direct PMM
+path. The zone source imports scheduling, locks, VM, pmap, diagnostics and
+security infrastructure: it is not a self-contained malloc.c to translate.
+
+These are substantial architectural advantages in reclaimability, scalability
+and hardening, not evidence of a measured speedup on Vinix. A small, uncontended
+intrusive allocator can have a shorter fast path. XNU itself cites Bonwick and
+Adams' magazine design and FreeBSD UMA in its cache description.
+
+Primary references:
+
+- Vinix heap and PMM: https://github.com/vlang/vinix/blob/7c085707f535e498ff2ce9a6447d8a5b59844388/kernel/modules/memory/physical.v
+- XNU zone implementation, including cache design near lines 250-370: https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/osfmk/kern/zalloc.c
+- Apple's allocator architecture and type-isolation explanation: https://security.apple.com/blog/towards-the-next-generation-of-xnu-memory-safety/
+- Existing ARM64 interrupt-state snapshot: https://github.com/vlang/vinix/blob/7c085707f535e498ff2ce9a6447d8a5b59844388/kernel/modules/klock/klock_arm64.v
+
+## Implemented scope
+
+`slab.v` replaces the original Slab implementation, and `physical.v` wires it
+into the existing malloc/free/realloc/calloc entry points. Initialization is
+lazy, without heap allocation. The 14 classes are 16, 32, 48, 64, 96, 128, 192,
+256, 384, 512, 768, 1024, 1536 and 2048 bytes.
+
+Each page has an 80-byte header on the intended 64-bit layouts, including four
+64-bit allocation words. Payload begins at a 16-byte-aligned offset. Tail bits
+are permanently occupied. A partial-page list supports constant-time list
+changes; full pages need no list. Allocation checks at most four bitmap words
+and uses bounded bit search. Partial pages are preferred over an empty spare.
+
+When the last object is freed, at most one empty page is retained per class.
+Further empty pages are detached under the class lock and returned to the PMM
+after releasing it. `memory.heap_trim()` releases all currently observed spare
+pages, returning bytes released. It is not yet wired into an OOM callback.
+Idle spare retention is at most 14 * 4096 = 56 KiB when quiescent; temporary
+in-flight detached pages and partially occupied pages are outside that bound.
+
+Malloc zeroing and free poisoning remain. Allocation zeroing is outside the
+class lock, after the slot is marked live. Header and slot checks catch some
+invalid frees and double frees while the page is still owned by that slab.
+They do NOT establish arbitrary-pointer validation or reliable detection after
+address reuse. Headers share writable pages with objects, so this is not
+XNU-style protected/external metadata, type isolation, or VA sequestering.
+
+Additional fixes reject calloc multiplication and large-allocation rounding
+/metadata-page overflow; failed growing realloc keeps its original allocation.
+The x86 lock now snapshots interrupt state before publishing unlock, matching
+the ordering already used by Vinix's ARM64 lock.
+
+The physical allocator and virtual-memory implementation are otherwise
+unchanged. Infallible PMM exhaustion still panics. Large heap allocations still
+need contiguous physical backing and the extra metadata page. Realloc-zero
+behavior is retained rather than imposing a new API contract.
+
+## Tradeoffs and work not included
+
+Intermediate size classes reduce rounding for some requests (for example,
+65 bytes uses a 96-byte class rather than 128). This is geometry, not a measured
+workload result. The larger header reduces object density in existing classes;
+small allocations now consume at least 16 bytes instead of 8. More classes can
+increase partially occupied-page fragmentation. One cached spare avoids PMM
+churn in single-object reuse but does not eliminate burst-induced churn.
+
+There are no per-CPU magazines, cross-CPU return queues, allocator reserves,
+NOWAIT semantics, type-aware heaps, separate metadata mappings, guard pages,
+or a noncontiguous VM-backed large-object allocator in this patch. Adding
+magazines requires retaining page liveness for every cached object and draining
+caches before reclamation; otherwise a speed optimization can introduce UAF.
+
+## Validation
+
+From a complete patched Vinix checkout:
+
+```sh
+python3 tests/memory/heap_model_test.py
+```
+
+The model checks all size classes across several pages, full/partial/empty
+transitions including one-slot pages, partial-before-spare selection, payload
+zeroing/poisoning, resident-page invalid/double frees, tail bits, arithmetic
+bounds, x86 snapshot source order, and mixed-size churn. It deliberately models
+an abstract PMM rather than claiming to execute the kernel PMM.
+
+Build the actual kernel in debug and production with the repository's toolchain
+and dependencies. Enable the boot tests by adding `VFLAGS='-d heap_selftest'`
+to the kernel make invocation. For example, using the native Linux CI flags:
+
+```sh
+# V must name an already built V compiler by absolute path.
+cd kernel
+./get-deps
+make PROD=false V="$V" VFLAGS='-d heap_selftest' \
+  CFLAGS='-Ulinux -U__linux -U__linux__ -U__gnu_linux__ -D__vinix__ -O2 -g -pipe'
+```
+
+This is a validation recipe, not a recorded successful build. Boot the resulting
+image through the repository's normal image workflow. The expected successful
+serial marker is `heap: self-test passed`. The self-test runs from pmm_init
+before SMP startup; its free-page comparisons require no concurrent clients.
+It exercises the actual V allocator and allocation API, not the Python model.
+
+Before merge, also boot both x86_64 and ARM64, run SMP allocation/free on different
+CPUs, interrupt-heavy workloads, concurrent trimming, and OOM/fragmentation
+stress. Compare identical workloads against the pinned base using throughput,
+p50/p99 latency, lock contention, peak pages, and pages retained after churn.
+Do not enable production deployment based on the Python model alone.

--- a/tests/memory/heap_model_test.py
+++ b/tests/memory/heap_model_test.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Executable specification, NOT a test of compiled V or kernel concurrency.
+
+Models the slab.v list/bitmap transitions with an abstract PMM. Source checks
+keep geometry and size classes aligned with the implementation. The separate
+V boot self-test exercises actual kernel code when a kernel can be built.
+"""
+from __future__ import annotations
+
+import ctypes
+from dataclasses import dataclass, field
+from pathlib import Path
+import random
+import re
+import unittest
+
+PAGE = 4096
+MASK = (1 << 64) - 1
+CLASSES = (16, 32, 48, 64, 96, 128, 192, 256, 384, 512, 768, 1024, 1536, 2048)
+
+
+class HeaderLayout(ctypes.Structure):
+    _fields_ = [(name, ctypes.c_uint64) for name in
+                ('slab', 'magic', 'prev', 'next', 'capacity', 'in_use')]
+    _fields_.append(('used', ctypes.c_uint64 * 4))
+
+
+OFFSET = (ctypes.sizeof(HeaderLayout) + 15) & ~15
+
+
+def first_zero(word: int) -> int:
+    bits = (~word) & MASK
+    if not bits:
+        raise ValueError('requires a zero bit')
+    index = 0
+    for shift in (32, 16, 8, 4, 2):
+        if bits & ((1 << shift) - 1) == 0:
+            index += shift
+            bits >>= shift
+    if bits & 1 == 0:
+        index += 1
+    return index
+
+
+@dataclass
+class Page:
+    base: int
+    size: int
+    prev: int = 0
+    next: int = 0
+    count: int = 0
+    bits: list[int] = field(default_factory=lambda: [MASK] * 4)
+    payload: bytearray = field(default_factory=lambda: bytearray([0xAA] * PAGE))
+
+    @property
+    def capacity(self) -> int:
+        return (PAGE - OFFSET) // self.size
+
+    def __post_init__(self) -> None:
+        for slot in range(self.capacity):
+            self.bits[slot // 64] &= ~(1 << (slot % 64))
+
+
+class PMM:
+    def __init__(self) -> None:
+        self.pages: dict[int, Page] = {}
+        self.returned: list[int] = []
+        self.next_base = PAGE
+        self.allocations = 0
+        self.frees = 0
+
+    def alloc(self, size: int) -> Page:
+        if self.returned:
+            base = self.returned.pop()
+        else:
+            base = self.next_base
+            self.next_base += PAGE
+        page = Page(base, size)
+        self.pages[base] = page
+        self.allocations += 1
+        return page
+
+    def free(self, page: Page) -> None:
+        assert page.count == 0
+        assert self.pages.pop(page.base) is page
+        self.returned.append(page.base)
+        self.frees += 1
+
+
+class Slab:
+    def __init__(self, pmm: PMM, size: int) -> None:
+        self.pmm, self.size = pmm, size
+        self.partial = self.spare = 0
+        self.owned: set[int] = set()
+        self.live: set[int] = set()
+
+    def add(self, page: Page) -> None:
+        page.prev, page.next = 0, self.partial
+        if self.partial:
+            self.pmm.pages[self.partial].prev = page.base
+        self.partial = page.base
+
+    def remove(self, page: Page) -> None:
+        if page.prev == 0:
+            self.partial = page.next
+        else:
+            self.pmm.pages[page.prev].next = page.next
+        if page.next:
+            self.pmm.pages[page.next].prev = page.prev
+        page.prev = page.next = 0
+
+    def alloc(self) -> int:
+        if not self.partial:
+            if self.spare:
+                page = self.pmm.pages[self.spare]
+                self.spare = 0
+            else:
+                page = self.pmm.alloc(self.size)
+                self.owned.add(page.base)
+            self.add(page)
+        page = self.pmm.pages[self.partial]
+        for i, word in enumerate(page.bits):
+            if word != MASK:
+                bit = first_zero(word)
+                page.bits[i] |= 1 << bit
+                slot = i * 64 + bit
+                break
+        else:
+            raise AssertionError('no slot on a partial page')
+        assert slot < page.capacity
+        page.count += 1
+        if page.count == page.capacity:
+            self.remove(page)
+        address = page.base + OFFSET + slot * self.size
+        assert address not in self.live and address % 16 == 0
+        self.live.add(address)
+        offset = address - page.base
+        page.payload[offset:offset + self.size] = bytes(self.size)
+        return address
+
+    def free(self, address: int) -> None:
+        if not address:
+            return
+        base, offset = address & ~(PAGE - 1), address & (PAGE - 1)
+        if base not in self.owned or offset < OFFSET:
+            raise ValueError('invalid header')
+        page = self.pmm.pages[base]
+        slot, remainder = divmod(offset - OFFSET, self.size)
+        if remainder or slot >= page.capacity:
+            raise ValueError('invalid alignment')
+        word, bit = slot // 64, 1 << (slot % 64)
+        if page.bits[word] & bit == 0 or page.count == 0:
+            raise ValueError('double free')
+        full = page.count == page.capacity
+        page.payload[offset:offset + self.size] = bytes([0xAA]) * self.size
+        page.bits[word] &= ~bit
+        page.count -= 1
+        self.live.remove(address)
+        if page.count == 0:
+            if not full:
+                self.remove(page)
+            if not self.spare:
+                self.spare = base
+            else:
+                self.owned.remove(base)
+                self.pmm.free(page)
+        elif full:
+            self.add(page)
+
+    def trim(self) -> int:
+        if not self.spare:
+            return 0
+        base, self.spare = self.spare, 0
+        self.owned.remove(base)
+        self.pmm.free(self.pmm.pages[base])
+        return PAGE
+
+    def check(self) -> None:
+        linked: set[int] = set()
+        base, prev = self.partial, 0
+        while base:
+            assert base not in linked
+            linked.add(base)
+            page = self.pmm.pages[base]
+            assert page.prev == prev and 0 < page.count < page.capacity
+            prev, base = base, page.next
+        expected_partial: set[int] = set()
+        expected_live: set[int] = set()
+        for base in self.owned:
+            page = self.pmm.pages[base]
+            assert 0 <= page.count <= page.capacity
+            active = 0
+            for slot in range(256):
+                used = bool(page.bits[slot // 64] & (1 << (slot % 64)))
+                if slot >= page.capacity:
+                    assert used, 'tail slot became available'
+                elif used:
+                    active += 1
+                    expected_live.add(base + OFFSET + slot * self.size)
+            assert active == page.count
+            if page.count == 0:
+                assert base == self.spare and page.prev == page.next == 0
+            elif page.count < page.capacity:
+                expected_partial.add(base)
+            else:
+                assert page.prev == page.next == 0
+        assert linked == expected_partial
+        assert self.live == expected_live
+        if self.spare:
+            assert self.spare in self.owned
+
+
+class HeapModelTests(unittest.TestCase):
+    def test_source_geometry_and_classes(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        source = (root / 'kernel/modules/memory/physical.v').read_text()
+        sizes = tuple(map(int, re.findall(r'slabs\[\d+\]\.init\((\d+)\)', source)))
+        self.assertEqual(sizes, CLASSES)
+        self.assertEqual(OFFSET, 80)
+        slab = (root / 'kernel/modules/memory/slab.v').read_text()
+        self.assertRegex(slab, r'used\s+\[4\]u64')
+        self.assertIn('const slab_alignment = u64(16)', slab)
+        for size in CLASSES:
+            self.assertEqual(size % 16, 0)
+            self.assertTrue(1 <= (PAGE - OFFSET) // size <= 256)
+
+    def test_bit_search_all_positions_and_random_words(self) -> None:
+        for bit in range(64):
+            self.assertEqual(first_zero(MASK ^ (1 << bit)), bit)
+        rng = random.Random(12345)
+        for _ in range(20000):
+            word = rng.getrandbits(64)
+            if word != MASK:
+                free = (~word) & MASK
+                self.assertEqual(first_zero(word), (free & -free).bit_length() - 1)
+
+    def test_all_classes_multi_page_lifecycle(self) -> None:
+        for size in CLASSES:
+            with self.subTest(size=size):
+                pmm = PMM()
+                slab = Slab(pmm, size)
+                capacity = (PAGE - OFFSET) // size
+                objects = [slab.alloc() for _ in range(3 * capacity + 1)]
+                self.assertEqual(len(pmm.pages), 4)
+                slab.check()
+                for address in objects[::2] + objects[1::2]:
+                    slab.free(address)
+                    slab.check()
+                self.assertEqual(len(pmm.pages), 1)
+                self.assertEqual(slab.trim(), PAGE)
+                self.assertEqual(slab.trim(), 0)
+                slab.check()
+                self.assertFalse(pmm.pages)
+                self.assertEqual(pmm.allocations, pmm.frees)
+
+    def test_single_slot_full_to_empty(self) -> None:
+        pmm, size = PMM(), 2048
+        slab = Slab(pmm, size)
+        a, b = slab.alloc(), slab.alloc()
+        slab.free(a)
+        slab.free(b)
+        slab.check()
+        self.assertEqual(len(pmm.pages), 1)
+        self.assertEqual(slab.alloc(), a)
+        slab.check()
+
+    def test_partial_preferred_to_spare(self) -> None:
+        pmm = PMM()
+        slab = Slab(pmm, 1024)
+        objects = [slab.alloc() for _ in range(7)]
+        slab.free(objects[6])  # third page becomes spare
+        slab.free(objects[1])  # first page becomes partial
+        self.assertEqual(slab.alloc(), objects[1])
+        self.assertNotEqual(slab.spare, 0)
+        slab.check()
+
+    def test_payload_poison_and_zero_on_reuse(self) -> None:
+        pmm = PMM()
+        slab = Slab(pmm, 64)
+        a, keeper = slab.alloc(), slab.alloc()
+        page = pmm.pages[a & ~(PAGE - 1)]
+        offset = a % PAGE
+        page.payload[offset:offset + 64] = bytes([0x13]) * 64
+        slab.free(a)
+        self.assertEqual(page.payload[offset:offset + 64], bytes([0xAA]) * 64)
+        self.assertEqual(slab.alloc(), a)
+        self.assertEqual(page.payload[offset:offset + 64], bytes(64))
+        slab.free(a)
+        slab.free(keeper)
+        slab.check()
+
+    def test_invalid_and_double_free_on_resident_page(self) -> None:
+        slab = Slab(PMM(), 64)
+        a, keeper = slab.alloc(), slab.alloc()
+        for bad in (a + 1, a - 1, a & ~(PAGE - 1)):
+            with self.assertRaises(ValueError):
+                slab.free(bad)
+        slab.free(a)
+        with self.assertRaises(ValueError):
+            slab.free(a)
+        slab.free(keeper)
+        slab.check()
+
+    def test_random_mixed_size_churn(self) -> None:
+        rng, pmm = random.Random(0x584E55), PMM()
+        slabs = [Slab(pmm, size) for size in CLASSES]
+        live: list[tuple[Slab, int]] = []
+        for i in range(100000):
+            if not live or (len(live) < 2048 and rng.random() < .52):
+                slab = rng.choice(slabs)
+                live.append((slab, slab.alloc()))
+            else:
+                index = rng.randrange(len(live))
+                slab, address = live[index]
+                live[index] = live[-1]
+                live.pop()
+                slab.free(address)
+            if i % 251 == 0:
+                rng.choice(slabs).trim()
+                for slab in slabs:
+                    slab.check()
+        rng.shuffle(live)
+        for slab, address in live:
+            slab.free(address)
+        self.assertLessEqual(len(pmm.pages), len(CLASSES))
+        for slab in slabs:
+            slab.trim()
+            slab.check()
+        self.assertFalse(pmm.pages)
+        self.assertEqual(pmm.allocations, pmm.frees)
+
+    def test_arithmetic_guards(self) -> None:
+        def checked_product(a: int, b: int) -> int | None:
+            return None if b and a > MASK // b else a * b
+        self.assertIsNone(checked_product(1 << 63, 2))
+        self.assertEqual(checked_product(MASK, 0), 0)
+        self.assertEqual(checked_product(7, 13), 91)
+        maximum = (MASK // PAGE - 1) * PAGE
+        for value in (0, 1, 2049, maximum - 1, maximum):
+            pages = (value + PAGE - 1) // PAGE
+            self.assertLessEqual((pages + 1) * PAGE, MASK)
+        self.assertGreater(((maximum + 1 + PAGE - 1) // PAGE + 1) * PAGE, MASK)
+        root = Path(__file__).resolve().parents[2]
+        source = (root / 'kernel/modules/memory/physical.v').read_text()
+        self.assertIn('if b != 0 && a > u64(-1) / b', source)
+        self.assertIn('if new_ptr == unsafe { nil }', source)
+        self.assertEqual(source.count('(u64(-1) / page_size - 1) * page_size'), 2)
+
+    def test_irq_snapshot_source_order(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        source = (root / 'kernel/modules/klock/klock_amd64.v').read_text()
+        release = source.split('pub fn (mut l Lock) release() {', 1)[1].split('\n}', 1)[0]
+        self.assertLess(release.index('ints := l.ints'), release.index('katomic.store'))
+        self.assertIn('cpu.interrupt_toggle(ints)', release)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Independent V-native allocator improvement, informed by a comparison of Vinix `7c085707f535e498ff2ce9a6447d8a5b59844388` and Apple's public XNU `f6217f891ac0bb64f3d375211650a4c1ff8ca1ea` (`xnu-12377.1.9`). **This is not a C-to-V XNU port; no XNU implementation is copied.** XNU's inspected allocator carries APSL 2.0 terms, while Vinix carries GPL v2, and a literal import would require licensing review and suitable permissions.

- Replace the non-reclaiming intrusive slab free list with per-page allocation bitmaps and partial-page lists; retain one empty spare per class and return additional empty pages to the PMM.
- Add `memory.heap_trim()` for explicit spare reclamation, lazy initialization, intermediate size classes and 16-byte alignment. Preserve allocation zeroing and free poisoning; move allocation zeroing outside the class lock after reserving the slot.
- Check calloc multiplication and large-allocation arithmetic; retain the original allocation when growing realloc returns nil. Fix the amd64 unlock interrupt-state snapshot ordering to match ARM64.
- Add an opt-in V boot self-test (`-d heap_selftest`), executable Python model/source checks, and a detailed comparison/validation note in `tests/memory/README.md`.

## Validation actually performed

- `git diff --check`: passed.
- Patch applies to the exact pinned allocator input blobs; all six resulting files match the authored files.
- `python3 tests/memory/heap_model_test.py`: **10 tests passed**, including 100,000 mixed-size operations, all 14 size classes, list/bitmap/tail-slot invariants, reclamation, payload zeroing/poisoning and arithmetic/source checks.

**The Python model does not execute the V implementation or model kernel concurrency. No V compiler or QEMU was available locally. V compilation, kernel boot, the supplied V self-test, SMP/interrupt/weak-memory-order tests and allocator performance measurements have NOT been performed.** No speedup is claimed.

## Scope and risks

The PMM and virtual-memory system are not replaced. No per-CPU magazines, type-aware heaps, external/protected metadata, guard pages, noncontiguous large-allocation mapping or automatic memory-pressure callback is implemented. Headers remain in writable slab pages. Checks catch some resident-page misuse, not arbitrary-pointer or stale-pointer-after-reuse attacks. Large allocations retain contiguous backing and a separate metadata page; infallible PMM exhaustion still panics.

The larger header and 16-byte minimum increase overhead for very small allocations; additional classes can increase partially occupied-page fragmentation. The quiescent empty-spare limit is 56 KiB, excluding partial and temporarily detached pages. Benchmarks against the pinned base are needed before drawing performance conclusions.

Keep this PR in draft until both architectures build and boot, actual V self-tests pass, concurrent allocation/free/trim and interrupt-heavy tests pass, and fragmentation/latency/throughput are measured. The default branch was not modified.