### PR TITLE
memory: XNU zone/cache translation and opt-in Vinix heap backend (draft)

### DIFF
--- a/.github/workflows/xnu-allocator-port.yml
+++ b/.github/workflows/xnu-allocator-port.yml
@@ -1,0 +1,47 @@
+name: XNU allocator translation tests
+
+on:
+  pull_request:
+    paths:
+      - 'kernel/modules/xnualloc/**'
+      - 'kernel/modules/memory/**'
+      - 'kernel/modules/**/smp/smp.v'
+      - 'tests/xnualloc/**'
+      - '.github/workflows/xnu-allocator-port.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  host-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Fetch pinned V 0.5.2 host toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --location --retry 3 \
+            https://github.com/vlang/v/releases/download/0.5.2/v_linux.zip \
+            -o "$RUNNER_TEMP/v_linux.zip"
+          echo "86caf9e70c3342d48ef19eb4f6c47b709f18c90ae86255520d5c29df6b482e23  $RUNNER_TEMP/v_linux.zip" | sha256sum -c -
+          mkdir -p "$RUNNER_TEMP/xnu-port-v"
+          unzip -q "$RUNNER_TEMP/v_linux.zip" -d "$RUNNER_TEMP/xnu-port-v"
+          chmod +x "$RUNNER_TEMP/xnu-port-v/v/v"
+          "$RUNNER_TEMP/xnu-port-v/v/v" version
+      - name: Retain verified toolchain for reproducing the host tests
+        uses: actions/upload-artifact@v4
+        with:
+          name: xnu-port-host-toolchain
+          path: ${{ runner.temp }}/v_linux.zip
+          retention-days: 1
+      - name: Actual V tests (debug and production)
+        shell: bash
+        run: |
+          set -euo pipefail
+          V="$RUNNER_TEMP/xnu-port-v/v/v"
+          "$V" -cc gcc -gc none -path "@vlib|@vmodules|$GITHUB_WORKSPACE/kernel/modules" test tests/xnualloc
+          "$V" -prod -cc gcc -gc none -path "@vlib|@vmodules|$GITHUB_WORKSPACE/kernel/modules" test tests/xnualloc

--- a/.github/workflows/xnu-allocator-port.yml
+++ b/.github/workflows/xnu-allocator-port.yml
@@ -38,6 +38,13 @@ jobs:
           name: xnu-port-host-toolchain
           path: ${{ runner.temp }}/v_linux.zip
           retention-days: 1
+      - name: Model and extracted C-reference checks (not V execution)
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tests/memory/heap_model_test.py
+          python3 tests/xnualloc/reference_test.py
+          python3 tests/xnualloc/zone_model_test.py
       - name: Actual V tests (debug and production)
         shell: bash
         run: |
@@ -45,3 +52,52 @@ jobs:
           V="$RUNNER_TEMP/xnu-port-v/v/v"
           "$V" -cc gcc -gc none -path "@vlib|@vmodules|$GITHUB_WORKSPACE/kernel/modules" test tests/xnualloc
           "$V" -prod -cc gcc -gc none -path "@vlib|@vmodules|$GITHUB_WORKSPACE/kernel/modules" test tests/xnualloc
+
+  kernel-smoke:
+    needs: host-tests
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: xnu-port-host-toolchain
+          path: ${{ runner.temp }}/xnu-port-archive
+      - name: Verify and unpack the pinned compiler
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/xnu-port-archive"
+          echo '86caf9e70c3342d48ef19eb4f6c47b709f18c90ae86255520d5c29df6b482e23  v_linux.zip' | sha256sum -c -
+          unzip -q v_linux.zip -d "$RUNNER_TEMP/xnu-port-v"
+          chmod +x "$RUNNER_TEMP/xnu-port-v/v/v"
+      - name: Install native and cross-build dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential clang lld llvm
+      - name: Fetch kernel dependencies
+        run: cd kernel && ./get-deps
+      - name: Build flag-off, bitmap-only and zone kernels (debug)
+        shell: bash
+        env:
+          TARGET_ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          V="$RUNNER_TEMP/xnu-port-v/v/v"
+          cd kernel
+          for mode in plain bitmap zone; do
+            # Heap flags are not part of the upstream make config stamp.
+            # Cleaning is mandatory when switching them.
+            make clean
+            flags='-d heap_selftest'
+            case "$mode" in
+              bitmap) flags="$flags -d xnu_bitmap" ;;
+              zone) flags="$flags -d xnu_zone" ;;
+            esac
+            make -j2 ARCH="$TARGET_ARCH" CC=clang AR=llvm-ar PROD=false \
+              V="$V" VFLAGS="$flags" \
+              CFLAGS='-Ulinux -U__linux -U__linux__ -U__gnu_linux__ -D__vinix__ -O2 -g -pipe'
+          done

--- a/docs/xnualloc/APPLE_LICENSE
+++ b/docs/xnualloc/APPLE_LICENSE
@@ -1,0 +1,367 @@
+APPLE PUBLIC SOURCE LICENSE
+Version 2.0 - August 6, 2003
+
+Please read this License carefully before downloading this software.
+By downloading or using this software, you are agreeing to be bound by
+the terms of this License. If you do not or cannot agree to the terms
+of this License, please do not download or use the software.
+
+1. General; Definitions. This License applies to any program or other
+work which Apple Computer, Inc. ("Apple") makes publicly available and
+which contains a notice placed by Apple identifying such program or
+work as "Original Code" and stating that it is subject to the terms of
+this Apple Public Source License version 2.0 ("License"). As used in
+this License:
+
+1.1 "Applicable Patent Rights" mean: (a) in the case where Apple is
+the grantor of rights, (i) claims of patents that are now or hereafter
+acquired, owned by or assigned to Apple and (ii) that cover subject
+matter contained in the Original Code, but only to the extent
+necessary to use, reproduce and/or distribute the Original Code
+without infringement; and (b) in the case where You are the grantor of
+rights, (i) claims of patents that are now or hereafter acquired,
+owned by or assigned to You and (ii) that cover subject matter in Your
+Modifications, taken alone or in combination with Original Code.
+
+1.2 "Contributor" means any person or entity that creates or
+contributes to the creation of Modifications.
+
+1.3 "Covered Code" means the Original Code, Modifications, the
+combination of Original Code and any Modifications, and/or any
+respective portions thereof.
+
+1.4 "Externally Deploy" means: (a) to sublicense, distribute or
+otherwise make Covered Code available, directly or indirectly, to
+anyone other than You; and/or (b) to use Covered Code, alone or as
+part of a Larger Work, in any way to provide a service, including but
+not limited to delivery of content, through electronic communication
+with a client other than You.
+
+1.5 "Larger Work" means a work which combines Covered Code or portions
+thereof with code not governed by the terms of this License.
+
+1.6 "Modifications" mean any addition to, deletion from, and/or change
+to, the substance and/or structure of the Original Code, any previous
+Modifications, the combination of Original Code and any previous
+Modifications, and/or any respective portions thereof. When code is
+released as a series of files, a Modification is: (a) any addition to
+or deletion from the contents of a file containing Covered Code;
+and/or (b) any new file or other representation of computer program
+statements that contains any part of Covered Code.
+
+1.7 "Original Code" means (a) the Source Code of a program or other
+work as originally made available by Apple under this License,
+including the Source Code of any updates or upgrades to such programs
+or works made available by Apple under this License, and that has been
+expressly identified by Apple as such in the header file(s) of such
+work; and (b) the object code compiled from such Source Code and
+originally made available by Apple under this License.
+
+1.8 "Source Code" means the human readable form of a program or other
+work that is suitable for making modifications to it, including all
+modules it contains, plus any associated interface definition files,
+scripts used to control compilation and installation of an executable
+(object code).
+
+1.9 "You" or "Your" means an individual or a legal entity exercising
+rights under this License. For legal entities, "You" or "Your"
+includes any entity which controls, is controlled by, or is under
+common control with, You, where "control" means (a) the power, direct
+or indirect, to cause the direction or management of such entity,
+whether by contract or otherwise, or (b) ownership of fifty percent
+(50%) or more of the outstanding shares or beneficial ownership of
+such entity.
+
+2. Permitted Uses; Conditions & Restrictions. Subject to the terms
+and conditions of this License, Apple hereby grants You, effective on
+the date You accept this License and download the Original Code, a
+world-wide, royalty-free, non-exclusive license, to the extent of
+Apple's Applicable Patent Rights and copyrights covering the Original
+Code, to do the following:
+
+2.1 Unmodified Code. You may use, reproduce, display, perform,
+internally distribute within Your organization, and Externally Deploy
+verbatim, unmodified copies of the Original Code, for commercial or
+non-commercial purposes, provided that in each instance:
+
+(a) You must retain and reproduce in all copies of Original Code the
+copyright and other proprietary notices and disclaimers of Apple as
+they appear in the Original Code, and keep intact all notices in the
+Original Code that refer to this License; and
+
+(b) You must include a copy of this License with every copy of Source
+Code of Covered Code and documentation You distribute or Externally
+Deploy, and You may not offer or impose any terms on such Source Code
+that alter or restrict this License or the recipients' rights
+hereunder, except as permitted under Section 6.
+
+2.2 Modified Code. You may modify Covered Code and use, reproduce,
+display, perform, internally distribute within Your organization, and
+Externally Deploy Your Modifications and Covered Code, for commercial
+or non-commercial purposes, provided that in each instance You also
+meet all of these conditions:
+
+(a) You must satisfy all the conditions of Section 2.1 with respect to
+the Source Code of the Covered Code;
+
+(b) You must duplicate, to the extent it does not already exist, the
+notice in Exhibit A in each file of the Source Code of all Your
+Modifications, and cause the modified files to carry prominent notices
+stating that You changed the files and the date of any change; and
+
+(c) If You Externally Deploy Your Modifications, You must make
+Source Code of all Your Externally Deployed Modifications either
+available to those to whom You have Externally Deployed Your
+Modifications, or publicly available. Source Code of Your Externally
+Deployed Modifications must be released under the terms set forth in
+this License, including the license grants set forth in Section 3
+below, for as long as you Externally Deploy the Covered Code or twelve
+(12) months from the date of initial External Deployment, whichever is
+longer. You should preferably distribute the Source Code of Your
+Externally Deployed Modifications electronically (e.g. download from a
+web site).
+
+2.3 Distribution of Executable Versions. In addition, if You
+Externally Deploy Covered Code (Original Code and/or Modifications) in
+object code, executable form only, You must include a prominent
+notice, in the code itself as well as in related documentation,
+stating that Source Code of the Covered Code is available under the
+terms of this License with information on how and where to obtain such
+Source Code.
+
+2.4 Third Party Rights. You expressly acknowledge and agree that
+although Apple and each Contributor grants the licenses to their
+respective portions of the Covered Code set forth herein, no
+assurances are provided by Apple or any Contributor that the Covered
+Code does not infringe the patent or other intellectual property
+rights of any other entity. Apple and each Contributor disclaim any
+liability to You for claims brought by any other entity based on
+infringement of intellectual property rights or otherwise. As a
+condition to exercising the rights and licenses granted hereunder, You
+hereby assume sole responsibility to secure any other intellectual
+property rights needed, if any. For example, if a third party patent
+license is required to allow You to distribute the Covered Code, it is
+Your responsibility to acquire that license before distributing the
+Covered Code.
+
+3. Your Grants. In consideration of, and as a condition to, the
+licenses granted to You under this License, You hereby grant to any
+person or entity receiving or distributing Covered Code under this
+License a non-exclusive, royalty-free, perpetual, irrevocable license,
+under Your Applicable Patent Rights and other intellectual property
+rights (other than patent) owned or controlled by You, to use,
+reproduce, display, perform, modify, sublicense, distribute and
+Externally Deploy Your Modifications of the same scope and extent as
+Apple's licenses under Sections 2.1 and 2.2 above.
+
+4. Larger Works. You may create a Larger Work by combining Covered
+Code with other code not governed by the terms of this License and
+distribute the Larger Work as a single product. In each such instance,
+You must make sure the requirements of this License are fulfilled for
+the Covered Code or any portion thereof.
+
+5. Limitations on Patent License. Except as expressly stated in
+Section 2, no other patent rights, express or implied, are granted by
+Apple herein. Modifications and/or Larger Works may require additional
+patent licenses from Apple which Apple may grant in its sole
+discretion.
+
+6. Additional Terms. You may choose to offer, and to charge a fee for,
+warranty, support, indemnity or liability obligations and/or other
+rights consistent with the scope of the license granted herein
+("Additional Terms") to one or more recipients of Covered Code.
+However, You may do so only on Your own behalf and as Your sole
+responsibility, and not on behalf of Apple or any Contributor. You
+must obtain the recipient's agreement that any such Additional Terms
+are offered by You alone, and You hereby agree to indemnify, defend
+and hold Apple and every Contributor harmless for any liability
+incurred by or claims asserted against Apple or such Contributor by
+reason of any such Additional Terms.
+
+7. Versions of the License. Apple may publish revised and/or new
+versions of this License from time to time. Each version will be given
+a distinguishing version number. Once Original Code has been published
+under a particular version of this License, You may continue to use it
+under the terms of that version. You may also choose to use such
+Original Code under the terms of any subsequent version of this
+License published by Apple. No one other than Apple has the right to
+modify the terms applicable to Covered Code created under this
+License.
+
+8. NO WARRANTY OR SUPPORT. The Covered Code may contain in whole or in
+part pre-release, untested, or not fully tested works. The Covered
+Code may contain errors that could cause failures or loss of data, and
+may be incomplete or contain inaccuracies. You expressly acknowledge
+and agree that use of the Covered Code, or any portion thereof, is at
+Your sole and entire risk. THE COVERED CODE IS PROVIDED "AS IS" AND
+WITHOUT WARRANTY, UPGRADES OR SUPPORT OF ANY KIND AND APPLE AND
+APPLE'S LICENSOR(S) (COLLECTIVELY REFERRED TO AS "APPLE" FOR THE
+PURPOSES OF SECTIONS 8 AND 9) AND ALL CONTRIBUTORS EXPRESSLY DISCLAIM
+ALL WARRANTIES AND/OR CONDITIONS, EXPRESS OR IMPLIED, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES AND/OR CONDITIONS OF
+MERCHANTABILITY, OF SATISFACTORY QUALITY, OF FITNESS FOR A PARTICULAR
+PURPOSE, OF ACCURACY, OF QUIET ENJOYMENT, AND NONINFRINGEMENT OF THIRD
+PARTY RIGHTS. APPLE AND EACH CONTRIBUTOR DOES NOT WARRANT AGAINST
+INTERFERENCE WITH YOUR ENJOYMENT OF THE COVERED CODE, THAT THE
+FUNCTIONS CONTAINED IN THE COVERED CODE WILL MEET YOUR REQUIREMENTS,
+THAT THE OPERATION OF THE COVERED CODE WILL BE UNINTERRUPTED OR
+ERROR-FREE, OR THAT DEFECTS IN THE COVERED CODE WILL BE CORRECTED. NO
+ORAL OR WRITTEN INFORMATION OR ADVICE GIVEN BY APPLE, AN APPLE
+AUTHORIZED REPRESENTATIVE OR ANY CONTRIBUTOR SHALL CREATE A WARRANTY.
+You acknowledge that the Covered Code is not intended for use in the
+operation of nuclear facilities, aircraft navigation, communication
+systems, or air traffic control machines in which case the failure of
+the Covered Code could lead to death, personal injury, or severe
+physical or environmental damage.
+
+9. LIMITATION OF LIABILITY. TO THE EXTENT NOT PROHIBITED BY LAW, IN NO
+EVENT SHALL APPLE OR ANY CONTRIBUTOR BE LIABLE FOR ANY INCIDENTAL,
+SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR RELATING
+TO THIS LICENSE OR YOUR USE OR INABILITY TO USE THE COVERED CODE, OR
+ANY PORTION THEREOF, WHETHER UNDER A THEORY OF CONTRACT, WARRANTY,
+TORT (INCLUDING NEGLIGENCE), PRODUCTS LIABILITY OR OTHERWISE, EVEN IF
+APPLE OR SUCH CONTRIBUTOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES AND NOTWITHSTANDING THE FAILURE OF ESSENTIAL PURPOSE OF ANY
+REMEDY. SOME JURISDICTIONS DO NOT ALLOW THE LIMITATION OF LIABILITY OF
+INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS LIMITATION MAY NOT APPLY
+TO YOU. In no event shall Apple's total liability to You for all
+damages (other than as may be required by applicable law) under this
+License exceed the amount of fifty dollars ($50.00).
+
+10. Trademarks. This License does not grant any rights to use the
+trademarks or trade names "Apple", "Apple Computer", "Mac", "Mac OS",
+"QuickTime", "QuickTime Streaming Server" or any other trademarks,
+service marks, logos or trade names belonging to Apple (collectively
+"Apple Marks") or to any trademark, service mark, logo or trade name
+belonging to any Contributor. You agree not to use any Apple Marks in
+or as part of the name of products derived from the Original Code or
+to endorse or promote products derived from the Original Code other
+than as expressly permitted by and in strict compliance at all times
+with Apple's third party trademark usage guidelines which are posted
+at http://www.apple.com/legal/guidelinesfor3rdparties.html.
+
+11. Ownership. Subject to the licenses granted under this License,
+each Contributor retains all rights, title and interest in and to any
+Modifications made by such Contributor. Apple retains all rights,
+title and interest in and to the Original Code and any Modifications
+made by or on behalf of Apple ("Apple Modifications"), and such Apple
+Modifications will not be automatically subject to this License. Apple
+may, at its sole discretion, choose to license such Apple
+Modifications under this License, or on different terms from those
+contained in this License or may choose not to license them at all.
+
+12. Termination.
+
+12.1 Termination. This License and the rights granted hereunder will
+terminate:
+
+(a) automatically without notice from Apple if You fail to comply with
+any term(s) of this License and fail to cure such breach within 30
+days of becoming aware of such breach;
+
+(b) immediately in the event of the circumstances described in Section
+13.5(b); or
+
+(c) automatically without notice from Apple if You, at any time during
+the term of this License, commence an action for patent infringement
+against Apple; provided that Apple did not first commence
+an action for patent infringement against You in that instance.
+
+12.2 Effect of Termination. Upon termination, You agree to immediately
+stop any further use, reproduction, modification, sublicensing and
+distribution of the Covered Code. All sublicenses to the Covered Code
+which have been properly granted prior to termination shall survive
+any termination of this License. Provisions which, by their nature,
+should remain in effect beyond the termination of this License shall
+survive, including but not limited to Sections 3, 5, 8, 9, 10, 11,
+12.2 and 13. No party will be liable to any other for compensation,
+indemnity or damages of any sort solely as a result of terminating
+this License in accordance with its terms, and termination of this
+License will be without prejudice to any other right or remedy of
+any party.
+
+13. Miscellaneous.
+
+13.1 Government End Users. The Covered Code is a "commercial item" as
+defined in FAR 2.101. Government software and technical data rights in
+the Covered Code include only those rights customarily provided to the
+public as defined in this License. This customary commercial license
+in technical data and software is provided in accordance with FAR
+12.211 (Technical Data) and 12.212 (Computer Software) and, for
+Department of Defense purchases, DFAR 252.227-7015 (Technical Data --
+Commercial Items) and 227.7202-3 (Rights in Commercial Computer
+Software or Computer Software Documentation). Accordingly, all U.S.
+Government End Users acquire Covered Code with only those rights set
+forth herein.
+
+13.2 Relationship of Parties. This License will not be construed as
+creating an agency, partnership, joint venture or any other form of
+legal association between or among You, Apple or any Contributor, and
+You will not represent to the contrary, whether expressly, by
+implication, appearance or otherwise.
+
+13.3 Independent Development. Nothing in this License will impair
+Apple's right to acquire, license, develop, have others develop for
+it, market and/or distribute technology or products that perform the
+same or similar functions as, or otherwise compete with,
+Modifications, Larger Works, technology or products that You may
+develop, produce, market or distribute.
+
+13.4 Waiver; Construction. Failure by Apple or any Contributor to
+enforce any provision of this License will not be deemed a waiver of
+future enforcement of that or any other provision. Any law or
+regulation which provides that the language of a contract shall be
+construed against the drafter will not apply to this License.
+
+13.5 Severability. (a) If for any reason a court of competent
+jurisdiction finds any provision of this License, or portion thereof,
+to be unenforceable, that provision of the License will be enforced to
+the maximum extent permissible so as to effect the economic benefits
+and intent of the parties, and the remainder of this License will
+continue in full force and effect. (b) Notwithstanding the foregoing,
+if applicable law prohibits or restricts You from fully and/or
+specifically complying with Sections 2 and/or 3 or prevents the
+enforceability of either of those Sections, this License will
+immediately terminate and You must immediately discontinue any use of
+the Covered Code and destroy all copies of it that are in your
+possession or control.
+
+13.6 Dispute Resolution. Any litigation or other dispute resolution
+between You and Apple relating to this License shall take place in the
+Northern District of California, and You and Apple hereby consent to
+the personal jurisdiction of, and venue in, the state and federal
+courts within that District with respect to this License. The
+application of the United Nations Convention on Contracts for the
+International Sale of Goods is expressly excluded.
+
+13.7 Entire Agreement; Governing Law. This License constitutes the
+entire agreement between the parties with respect to the subject
+matter hereof. This License shall be governed by the laws of the
+United States and the State of California, except that body of
+California law concerning conflicts of law.
+
+Where You are located in the province of Quebec, Canada, the following
+clause applies: The parties hereby confirm that they have requested
+that this License and all related documents be drafted in English. Les
+parties ont exige que le present contrat et tous les documents
+connexes soient rediges en anglais.
+
+EXHIBIT A.
+
+"Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+Reserved.
+
+This file contains Original Code and/or Modifications of Original Code
+as defined in and that are subject to the Apple Public Source License
+Version 2.0 (the 'License'). You may not use this file except in
+compliance with the License. Please obtain a copy of the License at
+http://www.opensource.apple.com/apsl/ and read it before using this
+file.
+
+The Original Code and all software distributed under the License are
+distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+Please see the License for the specific language governing rights and
+limitations under the License."

--- a/docs/xnualloc/NOTICES
+++ b/docs/xnualloc/NOTICES
@@ -1,0 +1,62 @@
+Retained notices for the translated source and supporting documentation.
+
+/*
+ * Copyright (c) 2000-2020 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/*
+ * @OSF_COPYRIGHT@
+ */
+/*
+ * Mach Operating System
+ * Copyright (c) 1991,1990,1989,1988,1987 Carnegie Mellon University
+ * All Rights Reserved.
+ *
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ *
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+ * CONDITION. CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+ * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ *
+ * Carnegie Mellon requests users of this software to return to
+ *
+ * Software Distribution Coordinator or Software.Distribution@CS.CMU.EDU
+ * School of Computer Science
+ * Carnegie Mellon University
+ * Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie Mellon
+ * the rights to redistribute these changes.
+ */
+
+Modified 2026-09-11: C-to-V translation and documented adaptations.
+Source: apple-oss-distributions/xnu f6217f891ac0bb64f3d375211650a4c1ff8ca1ea,
+osfmk/kern/zalloc.c. The exact upstream APPLE_LICENSE is included at
+kernel/modules/xnualloc/APPLE_LICENSE. These translations retain APSL 2.0.

--- a/docs/xnualloc/PORT_STATUS.md
+++ b/docs/xnualloc/PORT_STATUS.md
@@ -1,7 +1,149 @@
-# Experimental XNU allocator translation
+# XNU allocator translation and Vinix zone backend
 
-Source: apple-oss-distributions/xnu at f6217f891ac0bb64f3d375211650a4c1ff8ca1ea, osfmk/kern/zalloc.c (blob 0d79c2dd58f8eed4e8f80834fa1e3b9b43675eff).
+Updated 2026-09-11. Experimental continuation in draft PR #179. **This is an
+adapted, partial translation, not a completed transplant of every XNU allocator
+path or configuration. No V compilation, kernel boot, SMP stress or speedup is
+claimed.**
 
-This commit publishes the previously delivered bitmap, metadata-buddy, and magazine/depot translations. It does not enable them as the kernel heap. The original notices are retained in every translated file. The exact upstream APPLE_LICENSE is included alongside the code. Translation changes are marked 2026-09-11. These files remain under APSL 2.0, not GPL; this experimental branch makes no claim that a combined distribution is license-compatible.
+## Provenance
 
-This is not the complete XNU allocator. Kernel integration and additional zone state-machine tests are separate commits. Host CI downloads a checksum-pinned V toolchain and runs debug and production V tests. A workflow recipe is not a successful test result. No production readiness or performance improvement is claimed.
+Vinix base: `1dc68880818947654a69de85193d8800be0e4749` (PR #178), based on
+`7c085707f535e498ff2ce9a6447d8a5b59844388`. The new branch is
+`allocator/xnu-zone-port-2026-09-11`; master and PR #178 are unchanged.
+
+XNU source: `apple-oss-distributions/xnu` at
+`f6217f891ac0bb64f3d375211650a4c1ff8ca1ea` (`xnu-12377.1.9`), principally
+`osfmk/kern/zalloc.c`, blob `0d79c2dd58f8eed4e8f80834fa1e3b9b43675eff`.
+Source: https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/osfmk/kern/zalloc.c
+
+Apple and Carnegie Mellon notices are retained. The translated files retain
+APSL 2.0, not GPL. The exact upstream APPLE_LICENSE (blob
+`fe81a60cae982c042a69f97623b427666c455093`) accompanies source, tests and these
+documents. See NOTICES. This draft does not establish compatibility of a combined
+distribution or provide a license exception.
+
+## Translation coverage
+
+| XNU logic | Supplied V code | Status / adaptation |
+|---|---|---|
+| Packed zone page metadata; inline/reference bitmaps; rotating scans; initialization/merge/free; packed bitmap references | `xnualloc/bitmap.v` | Translated primitives. Explicit storage/length arguments and an exhaustion sentinel. |
+| Relative-index bitmap buddy free lists, split state, splitting/coalescing, two banks, extra tracking storage | `xnualloc/buddy.v` | Translated library for 4 KiB/16 KiB prebacked arenas. NOT the PMM and NOT live kernel bitmap backing. |
+| Full-prefix/empty-suffix depot lists, FIFO/LIFO moves, magazine swap/replacement, explicit SMR polling | `xnualloc/magazine.v` | Translated primitives used by the new ordinary-zone path. Fixed 32-element magazines. |
+| `zone_meta_queue_push`, remove/requeue, ordinary fully backed `zcram` | `xnualloc/zone.v` | Adapted to pointer-linked full/partial/empty chunk queues; no packed VA queue indices or partial VM population. |
+| `zalloc_import`, ordinary allocation dispatch and bitmap reservation | `Zone.zalloc_import`, `Zone.zalloc_ext` | Batch reservation and queue/counter transitions; caller supplies backing. Unavailable batches do not mutate state. |
+| `zfree_drop`, allocation/free validation and accounting | `Zone.zfree_drop`, `zone_mark_valid/invalid`, `zfree_ext` | Adds a distinct client-live bitmap. Cached objects remain bitmap-reserved until drained. |
+| Non-SMR cache prime, import, overflow, depot recirculation | `zalloc_cached_*`, `zfree_cached_*` | Adapted control flow with six fixed magazine containers per initialized CPU cache. No recursive magazine allocation. |
+| Element/cache draining and ordinary empty-chunk reclamation | `zone_reclaim_elements`, `zone_drain_cache`, `zone_drain_recirc`, `zone_reclaim_chunk` | Detach/account under one external lock; release backing outside the lock. No VA sequestering. |
+| Vinix small heap entry points and early/SMP registration | `memory/xnu_zone_heap*.v`, routing in `physical.v`/`slab.v`, both SMP initializers | Source-connected behind `-d xnu_zone`, but not compiled/boot-validated. |
+
+These are not byte-for-byte representations of XNU's full state. In particular,
+**recirculation objects stay reserved in this port** until an explicit drain;
+XNU's more elaborate bitmap/cache accounting is not reproduced wholesale.
+The non-SMR core exposes no success stubs for unsupported VM, grace periods,
+read-only mappings or security facilities.
+
+## Kernel behavior and synchronization contract
+
+`-d xnu_bitmap` selects only the earlier translated bitmap routines in the
+independent slab backend. `-d xnu_zone` instead routes small `malloc`, `free`,
+`realloc` and `heap_trim` through the new zone/cache state machine. Fourteen
+16-byte-aligned classes from 16 through 2048 bytes and one 4 KiB backing page per
+chunk are retained. Larger requests use Vinix's existing contiguous PMM-backed
+large allocation and page-aligned payload interface.
+
+**One interrupt-disabling class lock protects the zone, every CPU cache and both
+depot layers.** The per-CPU cache objects are real, but there is no lock-free or
+per-CPU-only fast path. This is a correctness-first adaptation, not XNU's scalable
+locking design. It can be slower than the original allocator. No performance
+improvement is asserted.
+
+CPU cache readiness is published with release ordering after SMP has installed
+all GS/TPIDR CPU numbers. Cache lookup uses an acquire load and never reads that
+CPU register before readiness. Logical CPU IDs 0 through 63 can use caches;
+others use the uncached path. ARM64 boot without SMP also remains uncached.
+This is not a CPU-hotplug/offline protocol. NMI/reentrant allocation while a
+class lock is held is not supported.
+
+Cache metadata is allocated lazily through the fallible PMM, never recursively
+through malloc. A new cache is attempted only when a payload slot is already
+available, preventing the last payload page from being spent on empty cache
+metadata. Failure to obtain metadata falls back to uncached allocation. The
+metadata is retained for the lifetime of the kernel, because magazine containers
+can migrate between depots. No cache-container teardown is implemented.
+
+The free path marks the client object invalid, poisons its payload, then
+publishes it to a magazine or zone bitmap, all under the class lock. A second
+client free is rejected while metadata is valid. `zfree_ext` itself is a trusted
+publication primitive: its caller must have just invalidated that object under
+the same lock, exactly once. It is not a general independently safe public free.
+Allocation reserves a live slot before unlocking and zeroing its payload.
+
+Cached objects pin their pages. Allocation drains all caches of a depleted
+class before requesting another page. `heap_trim()` drains every cache and the
+central depot, detaches empty pages into a private list, unlocks, and returns
+those pages to PMM. Valid client-live objects continue to pin their backing.
+Normal free retains one truly empty spare per class, but that limit does NOT
+bound cached payload, partially occupied pages or permanently retained cache
+metadata. Drain loops hold interrupts disabled for potentially long intervals;
+latency and pressure behavior need measurement. There is no automatic pressure
+callback, adaptive working-set/depot policy or cross-class OOM reclaim loop.
+
+Headers and bitmaps are still in writable payload backing. No guard mapping,
+protected metadata or type separation is supplied. Invalid/unmapped pointers
+may fault while their header is inspected; stale pointers after slot reuse are
+not reliably detected. The extra live bitmap is not a memory-safety guarantee.
+
+Without either feature flag the independent allocation algorithm is selected.
+The module imports and added source are still visible to the V compiler, so
+flag-off builds ALSO require validation; opt-in behavior is not a build-isolation
+guarantee.
+
+## Missing portions of the requested full port
+
+The complete `kalloc.c` dispatch, typed/variable heaps, type signatures and
+assignment policy remain untranslated. So do full zone creation/startup and
+configuration policy, permanent/per-CPU/read-only zones, SMR deferred frees,
+custom object-cache callbacks, guarded allocations, memory tagging/PAC,
+sanitisers, diagnostics and the working-set/adaptive-cache policy.
+
+Mach VM map/submap population, partially backed chunks, asynchronous expansion,
+waiter wakeup/NOFAIL/WAITOK semantics, VM pressure/jetsam, VA sequestering and
+large noncontiguous VM-backed allocations are NOT ported. The bridge uses
+Vinix PMM instead. It does not pretend to emulate those contracts.
+
+The full XNU split-lock/preemption protocol is also missing: introducing it
+requires a separate concurrency proof and tests. The existing single-lock
+core must not be called with only a CPU-local lock.
+
+## Validation and reproducibility
+
+Actually executed locally after these changes:
+
+- `python3 tests/memory/heap_model_test.py`: 10 tests passed, including 100,000
+  operations in the independent slab model and source checks.
+- `python3 tests/xnualloc/reference_test.py`: 4 tests passed. Builds extracted
+  C reference code with UndefinedBehaviorSanitizer and compares against models;
+  includes 12,000 bitmap cases and 40,000 mixed-order buddy operations.
+- `python3 tests/xnualloc/zone_model_test.py`: 6 tests passed, including 80,000
+  mixed operations at depot limits 0/1/2/4 with four logical CPU caches, ownership
+  and reclamation invariants, live survivors, duplicate frees and source hooks.
+- `git diff --check`: passed for the local continuation.
+
+**None of those tests executes V.** The protocol model is sequential under the
+one-lock assumption; it is not a hardware or weak-memory-order concurrency test.
+Eighteen actual V host test functions are supplied across `port_test.v`,
+`zone_test.v` and `smoke_test.v`, but have not run locally: no V compiler or QEMU
+was available. V/kernel GitHub Actions were queued at the last check during
+publication, not successful.
+
+CI pins the V 0.5.2 Linux archive by SHA-256, runs model/reference checks and
+runs the actual V tests in debug/production. Its recipe is not evidence of a
+successful result. Before merge, require flag-off, bitmap-only and zone-backend
+builds on both architectures; actual host tests; boot self-tests; concurrent
+cross-CPU allocation/free/drain with interrupt load; OOM/fault injection; and
+latency/throughput/retained-page measurements against the pinned base.
+
+The boot self-test now uses public malloc/free so it exercises the selected
+backend. It runs before SMP and does NOT test real CPU-cache registration.
+
+See `tests/xnualloc/README.md` for exact commands. Keep PR #179 in draft.

--- a/docs/xnualloc/PORT_STATUS.md
+++ b/docs/xnualloc/PORT_STATUS.md
@@ -1,0 +1,7 @@
+# Experimental XNU allocator translation
+
+Source: apple-oss-distributions/xnu at f6217f891ac0bb64f3d375211650a4c1ff8ca1ea, osfmk/kern/zalloc.c (blob 0d79c2dd58f8eed4e8f80834fa1e3b9b43675eff).
+
+This commit publishes the previously delivered bitmap, metadata-buddy, and magazine/depot translations. It does not enable them as the kernel heap. The original notices are retained in every translated file. The exact upstream APPLE_LICENSE is included alongside the code. Translation changes are marked 2026-09-11. These files remain under APSL 2.0, not GPL; this experimental branch makes no claim that a combined distribution is license-compatible.
+
+This is not the complete XNU allocator. Kernel integration and additional zone state-machine tests are separate commits. Host CI downloads a checksum-pinned V toolchain and runs debug and production V tests. A workflow recipe is not a successful test result. No production readiness or performance improvement is claimed.

--- a/kernel/modules/aarch64/smp/smp.v
+++ b/kernel/modules/aarch64/smp/smp.v
@@ -88,6 +88,8 @@ pub fn initialise(max_cpus u64) {
 		logical_cpu++
 	}
 
+	// All GS/TPIDR CPU numbers are now installed; publish cache readiness.
+	memory.heap_enable_cpu_caches(u64(cpu_locals.len))
 	smp_ready = true
 
 	println('smp: ${logical_cpu} CPUs online')

--- a/kernel/modules/klock/klock_amd64.v
+++ b/kernel/modules/klock/klock_amd64.v
@@ -24,8 +24,11 @@ pub fn (mut l Lock) acquire() {
 }
 
 pub fn (mut l Lock) release() {
+	// Snapshot before unlocking: another CPU can then overwrite l.ints.
+	// Keep the same ordering as the ARM64 implementation.
+	ints := l.ints
 	katomic.store(mut &l.l, false)
-	cpu.interrupt_toggle(l.ints)
+	cpu.interrupt_toggle(ints)
 }
 
 pub fn (mut l Lock) test_and_acquire() bool {

--- a/kernel/modules/memory/heap_selftest.v
+++ b/kernel/modules/memory/heap_selftest.v
@@ -24,12 +24,16 @@ fn heap_selftest() {
 	heap_trim()
 	baseline := free_bytes()
 	for mut slab in slabs {
-		capacity := (page_size - slab_data_offset()) / slab.ent_size
+		mut offset := slab_data_offset()
+		$if xnu_zone ? {
+			offset = lib.align_up(u64(sizeof(XnuHeapHeader)), 16)
+		}
+		capacity := (page_size - offset) / slab.ent_size
 		count := capacity * 2 + 1
 		heap_test_require(count <= 512)
 		mut objects := [512]voidptr{}
 		for i := u64(0); i < count; i++ {
-			ptr := slab.alloc()
+			ptr := malloc(slab.ent_size)
 			heap_test_require(ptr != unsafe { nil } && u64(ptr) % slab_alignment == 0)
 			for j := u64(0); j < i; j++ {
 				heap_test_require(objects[int(j)] != ptr)
@@ -39,11 +43,11 @@ fn heap_selftest() {
 			objects[int(i)] = ptr
 		}
 		for i := u64(0); i < count; i += 2 {
-			slab.sfree(objects[int(i)])
+			free(objects[int(i)])
 		}
 		for i := u64(1); i < count; i += 2 {
 			heap_test_bytes(objects[int(i)], slab.ent_size, u8(i % 251 + 1))
-			slab.sfree(objects[int(i)])
+			free(objects[int(i)])
 		}
 		// All but one empty page must have been returned automatically.
 		heap_test_require(free_bytes() == baseline - page_size)

--- a/kernel/modules/memory/heap_selftest.v
+++ b/kernel/modules/memory/heap_selftest.v
@@ -1,0 +1,96 @@
+@[manualfree]
+module memory
+
+import lib
+
+// Boot-time tests of the actual allocator, enabled with -d heap_selftest.
+// Run before SMP startup; free-page snapshots assume no concurrent clients.
+fn heap_test_require(ok bool) {
+	if !ok {
+		lib.kpanic(unsafe { nil }, c'Heap self-test failed')
+	}
+}
+
+fn heap_test_bytes(ptr voidptr, size u64, value u8) {
+	unsafe {
+		bytes := &u8(ptr)
+		for i := u64(0); i < size; i++ {
+			heap_test_require(bytes[i] == value)
+		}
+	}
+}
+
+fn heap_selftest() {
+	heap_trim()
+	baseline := free_bytes()
+	for mut slab in slabs {
+		capacity := (page_size - slab_data_offset()) / slab.ent_size
+		count := capacity * 2 + 1
+		heap_test_require(count <= 512)
+		mut objects := [512]voidptr{}
+		for i := u64(0); i < count; i++ {
+			ptr := slab.alloc()
+			heap_test_require(ptr != unsafe { nil } && u64(ptr) % slab_alignment == 0)
+			for j := u64(0); j < i; j++ {
+				heap_test_require(objects[int(j)] != ptr)
+			}
+			heap_test_bytes(ptr, slab.ent_size, 0)
+			unsafe { C.memset(ptr, int(i % 251 + 1), slab.ent_size) }
+			objects[int(i)] = ptr
+		}
+		for i := u64(0); i < count; i += 2 {
+			slab.sfree(objects[int(i)])
+		}
+		for i := u64(1); i < count; i += 2 {
+			heap_test_bytes(objects[int(i)], slab.ent_size, u8(i % 251 + 1))
+			slab.sfree(objects[int(i)])
+		}
+		// All but one empty page must have been returned automatically.
+		heap_test_require(free_bytes() == baseline - page_size)
+		heap_test_require(heap_trim() == page_size)
+		heap_test_require(free_bytes() == baseline)
+	}
+
+	// Every slab boundary, including zero and the transition to big_alloc.
+	for mut slab in slabs {
+		for delta := u64(0); delta < 3; delta++ {
+			size := slab.ent_size - 1 + delta
+			ptr := malloc(size)
+			heap_test_require(ptr != unsafe { nil } && u64(ptr) % slab_alignment == 0)
+			heap_test_bytes(ptr, size, 0)
+			free(ptr)
+		}
+	}
+	zero := malloc(0)
+	heap_test_require(zero != unsafe { nil })
+	free(zero)
+	free(unsafe { nil })
+
+	old := malloc(17)
+	unsafe { C.memset(old, 0x5a, 17) }
+	grown := realloc(old, 65)
+	heap_test_require(grown != unsafe { nil })
+	heap_test_bytes(grown, 17, 0x5a)
+	heap_test_require(realloc(grown, u64(-1)) == unsafe { nil })
+	heap_test_bytes(grown, 17, 0x5a)
+	free(grown)
+
+	big := malloc(page_size + 1)
+	unsafe { C.memset(big, 0x6b, page_size + 1) }
+	bigger := realloc(big, 2 * page_size + 1)
+	heap_test_require(bigger != unsafe { nil })
+	heap_test_bytes(bigger, page_size + 1, 0x6b)
+	heap_test_require(realloc(bigger, u64(-1)) == unsafe { nil })
+	heap_test_bytes(bigger, page_size + 1, 0x6b)
+	free(bigger)
+
+	cleared := calloc(7, 13)
+	heap_test_require(cleared != unsafe { nil })
+	heap_test_bytes(cleared, 91, 0)
+	free(cleared)
+	heap_test_require(calloc(u64(1) << 63, 2) == unsafe { nil })
+	heap_test_require(malloc(u64(-1)) == unsafe { nil })
+	heap_trim()
+	heap_test_require(free_bytes() == baseline)
+	C.printf(c'heap: self-test passed\n')
+}

--- a/kernel/modules/memory/physical.v
+++ b/kernel/modules/memory/physical.v
@@ -163,16 +163,25 @@ pub fn pmm_init() {
 	}
 	print_free()
 
-	// Initialise slabs
-	slabs[0].init(8)
-	slabs[1].init(16)
-	slabs[2].init(32)
+	// Size classes are initialized without allocating backing pages.
+	slabs[0].init(16)
+	slabs[1].init(32)
+	slabs[2].init(48)
 	slabs[3].init(64)
-	slabs[4].init(128)
-	slabs[5].init(256)
-	slabs[6].init(512)
-	slabs[7].init(1024)
-	slabs[8].init(2048)
+	slabs[4].init(96)
+	slabs[5].init(128)
+	slabs[6].init(192)
+	slabs[7].init(256)
+	slabs[8].init(384)
+	slabs[9].init(512)
+	slabs[10].init(768)
+	slabs[11].init(1024)
+	slabs[12].init(1536)
+	slabs[13].init(2048)
+
+	$if heap_selftest ? {
+		heap_selftest()
+	}
 }
 
 fn inner_alloc(count u64, limit u64) voidptr {
@@ -345,83 +354,8 @@ pub fn pmm_free(ptr voidptr, count u64) {
 	free_pages += count
 }
 
-pub struct Slab {
-mut:
-	@lock      klock.Lock
-	first_free u64
-	ent_size   u64
-}
-
-struct SlabHeader {
-mut:
-	slab &Slab
-}
-
-pub fn (mut this Slab) init(ent_size u64) {
-	this.ent_size = ent_size
-	this.first_free = u64(pmm_alloc_nozero(1))
-	this.first_free += higher_half
-
-	avl_size := page_size - lib.align_up(sizeof(SlabHeader), ent_size)
-	mut slabptr := unsafe { &SlabHeader(this.first_free) }
-	unsafe {
-		(*slabptr).slab = this
-	}
-	this.first_free += lib.align_up(sizeof(SlabHeader), ent_size)
-
-	mut arr := unsafe { &u64(this.first_free) }
-	max := avl_size / ent_size - 1
-	fact := ent_size / 8
-	for i := u64(0); i < max; i++ {
-		unsafe {
-			arr[i * fact] = u64(&arr[(i + 1) * fact])
-		}
-	}
-
-	unsafe {
-		arr[max * fact] = u64(0)
-	}
-}
-
-pub fn (mut this Slab) alloc() voidptr {
-	this.@lock.acquire()
-	defer {
-		this.@lock.release()
-	}
-
-	if this.first_free == 0 {
-		this.init(this.ent_size)
-	}
-
-	mut old_free := unsafe { &u64(this.first_free) }
-	this.first_free = *old_free
-
-	unsafe { C.memset(voidptr(old_free), 0, this.ent_size) }
-
-	return voidptr(old_free)
-}
-
-pub fn (mut this Slab) sfree(ptr voidptr) {
-	this.@lock.acquire()
-	defer {
-		this.@lock.release()
-	}
-
-	if ptr == unsafe { nil } {
-		return
-	}
-
-	unsafe { C.memset(ptr, 0xaa, this.ent_size) }
-
-	mut new_head := unsafe { &u64(ptr) }
-	unsafe {
-		*new_head = this.first_free
-	}
-	this.first_free = u64(new_head)
-}
-
 __global (
-	slabs [9]Slab
+	slabs [14]Slab
 )
 
 struct MallocMetadata {
@@ -436,13 +370,17 @@ pub fn free(ptr voidptr) {
 		return
 	}
 
-	if u64(ptr) & u64(0xfff) == 0 {
+	if u64(ptr) & (page_size - 1) == 0 {
 		big_free(ptr)
 		return
 	}
 
-	mut slab_hdr := unsafe { &SlabHeader(u64(ptr) & ~u64(0xfff)) }
+	mut slab_hdr := unsafe { &SlabHeader(u64(ptr) & ~(page_size - 1)) }
 
+	if slab_hdr.magic != slab_magic {
+		lib.kpanic(unsafe { nil }, c'Slab: invalid free')
+		return
+	}
 	slab_hdr.slab.sfree(ptr)
 }
 
@@ -470,6 +408,10 @@ pub fn malloc(size u64) voidptr {
 }
 
 fn big_alloc(size u64) voidptr {
+	// Include the metadata page without overflowing rounding or byte counts.
+	if size > (u64(-1) / page_size - 1) * page_size {
+		return unsafe { nil }
+	}
 	page_count := lib.div_roundup(size, page_size)
 
 	ptr := pmm_alloc(page_count + 1)
@@ -492,15 +434,22 @@ pub fn realloc(ptr voidptr, new_size u64) voidptr {
 		return malloc(new_size)
 	}
 
-	if u64(ptr) & u64(0xfff) == 0 {
+	if u64(ptr) & (page_size - 1) == 0 {
 		return big_realloc(ptr, new_size)
 	}
 
-	slab_hdr := unsafe { &SlabHeader(u64(ptr) & ~u64(0xfff)) }
+	slab_hdr := unsafe { &SlabHeader(u64(ptr) & ~(page_size - 1)) }
+	if slab_hdr.magic != slab_magic {
+		lib.kpanic(unsafe { nil }, c'Slab: invalid realloc')
+		return unsafe { nil }
+	}
 	mut slab := slab_hdr.slab
 
 	if new_size > slab.ent_size {
 		mut new_ptr := malloc(new_size)
+		if new_ptr == unsafe { nil } {
+			return unsafe { nil }
+		}
 		unsafe { C.memcpy(new_ptr, ptr, slab.ent_size) }
 		slab.sfree(ptr)
 		return new_ptr
@@ -510,6 +459,9 @@ pub fn realloc(ptr voidptr, new_size u64) voidptr {
 }
 
 fn big_realloc(ptr voidptr, new_size u64) voidptr {
+	if new_size > (u64(-1) / page_size - 1) * page_size {
+		return unsafe { nil }
+	}
 	mut metadata := unsafe { &MallocMetadata(u64(ptr) - page_size) }
 
 	if lib.div_roundup(metadata.size, page_size) == lib.div_roundup(new_size, page_size) {
@@ -535,5 +487,8 @@ fn big_realloc(ptr voidptr, new_size u64) voidptr {
 
 @[export: 'calloc']
 pub fn calloc(a u64, b u64) voidptr {
+	if b != 0 && a > u64(-1) / b {
+		return unsafe { nil }
+	}
 	return unsafe { malloc(a * b) }
 }

--- a/kernel/modules/memory/physical.v
+++ b/kernel/modules/memory/physical.v
@@ -179,6 +179,10 @@ pub fn pmm_init() {
 	slabs[12].init(1536)
 	slabs[13].init(2048)
 
+	$if xnu_zone ? {
+		xnu_heap_init()
+	}
+
 	$if heap_selftest ? {
 		heap_selftest()
 	}
@@ -375,6 +379,11 @@ pub fn free(ptr voidptr) {
 		return
 	}
 
+	$if xnu_zone ? {
+		xnu_heap_free(ptr)
+		return
+	}
+
 	mut slab_hdr := unsafe { &SlabHeader(u64(ptr) & ~(page_size - 1)) }
 
 	if slab_hdr.magic != slab_magic {
@@ -402,6 +411,9 @@ fn slab_for(size u64) ?&Slab {
 
 @[export: 'malloc']
 pub fn malloc(size u64) voidptr {
+	$if xnu_zone ? {
+		return xnu_heap_alloc(size)
+	}
 	mut slab := slab_for(size) or { return big_alloc(size) }
 
 	return slab.alloc()
@@ -436,6 +448,10 @@ pub fn realloc(ptr voidptr, new_size u64) voidptr {
 
 	if u64(ptr) & (page_size - 1) == 0 {
 		return big_realloc(ptr, new_size)
+	}
+
+	$if xnu_zone ? {
+		return xnu_heap_realloc(ptr, new_size)
 	}
 
 	slab_hdr := unsafe { &SlabHeader(u64(ptr) & ~(page_size - 1)) }

--- a/kernel/modules/memory/slab.v
+++ b/kernel/modules/memory/slab.v
@@ -3,8 +3,11 @@ module memory
 
 import klock
 import lib
+import xnualloc
 
-// Independent implementation for Vinix; no XNU implementation is copied.
+// The default bitmap path remains the independent Vinix implementation.
+// -d xnu_bitmap selects the APSL-preserving translation in xnualloc.
+// This does not select XNU magazines, VM expansion, or the full zone allocator.
 // Each size class has a list of nonempty, nonfull pages and at most one
 // empty spare page. Full pages are reached through their objects' headers.
 // Allocation bits live in the header, never in freed object payloads.
@@ -19,6 +22,8 @@ mut:
 	ent_size u64
 	partial  u64
 	spare    u64
+	// XNU scan cursor, serialized by the class lock (not per-CPU yet).
+	alloc_rr u16
 }
 
 struct SlabHeader {
@@ -29,7 +34,7 @@ mut:
 	next     u64
 	capacity u64
 	in_use   u64
-	// 1 = allocated or unavailable tail slot; 0 = available.
+	// Default: 1 = allocated/tail. With xnu_bitmap: 1 = free, 0 = used/tail.
 	used     [4]u64
 }
 
@@ -116,11 +121,15 @@ fn (mut this Slab) grow() {
 	}
 	hdr.magic = slab_magic
 	hdr.capacity = (page_size - slab_data_offset()) / this.ent_size
-	for i := 0; i < 4; i++ {
-		hdr.used[i] = u64(-1)
-	}
-	for i := u64(0); i < hdr.capacity; i++ {
-		hdr.used[int(i / 64)] &= ~(u64(1) << (i % 64))
+	$if xnu_bitmap ? {
+		xnualloc.zone_bits_init_ref(unsafe { &hdr.used[0] }, 4, u32(hdr.capacity))
+	} $else {
+		for i := 0; i < 4; i++ {
+			hdr.used[i] = u64(-1)
+		}
+		for i := u64(0); i < hdr.capacity; i++ {
+			hdr.used[int(i / 64)] &= ~(u64(1) << (i % 64))
+		}
 	}
 	this.add_partial(mut hdr)
 }
@@ -144,12 +153,19 @@ pub fn (mut this Slab) alloc() voidptr {
 	}
 	mut hdr := unsafe { &SlabHeader(this.partial) }
 	mut slot := u64(256)
-	for i := 0; i < 4; i++ {
-		if hdr.used[i] != u64(-1) {
-			bit := slab_first_zero(hdr.used[i])
-			hdr.used[i] |= u64(1) << bit
-			slot = u64(i) * 64 + bit
-			break
+	$if xnu_bitmap ? {
+		slot = xnualloc.zba_scan_bitmap_ref(unsafe { &hdr.used[0] }, 4, u64(this.alloc_rr) + 1)
+		if slot != xnualloc.no_element {
+			this.alloc_rr = u16(slot)
+		}
+	} $else {
+		for i := 0; i < 4; i++ {
+			if hdr.used[i] != u64(-1) {
+				bit := slab_first_zero(hdr.used[i])
+				hdr.used[i] |= u64(1) << bit
+				slot = u64(i) * 64 + bit
+				break
+			}
 		}
 	}
 	if slot >= hdr.capacity {
@@ -178,7 +194,7 @@ pub fn (mut this Slab) sfree(ptr voidptr) {
 	mut hdr := unsafe { &SlabHeader(u64(ptr) & ~(page_size - 1)) }
 	offset := u64(ptr) & (page_size - 1)
 	start := slab_data_offset()
-	if hdr.magic != slab_magic || hdr.slab != this || this.ent_size == 0 || offset < start {
+	if hdr.magic != slab_magic || u64(hdr.slab) != u64(&this) || this.ent_size == 0 || offset < start {
 		this.@lock.release()
 		lib.kpanic(unsafe { nil }, c'Slab: invalid free header')
 		return
@@ -191,7 +207,13 @@ pub fn (mut this Slab) sfree(ptr voidptr) {
 	}
 	word := int(slot / 64)
 	bit := u64(1) << (slot % 64)
-	if hdr.used[word] & bit == 0 || hdr.in_use == 0 {
+	mut is_free := false
+	$if xnu_bitmap ? {
+		is_free = xnualloc.zone_bits_is_free_ref(unsafe { &hdr.used[0] }, 4, slot)
+	} $else {
+		is_free = hdr.used[word] & bit == 0
+	}
+	if is_free || hdr.in_use == 0 {
 		this.@lock.release()
 		lib.kpanic(unsafe { nil }, c'Slab: double free')
 		return
@@ -199,7 +221,16 @@ pub fn (mut this Slab) sfree(ptr voidptr) {
 	was_full := hdr.in_use == hdr.capacity
 	// Poison before publishing the slot as free.
 	unsafe { C.memset(ptr, 0xaa, this.ent_size) }
-	hdr.used[word] &= ~bit
+	$if xnu_bitmap ? {
+		// The class lock and preceding check guarantee success.
+		if !xnualloc.zone_bits_mark_free_ref(unsafe { &hdr.used[0] }, 4, slot) {
+			this.@lock.release()
+			lib.kpanic(unsafe { nil }, c'Slab: corrupt XNU bitmap state')
+			return
+		}
+	} $else {
+		hdr.used[word] &= ~bit
+	}
 	hdr.in_use--
 	mut release_page := u64(0)
 	if hdr.in_use == 0 {
@@ -227,6 +258,9 @@ pub fn (mut this Slab) sfree(ptr voidptr) {
 // called concurrently, but never while holding a slab or PMM lock.
 // Returns bytes released by this call, not a global free-memory snapshot.
 pub fn heap_trim() u64 {
+	$if xnu_zone ? {
+		return xnu_heap_trim()
+	}
 	mut released := u64(0)
 	for mut slab in slabs {
 		slab.@lock.acquire()

--- a/kernel/modules/memory/slab.v
+++ b/kernel/modules/memory/slab.v
@@ -1,0 +1,246 @@
+@[has_globals; manualfree]
+module memory
+
+import klock
+import lib
+
+// Independent implementation for Vinix; no XNU implementation is copied.
+// Each size class has a list of nonempty, nonfull pages and at most one
+// empty spare page. Full pages are reached through their objects' headers.
+// Allocation bits live in the header, never in freed object payloads.
+// Headers remain in the same writable page: this is NOT metadata isolation
+// or XNU's virtual-address/type sequestering.
+const slab_magic = u64(0x56494e4958534c42)
+const slab_alignment = u64(16)
+
+pub struct Slab {
+mut:
+	@lock    klock.Lock
+	ent_size u64
+	partial  u64
+	spare    u64
+}
+
+struct SlabHeader {
+mut:
+	slab     &Slab = unsafe { nil }
+	magic    u64
+	prev     u64
+	next     u64
+	capacity u64
+	in_use   u64
+	// 1 = allocated or unavailable tail slot; 0 = available.
+	used     [4]u64
+}
+
+fn slab_data_offset() u64 {
+	return lib.align_up(u64(sizeof(SlabHeader)), slab_alignment)
+}
+
+// Initialization is boot-only. Slab instances must not move after use.
+// Pages are acquired lazily, without recursing through malloc.
+pub fn (mut this Slab) init(ent_size u64) {
+	if ent_size == 0 || ent_size > page_size / 2 || this.ent_size != 0 {
+		lib.kpanic(unsafe { nil }, c'Slab: invalid initialization')
+		return
+	}
+	this.ent_size = lib.align_up(ent_size, slab_alignment)
+	capacity := (page_size - slab_data_offset()) / this.ent_size
+	if capacity == 0 || capacity > 256 {
+		lib.kpanic(unsafe { nil }, c'Slab: unsupported page geometry')
+	}
+}
+
+// All list and bitmap operations require this.@lock.
+fn (mut this Slab) add_partial(mut hdr SlabHeader) {
+	hdr.prev = 0
+	hdr.next = this.partial
+	if this.partial != 0 {
+		mut next := unsafe { &SlabHeader(this.partial) }
+		next.prev = u64(hdr)
+	}
+	this.partial = u64(hdr)
+}
+
+fn (mut this Slab) remove_partial(mut hdr SlabHeader) {
+	if hdr.prev == 0 {
+		this.partial = hdr.next
+	} else {
+		mut prev := unsafe { &SlabHeader(hdr.prev) }
+		prev.next = hdr.next
+	}
+	if hdr.next != 0 {
+		mut next := unsafe { &SlabHeader(hdr.next) }
+		next.prev = hdr.prev
+	}
+	hdr.prev = 0
+	hdr.next = 0
+}
+
+// The argument must contain a zero bit. Bounded binary bit search, in V.
+fn slab_first_zero(word u64) u64 {
+	mut bits := ~word
+	mut index := u64(0)
+	if bits & u64(0xffffffff) == 0 {
+		index += 32
+		bits >>= 32
+	}
+	if bits & u64(0xffff) == 0 {
+		index += 16
+		bits >>= 16
+	}
+	if bits & u64(0xff) == 0 {
+		index += 8
+		bits >>= 8
+	}
+	if bits & u64(0xf) == 0 {
+		index += 4
+		bits >>= 4
+	}
+	if bits & u64(3) == 0 {
+		index += 2
+		bits >>= 2
+	}
+	if bits & u64(1) == 0 {
+		index++
+	}
+	return index
+}
+
+fn (mut this Slab) grow() {
+	base := u64(pmm_alloc_nozero(1)) + higher_half
+	mut hdr := unsafe { &SlabHeader(base) }
+	unsafe {
+		C.memset(voidptr(hdr), 0, sizeof(SlabHeader))
+		hdr.slab = this
+	}
+	hdr.magic = slab_magic
+	hdr.capacity = (page_size - slab_data_offset()) / this.ent_size
+	for i := 0; i < 4; i++ {
+		hdr.used[i] = u64(-1)
+	}
+	for i := u64(0); i < hdr.capacity; i++ {
+		hdr.used[int(i / 64)] &= ~(u64(1) << (i % 64))
+	}
+	this.add_partial(mut hdr)
+}
+
+pub fn (mut this Slab) alloc() voidptr {
+	this.@lock.acquire()
+	if this.ent_size == 0 {
+		this.@lock.release()
+		lib.kpanic(unsafe { nil }, c'Slab: allocation before initialization')
+		return unsafe { nil }
+	}
+	if this.partial == 0 {
+		if this.spare != 0 {
+			mut spare := unsafe { &SlabHeader(this.spare) }
+			this.spare = 0
+			this.add_partial(mut spare)
+		} else {
+			// Existing lock order: slab -> PMM. The PMM does not use malloc.
+			this.grow()
+		}
+	}
+	mut hdr := unsafe { &SlabHeader(this.partial) }
+	mut slot := u64(256)
+	for i := 0; i < 4; i++ {
+		if hdr.used[i] != u64(-1) {
+			bit := slab_first_zero(hdr.used[i])
+			hdr.used[i] |= u64(1) << bit
+			slot = u64(i) * 64 + bit
+			break
+		}
+	}
+	if slot >= hdr.capacity {
+		this.@lock.release()
+		lib.kpanic(unsafe { nil }, c'Slab: corrupt allocation bitmap')
+		return unsafe { nil }
+	}
+	hdr.in_use++
+	if hdr.in_use == hdr.capacity {
+		this.remove_partial(mut hdr)
+	}
+	size := this.ent_size
+	ptr := voidptr(u64(hdr) + slab_data_offset() + slot * size)
+	this.@lock.release()
+
+	// The reserved slot keeps its page live. Zeroing need not hold the lock.
+	unsafe { C.memset(ptr, 0, size) }
+	return ptr
+}
+
+pub fn (mut this Slab) sfree(ptr voidptr) {
+	if ptr == unsafe { nil } {
+		return
+	}
+	this.@lock.acquire()
+	mut hdr := unsafe { &SlabHeader(u64(ptr) & ~(page_size - 1)) }
+	offset := u64(ptr) & (page_size - 1)
+	start := slab_data_offset()
+	if hdr.magic != slab_magic || hdr.slab != this || this.ent_size == 0 || offset < start {
+		this.@lock.release()
+		lib.kpanic(unsafe { nil }, c'Slab: invalid free header')
+		return
+	}
+	slot := (offset - start) / this.ent_size
+	if (offset - start) % this.ent_size != 0 || slot >= hdr.capacity {
+		this.@lock.release()
+		lib.kpanic(unsafe { nil }, c'Slab: invalid free alignment')
+		return
+	}
+	word := int(slot / 64)
+	bit := u64(1) << (slot % 64)
+	if hdr.used[word] & bit == 0 || hdr.in_use == 0 {
+		this.@lock.release()
+		lib.kpanic(unsafe { nil }, c'Slab: double free')
+		return
+	}
+	was_full := hdr.in_use == hdr.capacity
+	// Poison before publishing the slot as free.
+	unsafe { C.memset(ptr, 0xaa, this.ent_size) }
+	hdr.used[word] &= ~bit
+	hdr.in_use--
+	mut release_page := u64(0)
+	if hdr.in_use == 0 {
+		if !was_full {
+			this.remove_partial(mut hdr)
+		}
+		if this.spare == 0 {
+			this.spare = u64(hdr)
+		} else {
+			release_page = u64(hdr)
+			hdr.magic = 0
+		}
+	} else if was_full {
+		this.add_partial(mut hdr)
+	}
+	this.@lock.release()
+	if release_page != 0 {
+		// Detached and empty: no valid outstanding object can reference it.
+		pmm_free(voidptr(release_page - higher_half), 1)
+	}
+}
+
+// Return empty spare pages explicitly; excess empty pages are already
+// returned by sfree. Does not compact partially occupied pages. May be
+// called concurrently, but never while holding a slab or PMM lock.
+// Returns bytes released by this call, not a global free-memory snapshot.
+pub fn heap_trim() u64 {
+	mut released := u64(0)
+	for mut slab in slabs {
+		slab.@lock.acquire()
+		base := slab.spare
+		slab.spare = 0
+		if base != 0 {
+			mut hdr := unsafe { &SlabHeader(base) }
+			hdr.magic = 0
+		}
+		slab.@lock.release()
+		if base != 0 {
+			pmm_free(voidptr(base - higher_half), 1)
+			released += page_size
+		}
+	}
+	return released
+}

--- a/kernel/modules/memory/xnu_zone_heap.v
+++ b/kernel/modules/memory/xnu_zone_heap.v
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2000-2020 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/*
+ * @OSF_COPYRIGHT@
+ */
+/*
+ * Mach Operating System
+ * Copyright (c) 1991,1990,1989,1988,1987 Carnegie Mellon University
+ * All Rights Reserved.
+ *
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ *
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+ * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ *
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie Mellon
+ * the rights to redistribute these changes.
+ */
+// Modified 2026-09-11: C-to-V translation and explicitly documented adaptations.
+// Upstream: apple-oss-distributions/xnu f6217f891ac0bb64f3d375211650a4c1ff8ca1ea,
+// osfmk/kern/zalloc.c. See docs/xnualloc/PORT_STATUS.md and
+// kernel/modules/xnualloc/APPLE_LICENSE.
+// These translations retain APSL 2.0; they are NOT relicensed as GPL.
+
+
+@[has_globals; manualfree]
+module memory
+
+import xnualloc
+import klock
+import katomic
+import lib
+
+// Opt-in bridge for the ordinary XNU zone state machine. The class lock covers
+// ALL CPU caches and depots as well as the core. This is deliberately a
+// correctness-first serialization policy, not XNU's scalable locking scheme.
+// Metadata remains in the same writable backing page. Large allocations still
+// use Vinix's page-aligned malloc interface and contiguous physical allocation.
+const xnu_heap_magic = u64(0x584e555a4f4e4531)
+const xnu_heap_max_cpus = 64
+
+struct XnuHeapClass {
+mut:
+	@lock  klock.Lock
+	zone   xnualloc.Zone
+	caches [64]&xnualloc.CpuCache
+}
+
+struct XnuHeapHeader {
+mut:
+	magic      u64
+	class      u64
+	chunk      xnualloc.ZoneChunk
+	free_bits  [4]u64
+	live_bits  [4]u64
+}
+
+__global (
+	xnu_heap_classes [14]XnuHeapClass
+	xnu_heap_cpus    = u64(0)
+)
+
+fn xnu_heap_init() {
+	for i := 0; i < 14; i++ {
+		mut h := &xnu_heap_classes[i]
+		ok := h.zone.zone_init(slabs[i].ent_size, 2)
+		if !ok {
+			lib.kpanic(unsafe { nil }, c'XNU zone initialization failed')
+			return
+		}
+		h.zone.resolve = xnu_heap_resolve
+		for cpu := 0; cpu < xnu_heap_max_cpus; cpu++ {
+			h.caches[cpu] = unsafe { nil }
+		}
+	}
+}
+
+// Called once by SMP bootstrap only AFTER every CPU has its kernel GS/TPIDR
+// number installed and the online acquire/release handshake has completed.
+// Readers load-acquire before inspecting CPU number. Early boot never reads it.
+pub fn heap_enable_cpu_caches(count u64) {
+	$if xnu_zone ? {
+		if count == 0 {
+			return
+		}
+		katomic.store(mut &xnu_heap_cpus, count)
+	}
+}
+
+fn xnu_heap_resolve(addr u64) &xnualloc.ZoneChunk {
+	if addr == 0 {
+		return unsafe { nil }
+	}
+	mut hdr := unsafe { &XnuHeapHeader(addr & ~(page_size - 1)) }
+	if hdr.magic != xnu_heap_magic || hdr.class >= 14 {
+		return unsafe { nil }
+	}
+	return unsafe { &hdr.chunk }
+}
+
+fn (mut h XnuHeapClass) cache_locked(allow_create bool) &xnualloc.CpuCache {
+	count := katomic.load(&xnu_heap_cpus)
+	if count == 0 {
+		return unsafe { nil }
+	}
+	// h.lock disables interrupts: CPU identity cannot migrate during this call.
+	index := xnu_heap_cpu_number()
+	if index >= count || index >= xnu_heap_max_cpus {
+		return unsafe { nil }
+	}
+	mut c := h.caches[int(index)]
+	// Do not spend the last backing page on an empty cache before a payload
+	// exists. Failure to create a cache must leave this allocation satisfiable.
+	if c == unsafe { nil } && allow_create && h.zone.elems_free != 0 {
+		// No runtime allocation or recursive use of this heap for its caches.
+		pages := lib.div_roundup(u64(sizeof(xnualloc.CpuCache)), page_size)
+		phys := pmm_alloc_fallible(pages)
+		if phys == unsafe { nil } {
+			return unsafe { nil }
+		}
+		c = unsafe { &xnualloc.CpuCache(u64(phys) + higher_half) }
+		ok := c.cache_init()
+		if !ok {
+			lib.kpanic(unsafe { nil }, c'XNU cache initialization failed')
+			return unsafe { nil }
+		}
+		h.caches[int(index)] = c
+	}
+	return c
+}
+
+fn (mut h XnuHeapClass) grow_locked(index int) bool {
+	phys := pmm_alloc_fallible(1)
+	if phys == unsafe { nil } {
+		return false
+	}
+	base := u64(phys) + higher_half
+	mut hdr := unsafe { &XnuHeapHeader(base) }
+	hdr.magic = xnu_heap_magic
+	hdr.class = u64(index)
+	hdr.chunk.base = base
+	hdr.chunk.bytes = page_size
+	hdr.chunk.offset = lib.align_up(u64(sizeof(XnuHeapHeader)), 16)
+	hdr.chunk.pages = 1
+	hdr.chunk.words = 4
+	hdr.chunk.bits = unsafe { &hdr.free_bits[0] }
+	hdr.chunk.live = unsafe { &hdr.live_bits[0] }
+	if !h.zone.zcram(mut hdr.chunk) {
+		hdr.magic = 0
+		pmm_free(phys, 1)
+		return false
+	}
+	return true
+}
+
+fn (mut h XnuHeapClass) drain_locked() {
+	for i := 0; i < xnu_heap_max_cpus; i++ {
+		mut c := h.caches[i]
+		if c != unsafe { nil } {
+			h.zone.zone_drain_cache(mut c)
+		}
+	}
+	h.zone.zone_drain_recirc()
+}
+
+fn xnu_heap_alloc(size u64) voidptr {
+	mut index := 0
+	for index < 14 && xnu_heap_classes[index].zone.elem_size < size {
+		index++
+	}
+	if index == 14 {
+		return big_alloc(size)
+	}
+	mut h := &xnu_heap_classes[index]
+	h.@lock.acquire()
+	c := h.cache_locked(true)
+	mut addr := h.zone.zalloc_ext(c)
+	if addr == 0 {
+		// Recover elements stranded in other CPU caches before requesting RAM.
+		h.drain_locked()
+		addr = h.zone.zalloc_ext(c)
+	}
+	if addr == 0 && h.grow_locked(index) {
+		addr = h.zone.zalloc_ext(c)
+	}
+	capacity := h.zone.elem_size
+	h.@lock.release()
+	if addr == 0 {
+		// Preserve Vinix's existing infallible small malloc OOM behavior.
+		lib.kpanic(unsafe { nil }, c'XNU zone heap exhausted')
+		return unsafe { nil }
+	}
+	// The client-live slot pins its page after unlock.
+	unsafe { C.memset(voidptr(addr), 0, capacity) }
+	return voidptr(addr)
+}
+
+fn xnu_heap_free(ptr voidptr) {
+	mut hdr := unsafe { &XnuHeapHeader(u64(ptr) & ~(page_size - 1)) }
+	if hdr.magic != xnu_heap_magic || hdr.class >= 14 {
+		lib.kpanic(unsafe { nil }, c'XNU zone invalid free header')
+		return
+	}
+	mut h := &xnu_heap_classes[int(hdr.class)]
+	h.@lock.acquire()
+	if !h.zone.zone_mark_invalid(u64(ptr)) {
+		h.@lock.release()
+		lib.kpanic(unsafe { nil }, c'XNU zone double or misaligned free')
+		return
+	}
+	// Invalidate then poison before publishing to any cache or zone bitmap.
+	unsafe { C.memset(ptr, 0xaa, h.zone.elem_size) }
+	c := h.cache_locked(false)
+	if !h.zone.zfree_ext(u64(ptr), c) {
+		h.@lock.release()
+		lib.kpanic(unsafe { nil }, c'XNU zone corrupt free state')
+		return
+	}
+	// Keep one fully empty spare; cached objects intentionally pin pages.
+	mut dead := u64(0)
+	if h.zone.wired_empty > 1 {
+		p := h.zone.zone_reclaim_chunk()
+		dead = p.base
+		mut old := unsafe { &XnuHeapHeader(dead) }
+		old.magic = 0
+	}
+	h.@lock.release()
+	if dead != 0 {
+		pmm_free(voidptr(dead - higher_half), 1)
+	}
+}
+
+fn xnu_heap_realloc(ptr voidptr, size u64) voidptr {
+	mut hdr := unsafe { &XnuHeapHeader(u64(ptr) & ~(page_size - 1)) }
+	if hdr.magic != xnu_heap_magic || hdr.class >= 14 {
+		lib.kpanic(unsafe { nil }, c'XNU zone invalid realloc')
+		return unsafe { nil }
+	}
+	old_size := xnu_heap_classes[int(hdr.class)].zone.elem_size
+	if size <= old_size {
+		return ptr
+	}
+	new_ptr := malloc(size)
+	if new_ptr == unsafe { nil } {
+		return unsafe { nil }
+	}
+	unsafe { C.memcpy(new_ptr, ptr, old_size) }
+	xnu_heap_free(ptr)
+	return new_ptr
+}
+
+fn xnu_heap_trim() u64 {
+	mut bytes := u64(0)
+	for i := 0; i < 14; i++ {
+		mut h := &xnu_heap_classes[i]
+		h.@lock.acquire()
+		h.drain_locked()
+		// Detach a private list under the lock, then release outside it.
+		mut head := u64(0)
+		for h.zone.empty != unsafe { nil } {
+			mut p := h.zone.zone_reclaim_chunk()
+			mut hdr := unsafe { &XnuHeapHeader(p.base) }
+			hdr.magic = 0
+			p.next = unsafe { &xnualloc.ZoneChunk(head) }
+			head = u64(p)
+		}
+		h.@lock.release()
+		for head != 0 {
+			p := unsafe { &xnualloc.ZoneChunk(head) }
+			next := u64(p.next)
+			base := p.base
+			// Capture everything needed before PMM poisons the backing page.
+			pmm_free(voidptr(base - higher_half), 1)
+			bytes += page_size
+			head = next
+		}
+	}
+	return bytes
+}

--- a/kernel/modules/memory/xnu_zone_heap_amd64.v
+++ b/kernel/modules/memory/xnu_zone_heap_amd64.v
@@ -1,0 +1,12 @@
+module memory
+
+// Only called with interrupts masked, after SMP publishes CPU readiness.
+fn xnu_heap_cpu_number() u64 {
+	mut number := u64(0)
+	asm volatile amd64 {
+		mov number, gs:[0]
+		; =r (number)
+		; ; memory
+	}
+	return number
+}

--- a/kernel/modules/memory/xnu_zone_heap_arm64.v
+++ b/kernel/modules/memory/xnu_zone_heap_arm64.v
@@ -1,0 +1,12 @@
+module memory
+
+// Only called with interrupts masked, after SMP publishes CPU readiness.
+fn xnu_heap_cpu_number() u64 {
+	mut number := u64(0)
+	asm volatile aarch64 {
+		mrs number, tpidr_el1
+		; =r (number)
+		; ; memory
+	}
+	return number
+}

--- a/kernel/modules/x86/smp/smp.v
+++ b/kernel/modules/x86/smp/smp.v
@@ -55,6 +55,8 @@ pub fn initialise() {
 		for katomic.load(&cpu_local.online) == 0 {}
 	}
 
+	// All GS/TPIDR CPU numbers are now installed; publish cache readiness.
+	memory.heap_enable_cpu_caches(u64(cpu_locals.len))
 	smp_ready = true
 
 	print('smp: All CPUs online!\n')

--- a/kernel/modules/xnualloc/APPLE_LICENSE
+++ b/kernel/modules/xnualloc/APPLE_LICENSE
@@ -1,0 +1,367 @@
+APPLE PUBLIC SOURCE LICENSE
+Version 2.0 - August 6, 2003
+
+Please read this License carefully before downloading this software.
+By downloading or using this software, you are agreeing to be bound by
+the terms of this License. If you do not or cannot agree to the terms
+of this License, please do not download or use the software.
+
+1. General; Definitions. This License applies to any program or other
+work which Apple Computer, Inc. ("Apple") makes publicly available and
+which contains a notice placed by Apple identifying such program or
+work as "Original Code" and stating that it is subject to the terms of
+this Apple Public Source License version 2.0 ("License"). As used in
+this License:
+
+1.1 "Applicable Patent Rights" mean: (a) in the case where Apple is
+the grantor of rights, (i) claims of patents that are now or hereafter
+acquired, owned by or assigned to Apple and (ii) that cover subject
+matter contained in the Original Code, but only to the extent
+necessary to use, reproduce and/or distribute the Original Code
+without infringement; and (b) in the case where You are the grantor of
+rights, (i) claims of patents that are now or hereafter acquired,
+owned by or assigned to You and (ii) that cover subject matter in Your
+Modifications, taken alone or in combination with Original Code.
+
+1.2 "Contributor" means any person or entity that creates or
+contributes to the creation of Modifications.
+
+1.3 "Covered Code" means the Original Code, Modifications, the
+combination of Original Code and any Modifications, and/or any
+respective portions thereof.
+
+1.4 "Externally Deploy" means: (a) to sublicense, distribute or
+otherwise make Covered Code available, directly or indirectly, to
+anyone other than You; and/or (b) to use Covered Code, alone or as
+part of a Larger Work, in any way to provide a service, including but
+not limited to delivery of content, through electronic communication
+with a client other than You.
+
+1.5 "Larger Work" means a work which combines Covered Code or portions
+thereof with code not governed by the terms of this License.
+
+1.6 "Modifications" mean any addition to, deletion from, and/or change
+to, the substance and/or structure of the Original Code, any previous
+Modifications, the combination of Original Code and any previous
+Modifications, and/or any respective portions thereof. When code is
+released as a series of files, a Modification is: (a) any addition to
+or deletion from the contents of a file containing Covered Code;
+and/or (b) any new file or other representation of computer program
+statements that contains any part of Covered Code.
+
+1.7 "Original Code" means (a) the Source Code of a program or other
+work as originally made available by Apple under this License,
+including the Source Code of any updates or upgrades to such programs
+or works made available by Apple under this License, and that has been
+expressly identified by Apple as such in the header file(s) of such
+work; and (b) the object code compiled from such Source Code and
+originally made available by Apple under this License.
+
+1.8 "Source Code" means the human readable form of a program or other
+work that is suitable for making modifications to it, including all
+modules it contains, plus any associated interface definition files,
+scripts used to control compilation and installation of an executable
+(object code).
+
+1.9 "You" or "Your" means an individual or a legal entity exercising
+rights under this License. For legal entities, "You" or "Your"
+includes any entity which controls, is controlled by, or is under
+common control with, You, where "control" means (a) the power, direct
+or indirect, to cause the direction or management of such entity,
+whether by contract or otherwise, or (b) ownership of fifty percent
+(50%) or more of the outstanding shares or beneficial ownership of
+such entity.
+
+2. Permitted Uses; Conditions & Restrictions. Subject to the terms
+and conditions of this License, Apple hereby grants You, effective on
+the date You accept this License and download the Original Code, a
+world-wide, royalty-free, non-exclusive license, to the extent of
+Apple's Applicable Patent Rights and copyrights covering the Original
+Code, to do the following:
+
+2.1 Unmodified Code. You may use, reproduce, display, perform,
+internally distribute within Your organization, and Externally Deploy
+verbatim, unmodified copies of the Original Code, for commercial or
+non-commercial purposes, provided that in each instance:
+
+(a) You must retain and reproduce in all copies of Original Code the
+copyright and other proprietary notices and disclaimers of Apple as
+they appear in the Original Code, and keep intact all notices in the
+Original Code that refer to this License; and
+
+(b) You must include a copy of this License with every copy of Source
+Code of Covered Code and documentation You distribute or Externally
+Deploy, and You may not offer or impose any terms on such Source Code
+that alter or restrict this License or the recipients' rights
+hereunder, except as permitted under Section 6.
+
+2.2 Modified Code. You may modify Covered Code and use, reproduce,
+display, perform, internally distribute within Your organization, and
+Externally Deploy Your Modifications and Covered Code, for commercial
+or non-commercial purposes, provided that in each instance You also
+meet all of these conditions:
+
+(a) You must satisfy all the conditions of Section 2.1 with respect to
+the Source Code of the Covered Code;
+
+(b) You must duplicate, to the extent it does not already exist, the
+notice in Exhibit A in each file of the Source Code of all Your
+Modifications, and cause the modified files to carry prominent notices
+stating that You changed the files and the date of any change; and
+
+(c) If You Externally Deploy Your Modifications, You must make
+Source Code of all Your Externally Deployed Modifications either
+available to those to whom You have Externally Deployed Your
+Modifications, or publicly available. Source Code of Your Externally
+Deployed Modifications must be released under the terms set forth in
+this License, including the license grants set forth in Section 3
+below, for as long as you Externally Deploy the Covered Code or twelve
+(12) months from the date of initial External Deployment, whichever is
+longer. You should preferably distribute the Source Code of Your
+Externally Deployed Modifications electronically (e.g. download from a
+web site).
+
+2.3 Distribution of Executable Versions. In addition, if You
+Externally Deploy Covered Code (Original Code and/or Modifications) in
+object code, executable form only, You must include a prominent
+notice, in the code itself as well as in related documentation,
+stating that Source Code of the Covered Code is available under the
+terms of this License with information on how and where to obtain such
+Source Code.
+
+2.4 Third Party Rights. You expressly acknowledge and agree that
+although Apple and each Contributor grants the licenses to their
+respective portions of the Covered Code set forth herein, no
+assurances are provided by Apple or any Contributor that the Covered
+Code does not infringe the patent or other intellectual property
+rights of any other entity. Apple and each Contributor disclaim any
+liability to You for claims brought by any other entity based on
+infringement of intellectual property rights or otherwise. As a
+condition to exercising the rights and licenses granted hereunder, You
+hereby assume sole responsibility to secure any other intellectual
+property rights needed, if any. For example, if a third party patent
+license is required to allow You to distribute the Covered Code, it is
+Your responsibility to acquire that license before distributing the
+Covered Code.
+
+3. Your Grants. In consideration of, and as a condition to, the
+licenses granted to You under this License, You hereby grant to any
+person or entity receiving or distributing Covered Code under this
+License a non-exclusive, royalty-free, perpetual, irrevocable license,
+under Your Applicable Patent Rights and other intellectual property
+rights (other than patent) owned or controlled by You, to use,
+reproduce, display, perform, modify, sublicense, distribute and
+Externally Deploy Your Modifications of the same scope and extent as
+Apple's licenses under Sections 2.1 and 2.2 above.
+
+4. Larger Works. You may create a Larger Work by combining Covered
+Code with other code not governed by the terms of this License and
+distribute the Larger Work as a single product. In each such instance,
+You must make sure the requirements of this License are fulfilled for
+the Covered Code or any portion thereof.
+
+5. Limitations on Patent License. Except as expressly stated in
+Section 2, no other patent rights, express or implied, are granted by
+Apple herein. Modifications and/or Larger Works may require additional
+patent licenses from Apple which Apple may grant in its sole
+discretion.
+
+6. Additional Terms. You may choose to offer, and to charge a fee for,
+warranty, support, indemnity or liability obligations and/or other
+rights consistent with the scope of the license granted herein
+("Additional Terms") to one or more recipients of Covered Code.
+However, You may do so only on Your own behalf and as Your sole
+responsibility, and not on behalf of Apple or any Contributor. You
+must obtain the recipient's agreement that any such Additional Terms
+are offered by You alone, and You hereby agree to indemnify, defend
+and hold Apple and every Contributor harmless for any liability
+incurred by or claims asserted against Apple or such Contributor by
+reason of any such Additional Terms.
+
+7. Versions of the License. Apple may publish revised and/or new
+versions of this License from time to time. Each version will be given
+a distinguishing version number. Once Original Code has been published
+under a particular version of this License, You may continue to use it
+under the terms of that version. You may also choose to use such
+Original Code under the terms of any subsequent version of this
+License published by Apple. No one other than Apple has the right to
+modify the terms applicable to Covered Code created under this
+License.
+
+8. NO WARRANTY OR SUPPORT. The Covered Code may contain in whole or in
+part pre-release, untested, or not fully tested works. The Covered
+Code may contain errors that could cause failures or loss of data, and
+may be incomplete or contain inaccuracies. You expressly acknowledge
+and agree that use of the Covered Code, or any portion thereof, is at
+Your sole and entire risk. THE COVERED CODE IS PROVIDED "AS IS" AND
+WITHOUT WARRANTY, UPGRADES OR SUPPORT OF ANY KIND AND APPLE AND
+APPLE'S LICENSOR(S) (COLLECTIVELY REFERRED TO AS "APPLE" FOR THE
+PURPOSES OF SECTIONS 8 AND 9) AND ALL CONTRIBUTORS EXPRESSLY DISCLAIM
+ALL WARRANTIES AND/OR CONDITIONS, EXPRESS OR IMPLIED, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES AND/OR CONDITIONS OF
+MERCHANTABILITY, OF SATISFACTORY QUALITY, OF FITNESS FOR A PARTICULAR
+PURPOSE, OF ACCURACY, OF QUIET ENJOYMENT, AND NONINFRINGEMENT OF THIRD
+PARTY RIGHTS. APPLE AND EACH CONTRIBUTOR DOES NOT WARRANT AGAINST
+INTERFERENCE WITH YOUR ENJOYMENT OF THE COVERED CODE, THAT THE
+FUNCTIONS CONTAINED IN THE COVERED CODE WILL MEET YOUR REQUIREMENTS,
+THAT THE OPERATION OF THE COVERED CODE WILL BE UNINTERRUPTED OR
+ERROR-FREE, OR THAT DEFECTS IN THE COVERED CODE WILL BE CORRECTED. NO
+ORAL OR WRITTEN INFORMATION OR ADVICE GIVEN BY APPLE, AN APPLE
+AUTHORIZED REPRESENTATIVE OR ANY CONTRIBUTOR SHALL CREATE A WARRANTY.
+You acknowledge that the Covered Code is not intended for use in the
+operation of nuclear facilities, aircraft navigation, communication
+systems, or air traffic control machines in which case the failure of
+the Covered Code could lead to death, personal injury, or severe
+physical or environmental damage.
+
+9. LIMITATION OF LIABILITY. TO THE EXTENT NOT PROHIBITED BY LAW, IN NO
+EVENT SHALL APPLE OR ANY CONTRIBUTOR BE LIABLE FOR ANY INCIDENTAL,
+SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR RELATING
+TO THIS LICENSE OR YOUR USE OR INABILITY TO USE THE COVERED CODE, OR
+ANY PORTION THEREOF, WHETHER UNDER A THEORY OF CONTRACT, WARRANTY,
+TORT (INCLUDING NEGLIGENCE), PRODUCTS LIABILITY OR OTHERWISE, EVEN IF
+APPLE OR SUCH CONTRIBUTOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES AND NOTWITHSTANDING THE FAILURE OF ESSENTIAL PURPOSE OF ANY
+REMEDY. SOME JURISDICTIONS DO NOT ALLOW THE LIMITATION OF LIABILITY OF
+INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS LIMITATION MAY NOT APPLY
+TO YOU. In no event shall Apple's total liability to You for all
+damages (other than as may be required by applicable law) under this
+License exceed the amount of fifty dollars ($50.00).
+
+10. Trademarks. This License does not grant any rights to use the
+trademarks or trade names "Apple", "Apple Computer", "Mac", "Mac OS",
+"QuickTime", "QuickTime Streaming Server" or any other trademarks,
+service marks, logos or trade names belonging to Apple (collectively
+"Apple Marks") or to any trademark, service mark, logo or trade name
+belonging to any Contributor. You agree not to use any Apple Marks in
+or as part of the name of products derived from the Original Code or
+to endorse or promote products derived from the Original Code other
+than as expressly permitted by and in strict compliance at all times
+with Apple's third party trademark usage guidelines which are posted
+at http://www.apple.com/legal/guidelinesfor3rdparties.html.
+
+11. Ownership. Subject to the licenses granted under this License,
+each Contributor retains all rights, title and interest in and to any
+Modifications made by such Contributor. Apple retains all rights,
+title and interest in and to the Original Code and any Modifications
+made by or on behalf of Apple ("Apple Modifications"), and such Apple
+Modifications will not be automatically subject to this License. Apple
+may, at its sole discretion, choose to license such Apple
+Modifications under this License, or on different terms from those
+contained in this License or may choose not to license them at all.
+
+12. Termination.
+
+12.1 Termination. This License and the rights granted hereunder will
+terminate:
+
+(a) automatically without notice from Apple if You fail to comply with
+any term(s) of this License and fail to cure such breach within 30
+days of becoming aware of such breach;
+
+(b) immediately in the event of the circumstances described in Section
+13.5(b); or
+
+(c) automatically without notice from Apple if You, at any time during
+the term of this License, commence an action for patent infringement
+against Apple; provided that Apple did not first commence
+an action for patent infringement against You in that instance.
+
+12.2 Effect of Termination. Upon termination, You agree to immediately
+stop any further use, reproduction, modification, sublicensing and
+distribution of the Covered Code. All sublicenses to the Covered Code
+which have been properly granted prior to termination shall survive
+any termination of this License. Provisions which, by their nature,
+should remain in effect beyond the termination of this License shall
+survive, including but not limited to Sections 3, 5, 8, 9, 10, 11,
+12.2 and 13. No party will be liable to any other for compensation,
+indemnity or damages of any sort solely as a result of terminating
+this License in accordance with its terms, and termination of this
+License will be without prejudice to any other right or remedy of
+any party.
+
+13. Miscellaneous.
+
+13.1 Government End Users. The Covered Code is a "commercial item" as
+defined in FAR 2.101. Government software and technical data rights in
+the Covered Code include only those rights customarily provided to the
+public as defined in this License. This customary commercial license
+in technical data and software is provided in accordance with FAR
+12.211 (Technical Data) and 12.212 (Computer Software) and, for
+Department of Defense purchases, DFAR 252.227-7015 (Technical Data --
+Commercial Items) and 227.7202-3 (Rights in Commercial Computer
+Software or Computer Software Documentation). Accordingly, all U.S.
+Government End Users acquire Covered Code with only those rights set
+forth herein.
+
+13.2 Relationship of Parties. This License will not be construed as
+creating an agency, partnership, joint venture or any other form of
+legal association between or among You, Apple or any Contributor, and
+You will not represent to the contrary, whether expressly, by
+implication, appearance or otherwise.
+
+13.3 Independent Development. Nothing in this License will impair
+Apple's right to acquire, license, develop, have others develop for
+it, market and/or distribute technology or products that perform the
+same or similar functions as, or otherwise compete with,
+Modifications, Larger Works, technology or products that You may
+develop, produce, market or distribute.
+
+13.4 Waiver; Construction. Failure by Apple or any Contributor to
+enforce any provision of this License will not be deemed a waiver of
+future enforcement of that or any other provision. Any law or
+regulation which provides that the language of a contract shall be
+construed against the drafter will not apply to this License.
+
+13.5 Severability. (a) If for any reason a court of competent
+jurisdiction finds any provision of this License, or portion thereof,
+to be unenforceable, that provision of the License will be enforced to
+the maximum extent permissible so as to effect the economic benefits
+and intent of the parties, and the remainder of this License will
+continue in full force and effect. (b) Notwithstanding the foregoing,
+if applicable law prohibits or restricts You from fully and/or
+specifically complying with Sections 2 and/or 3 or prevents the
+enforceability of either of those Sections, this License will
+immediately terminate and You must immediately discontinue any use of
+the Covered Code and destroy all copies of it that are in your
+possession or control.
+
+13.6 Dispute Resolution. Any litigation or other dispute resolution
+between You and Apple relating to this License shall take place in the
+Northern District of California, and You and Apple hereby consent to
+the personal jurisdiction of, and venue in, the state and federal
+courts within that District with respect to this License. The
+application of the United Nations Convention on Contracts for the
+International Sale of Goods is expressly excluded.
+
+13.7 Entire Agreement; Governing Law. This License constitutes the
+entire agreement between the parties with respect to the subject
+matter hereof. This License shall be governed by the laws of the
+United States and the State of California, except that body of
+California law concerning conflicts of law.
+
+Where You are located in the province of Quebec, Canada, the following
+clause applies: The parties hereby confirm that they have requested
+that this License and all related documents be drafted in English. Les
+parties ont exige que le present contrat et tous les documents
+connexes soient rediges en anglais.
+
+EXHIBIT A.
+
+"Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+Reserved.
+
+This file contains Original Code and/or Modifications of Original Code
+as defined in and that are subject to the Apple Public Source License
+Version 2.0 (the 'License'). You may not use this file except in
+compliance with the License. Please obtain a copy of the License at
+http://www.opensource.apple.com/apsl/ and read it before using this
+file.
+
+The Original Code and all software distributed under the License are
+distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+Please see the License for the specific language governing rights and
+limitations under the License."

--- a/kernel/modules/xnualloc/bitmap.v
+++ b/kernel/modules/xnualloc/bitmap.v
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2000-2020 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/*
+ * @OSF_COPYRIGHT@
+ */
+/*
+ * Mach Operating System
+ * Copyright (c) 1991,1990,1989,1988,1987 Carnegie Mellon University
+ * All Rights Reserved.
+ *
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ *
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+ * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ *
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie Mellon
+ * the rights to redistribute these changes.
+ */
+// Modified 2026-09-11: C-to-V translation and explicitly documented adaptations.
+// Upstream: apple-oss-distributions/xnu f6217f891ac0bb64f3d375211650a4c1ff8ca1ea,
+// osfmk/kern/zalloc.c. See docs/xnualloc/PORT_STATUS.md and
+// kernel/modules/xnualloc/APPLE_LICENSE.
+// These translations retain APSL 2.0; they are NOT relicensed as GPL.
+
+
+@[manualfree]
+module xnualloc
+
+pub const no_element = u64(-1)
+pub const zba_ptr_mask = u32(0x0fffffff)
+pub const zba_order_shift = u32(29)
+pub const zba_has_extra_bit = u32(0x10000000)
+
+// C's packed bitfield/union representation, expressed explicitly in V.
+// Supported targets are the little-endian 64-bit architectures used by Vinix.
+// bits: zone index [0:9], guarded [10], inline [11], chunk length [12:15].
+// alloc_size doubles as secondary-page index/subchunk length.
+@[packed]
+pub struct PageMetadata {
+pub mut:
+	bits       u16
+	alloc_size u16
+	bitmap     u32
+	page_next  u32
+	page_prev  u32
+}
+
+@[inline]
+pub fn (meta &PageMetadata) is_inline() bool {
+	return meta.bits & u16(1 << 11) != 0
+}
+
+@[inline]
+pub fn (meta &PageMetadata) chunk_len() u32 {
+	return u32(meta.bits >> 12)
+}
+
+// Equivalent to __builtin_ctzll on a nonzero operand; no FP or runtime call.
+@[inline]
+fn trailing_zeros(input u64) u64 {
+	mut value := input
+	assert value != 0
+	mut index := u64(0)
+	if value & u64(0xffffffff) == 0 {
+		index += 32
+		value >>= 32
+	}
+	if value & u64(0xffff) == 0 {
+		index += 16
+		value >>= 16
+	}
+	if value & u64(0xff) == 0 {
+		index += 8
+		value >>= 8
+	}
+	if value & u64(0xf) == 0 {
+		index += 4
+		value >>= 4
+	}
+	if value & u64(3) == 0 {
+		index += 2
+		value >>= 2
+	}
+	if value & u64(1) == 0 {
+		index++
+	}
+	return index
+}
+
+@[inline]
+fn mask_ge64(index u64) u64 {
+	return u64(-1) << (index % 64)
+}
+
+@[inline]
+fn mask_lt64(index u64) u64 {
+	return (u64(1) << (index % 64)) - 1
+}
+
+// Direct translation of zba_scan_bitmap_ref, with explicit storage/word-count
+// parameters instead of XNU's global zone_info lookup. 1 = free, 0 = occupied.
+// eidx may equal words * 64 (the wrap boundary), but may not exceed it.
+// Unlike upstream's accounting panic, exhaustion returns no_element; the
+// Vinix bridge turns this into a kernel panic when its page claims free slots.
+// The caller holds the owning zone lock. This routine is NOT atomic.
+pub fn zba_scan_bitmap_ref(bits &u64, words u32, eidx u64) u64 {
+	assert bits != unsafe { nil } && words > 0 && words <= 128
+	assert words & (words - 1) == 0 && eidx <= u64(words) * 64
+	mut i := eidx / 64
+	unsafe {
+		if eidx % 64 != 0 {
+			map := bits[i] & mask_ge64(eidx)
+			if map != 0 {
+				bit := trailing_zeros(map)
+				bits[i] ^= u64(1) << bit
+				return i * 64 + bit
+			}
+			i++
+		}
+		for j := u32(0); j < words; j++ {
+			if i >= words {
+				i = 0
+			}
+			map := bits[i]
+			if map != 0 {
+				bits[i] &= map - 1
+				return i * 64 + trailing_zeros(map)
+			}
+			i++
+		}
+	}
+	return no_element
+}
+
+// Direct translation of zba_scan_bitmap_inline. chunk_len is supplied by the
+// caller: ordinary chunks use meta.chunk_len(); Z_PCPU uses CPU count instead.
+pub fn zba_scan_bitmap_inline(meta &PageMetadata, chunk_len u32, eidx u64) u64 {
+	assert meta != unsafe { nil } && chunk_len > 0
+	assert eidx <= u64(chunk_len) * 32
+	mut i := eidx / 32
+	unsafe {
+		if eidx % 32 != 0 {
+			map := meta[i].bitmap & (u32(-1) << (eidx % 32))
+			if map != 0 {
+				bit := trailing_zeros(u64(map))
+				meta[i].bitmap ^= u32(1) << bit
+				return i * 32 + bit
+			}
+			i++
+		}
+		for j := u32(0); j < chunk_len; j++ {
+			if i >= chunk_len {
+				i = 0
+			}
+			map := meta[i].bitmap
+			if map != 0 {
+				meta[i].bitmap &= map - 1
+				return i * 32 + trailing_zeros(u64(map))
+			}
+			i++
+		}
+	}
+	return no_element
+}
+
+// Upstream requires zero-initialized metadata before this call.
+pub fn zone_meta_bits_init_inline(meta &PageMetadata, count u32, chunks u32) {
+	assert meta != unsafe { nil } && u64(count) <= u64(chunks) * 32
+	unsafe {
+		for i := u32(0); i < count / 32; i++ {
+			meta[i].bitmap = u32(-1)
+		}
+		if count % 32 != 0 {
+			meta[count / 32].bitmap = (u32(1) << (count % 32)) - 1
+		}
+	}
+}
+
+// The initialization loop in zone_meta_bits_alloc_init, also exposed for
+// caller-owned bitmaps such as Vinix's one-page slab geometry.
+pub fn zone_bits_init_ref(bits &u64, words u32, count u32) {
+	assert bits != unsafe { nil } && words > 0 && words <= 128
+	assert u64(count) <= u64(words) * 64
+	mut i := u32(0)
+	unsafe {
+		for i < count / 64 {
+			bits[i] = u64(-1)
+			i++
+		}
+		if count % 64 != 0 {
+			bits[i] = mask_lt64(count)
+			i++
+		}
+		for i < words {
+			bits[i] = 0
+			i++
+		}
+	}
+}
+
+pub fn zone_bits_merge_ref(bits &u64, words u32, first u32, end u32) {
+	assert bits != unsafe { nil } && first <= end && u64(end) <= u64(words) * 64
+	mut start := first
+	unsafe {
+		for start < end {
+			i := start / 64
+			if i == end / 64 {
+				bits[i] |= mask_lt64(end) & mask_ge64(start)
+				break
+			}
+			bits[i] |= mask_ge64(start)
+			start += 64 - start % 64
+		}
+	}
+}
+
+pub fn zone_bits_merge_inline(meta &PageMetadata, chunks u32, first u32, end u32) {
+	assert meta != unsafe { nil } && first <= end && u64(end) <= u64(chunks) * 32
+	mut start := first
+	unsafe {
+		for start < end {
+			i := start / 32
+			if i == end / 32 {
+				meta[i].bitmap |= ((u32(1) << (end % 32)) - 1) &
+					(u32(-1) << (start % 32))
+				break
+			}
+			meta[i].bitmap |= u32(-1) << (start % 32)
+			start += 32 - start % 32
+		}
+	}
+}
+
+pub fn zone_bits_is_free_ref(bits &u64, words u32, index u64) bool {
+	assert bits != unsafe { nil } && index < u64(words) * 64
+	return unsafe { bits[index / 64] & (u64(1) << (index % 64)) != 0 }
+}
+
+pub fn zone_bits_mark_free_ref(bits &u64, words u32, index u64) bool {
+	assert bits != unsafe { nil } && index < u64(words) * 64
+	bit := u64(1) << (index % 64)
+	unsafe {
+		if bits[index / 64] & bit != 0 {
+			return false
+		}
+		bits[index / 64] ^= bit
+	}
+	return true
+}
+
+pub fn zone_meta_is_free(meta &PageMetadata, arena &Buddy, chunks u32, index u64) bool {
+	if meta.is_inline() {
+		assert index < u64(chunks) * 32
+		return unsafe { meta[index / 32].bitmap & (u32(1) << (index % 32)) != 0 }
+	}
+	return zone_bits_is_free_ref(arena.zba_bits_ref_ptr(meta.bitmap),
+		u32(1) << (meta.bitmap >> zba_order_shift), index)
+}
+
+pub fn zone_meta_mark_free(meta &PageMetadata, arena &Buddy, chunks u32, index u64) bool {
+	if meta.is_inline() {
+		assert index < u64(chunks) * 32
+		bit := u32(1) << (index % 32)
+		unsafe {
+			if meta[index / 32].bitmap & bit != 0 {
+				return false
+			}
+			meta[index / 32].bitmap ^= bit
+		}
+		return true
+	}
+	return zone_bits_mark_free_ref(arena.zba_bits_ref_ptr(meta.bitmap),
+		u32(1) << (meta.bitmap >> zba_order_shift), index)
+}
+
+pub fn zone_meta_bits_merge(meta &PageMetadata, arena &Buddy, chunks u32, start u32, end u32) {
+	if meta.is_inline() {
+		zone_bits_merge_inline(meta, chunks, start, end)
+	} else {
+		zone_bits_merge_ref(arena.zba_bits_ref_ptr(meta.bitmap),
+			u32(1) << (meta.bitmap >> zba_order_shift), start, end)
+	}
+}
+
+// Caller supplies its per-CPU cursor. A Vinix shared-lock adapter may instead
+// keep one cursor per slab class, which is a documented behavioral difference.
+pub fn zone_meta_find_and_clear_bit(meta &PageMetadata, arena &Buddy, chunks u32,
+	last &u16) u64 {
+	start := u64(unsafe { *last }) + 1
+	mut index := no_element
+	if meta.is_inline() {
+		index = zba_scan_bitmap_inline(meta, chunks, start)
+	} else {
+		index = zba_scan_bitmap_ref(arena.zba_bits_ref_ptr(meta.bitmap),
+			u32(1) << (meta.bitmap >> zba_order_shift), start)
+	}
+	if index != no_element {
+		unsafe { *last = u16(index) }
+	}
+	return index
+}

--- a/kernel/modules/xnualloc/buddy.v
+++ b/kernel/modules/xnualloc/buddy.v
@@ -1,0 +1,414 @@
+/*
+ * Copyright (c) 2000-2020 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/*
+ * @OSF_COPYRIGHT@
+ */
+/*
+ * Mach Operating System
+ * Copyright (c) 1991,1990,1989,1988,1987 Carnegie Mellon University
+ * All Rights Reserved.
+ *
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ *
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+ * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ *
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie Mellon
+ * the rights to redistribute these changes.
+ */
+// Modified 2026-09-11: C-to-V translation and explicitly documented adaptations.
+// Upstream: apple-oss-distributions/xnu f6217f891ac0bb64f3d375211650a4c1ff8ca1ea,
+// osfmk/kern/zalloc.c. See docs/xnualloc/PORT_STATUS.md and
+// kernel/modules/xnualloc/APPLE_LICENSE.
+// These translations retain APSL 2.0; they are NOT relicensed as GPL.
+
+
+@[manualfree]
+module xnualloc
+
+// Translation of XNU's zba_* buddy allocator, including both free-list banks,
+// split-bit coalescing, relative indices and packed bitmap references.
+//
+// BACKING ADAPTATION: the caller supplies an already mapped, page-aligned arena.
+// zba_grow initializes another chunk of that arena; it cannot populate VM or
+// wait for VM_PAGE_WAIT. Exhaustion returns 0 rather than sleeping/panicking.
+// This object is not internally synchronized. Hold one external arena lock.
+// Do not reinitialize, move the backing arena, or use stale/double-freed refs.
+pub struct Buddy {
+mut:
+	base        u64
+	bytes       u64
+	chunk_size  u64
+	max_order   u32
+	head_count  u32
+	extra_base  u64
+	extra_bytes u64
+	extra_shift u32
+}
+
+@[packed]
+struct BitsChain {
+mut:
+	next u32
+	prev u32
+}
+
+// The first two u32 words are zbam_left / zbam_right. The list heads follow.
+// Computing their offsets permits the exact 4 KiB and 16 KiB XNU geometries
+// without making a fixed-size V array change the upstream header size.
+fn (b &Buddy) header_bytes() u64 {
+	return b.chunk_size / 64
+}
+
+fn (b &Buddy) meta_words() &u32 {
+	return unsafe { &u32(b.base + b.header_bytes()) }
+}
+
+fn (b &Buddy) left() u32 {
+	return unsafe { b.meta_words()[0] }
+}
+
+fn (b &Buddy) right() u32 {
+	return unsafe { b.meta_words()[1] }
+}
+
+fn zero_words(base u64, bytes u64) {
+	assert bytes % 8 == 0
+	unsafe {
+		mut p := &u64(base)
+		for i := u64(0); i < bytes / 8; i++ {
+			p[i] = 0
+		}
+	}
+}
+
+// page_shift must be 12 or 14. The arena must outlive every bitmap reference.
+// Only the first chunk is initialized now; others are initialized on growth.
+pub fn buddy_init(arena voidptr, bytes u64, page_shift u32) ?Buddy {
+	base := u64(arena)
+	if (page_shift != 12 && page_shift != 14) || base == 0 {
+		return none
+	}
+	chunk := u64(1) << page_shift
+	if base % chunk != 0 || bytes < chunk || bytes % chunk != 0
+		|| bytes > (u64(zba_ptr_mask) + 1) * 8 || base > u64(-1) - bytes {
+		return none
+	}
+	mut b := Buddy{
+		base: base
+		bytes: bytes
+		chunk_size: chunk
+		max_order: page_shift - 4
+		head_count: page_shift - 3
+	}
+	zero_words(base, chunk)
+	unsafe {
+		mut meta := b.meta_words()
+		meta[0] = 1
+		meta[1] = u32(bytes / chunk)
+	}
+	b.zba_init_chunk(0, false)
+	return b
+}
+
+// Optional prebacked VM-tracking shadow. Requests with_extra fail unless this
+// is configured; they never pretend that the shadow exists. No VM mapping or
+// Apple tagging machinery is implemented by this library.
+pub fn (mut b Buddy) configure_extra(arena voidptr, bytes u64, shift u32) bool {
+	if b.base == 0 || b.extra_base != 0 || u64(arena) == 0 || shift > 8 {
+		return false
+	}
+	scale := u64(8) << shift
+	if b.bytes > u64(-1) / scale || bytes < b.bytes * scale
+		|| u64(arena) % 8 != 0 || u64(arena) > u64(-1) - bytes {
+		return false
+	}
+	// Separate storage is required; otherwise population would overwrite the
+	// allocator itself. The caller must likewise avoid overlap with other users.
+	if u64(arena) < b.base + b.bytes && b.base < u64(arena) + bytes {
+		return false
+	}
+	b.extra_base = u64(arena)
+	b.extra_bytes = bytes
+	b.extra_shift = shift
+	return true
+}
+
+fn (b &Buddy) zba_head(order u32, with_extra bool) &BitsChain {
+	assert order <= b.max_order
+	bank := if with_extra { b.head_count } else { u32(0) }
+	return unsafe { &BitsChain(b.base + b.header_bytes() + 8 + u64(bank + order) * 8) }
+}
+
+fn (b &Buddy) zba_chain_for_index(index u32) &BitsChain {
+	assert index != 0 && u64(index) * 8 + 8 <= b.bytes
+	return unsafe { &BitsChain(b.base + u64(index) * 8) }
+}
+
+fn (b &Buddy) zba_chain_to_index(chain &BitsChain) u32 {
+	addr := u64(chain)
+	assert addr >= b.base && addr < b.base + b.bytes && (addr - b.base) % 8 == 0
+	return u32((addr - b.base) / 8)
+}
+
+fn (mut b Buddy) zba_push_block(chain &BitsChain, order u32, with_extra bool) {
+	unsafe {
+		mut hd := b.zba_head(order, with_extra)
+		hd_index := b.zba_chain_to_index(hd)
+		index := b.zba_chain_to_index(chain)
+		if hd.next != 0 {
+			mut next := b.zba_chain_for_index(hd.next)
+			if next.prev != hd_index {
+				panic('xnualloc: zone bits allocator head is corrupt')
+			}
+			next.prev = index
+		}
+		mut node := chain
+		node.next = hd.next
+		node.prev = hd_index
+		hd.next = index
+	}
+}
+
+fn (mut b Buddy) zba_remove_block(chain &BitsChain) {
+	unsafe {
+		mut prev := b.zba_chain_for_index(chain.prev)
+		index := b.zba_chain_to_index(chain)
+		if prev.next != index {
+			panic('xnualloc: zone bits allocator previous link is corrupt')
+		}
+		prev.next = chain.next
+		if chain.next != 0 {
+			mut next := b.zba_chain_for_index(chain.next)
+			if next.prev != index {
+				panic('xnualloc: zone bits allocator next link is corrupt')
+			}
+			next.prev = chain.prev
+		}
+	}
+}
+
+fn (mut b Buddy) zba_try_pop_block(order u32, with_extra bool) u64 {
+	hd := b.zba_head(order, with_extra)
+	if hd.next == 0 {
+		return 0
+	}
+	chain := b.zba_chain_for_index(hd.next)
+	b.zba_remove_block(chain)
+	return u64(chain)
+}
+
+@[inline]
+fn zba_node_parent(node u64) u64 {
+	assert node != 0
+	return (node - 1) / 2
+}
+
+@[inline]
+fn zba_node_left_child(node u64) u64 {
+	return node * 2 + 1
+}
+
+@[inline]
+fn zba_node_buddy(node u64) u64 {
+	assert node != 0
+	return ((node - 1) ^ 1) + 1
+}
+
+fn (b &Buddy) zba_node(addr u64, order u32) u64 {
+	offs := (addr % b.chunk_size) / 8
+	return (offs >> order) + (u64(1) << (b.max_order - order + 1)) - 1
+}
+
+fn (b &Buddy) zba_chain_for_node(header u64, node u64, order u32) &BitsChain {
+	offs := (node - (u64(1) << (b.max_order - order + 1)) + 1) << order
+	return unsafe { &BitsChain(header + offs * 8) }
+}
+
+fn zba_node_flip_split(header u64, node u64) {
+	unsafe {
+		mut bits := &u64(header)
+		bits[node / 64] ^= u64(1) << (node % 64)
+	}
+}
+
+fn zba_node_is_split(header u64, node u64) bool {
+	return unsafe { (&u64(header))[node / 64] & (u64(1) << (node % 64)) != 0 }
+}
+
+fn (b &Buddy) zba_chunk_header_size(index u32) u64 {
+	return b.header_bytes() + if index == 0 { u64(8) + u64(b.head_count) * 16 } else { u64(0) }
+}
+
+fn (mut b Buddy) zba_init_chunk(index u32, with_extra bool) {
+	hdr_size := b.zba_chunk_header_size(index)
+	page := b.base + u64(index) * b.chunk_size
+	mut size := b.chunk_size
+	for o := int(b.max_order); o >= 0; o-- {
+		block := u64(8) << u32(o)
+		if size < hdr_size + block {
+			continue
+		}
+		size -= block
+		node := b.zba_node(page + size, u32(o))
+		zba_node_flip_split(page, zba_node_parent(node))
+		b.zba_push_block(b.zba_chain_for_node(page, node, u32(o)), u32(o), with_extra)
+	}
+}
+
+// This is the sole backing-policy adaptation to the C zba_grow path: mapped
+// storage is already owned. We return failure at the arena limit, never wait.
+fn (mut b Buddy) zba_grow(with_extra bool) bool {
+	if b.left() >= b.right() || (with_extra && b.extra_base == 0) {
+		return false
+	}
+	index := if with_extra { b.right() - 1 } else { b.left() }
+	zero_words(b.base + u64(index) * b.chunk_size, b.chunk_size)
+	if with_extra {
+		xsize := b.chunk_size * 8 << b.extra_shift
+		zero_words(b.extra_base + u64(index) * xsize, xsize)
+	}
+	unsafe {
+		mut meta := b.meta_words()
+		if with_extra {
+			meta[1]--
+		} else {
+			meta[0]++
+		}
+	}
+	b.zba_init_chunk(index, with_extra)
+	return true
+}
+
+pub fn (mut b Buddy) zba_alloc(order u32, with_extra bool) u64 {
+	if b.base == 0 || order > b.max_order || (with_extra && b.extra_base == 0) {
+		return 0
+	}
+	mut current := order
+	mut addr := b.zba_try_pop_block(current, with_extra)
+	for addr == 0 {
+		if current >= b.max_order {
+			if !b.zba_grow(with_extra) {
+				return 0
+			}
+			current = order
+		} else {
+			current++
+		}
+		addr = b.zba_try_pop_block(current, with_extra)
+	}
+	header := addr & ~(b.chunk_size - 1)
+	mut node := b.zba_node(addr, current)
+	zba_node_flip_split(header, zba_node_parent(node))
+	for current > order {
+		current--
+		zba_node_flip_split(header, node)
+		node = zba_node_left_child(node)
+		b.zba_push_block(b.zba_chain_for_node(header, node + 1, current), current, with_extra)
+	}
+	return addr
+}
+
+pub fn (mut b Buddy) zba_free(addr u64, initial_order u32, with_extra bool) {
+	assert b.base != 0 && initial_order <= b.max_order
+	assert addr >= b.base && addr < b.base + b.bytes
+	assert addr % (u64(8) << initial_order) == 0
+	index := u32((addr - b.base) / b.chunk_size)
+	assert (with_extra && b.extra_base != 0 && index >= b.right())
+		|| (!with_extra && index < b.left())
+	assert addr % b.chunk_size >= b.zba_chunk_header_size(index)
+	assert addr % b.chunk_size + (u64(8) << initial_order) <= b.chunk_size
+	header := addr & ~(b.chunk_size - 1)
+	mut order := initial_order
+	mut node := b.zba_node(addr, order)
+	for node != 0 {
+		parent := zba_node_parent(node)
+		zba_node_flip_split(header, parent)
+		if zba_node_is_split(header, parent) {
+			break
+		}
+		chain := b.zba_chain_for_node(header, zba_node_buddy(node), order)
+		b.zba_remove_block(chain)
+		order++
+		node = parent
+	}
+	assert order <= b.max_order
+	b.zba_push_block(b.zba_chain_for_node(header, node, order), order, with_extra)
+}
+
+pub fn (b &Buddy) zba_bits_ref_ptr(reference u32) &u64 {
+	order := reference >> zba_order_shift
+	index := reference & zba_ptr_mask
+	assert b.base != 0 && index != 0 && order <= 7
+	assert u64(index) * 8 + (u64(8) << order) <= b.bytes
+	return unsafe { &u64(b.base + u64(index) * 8) }
+}
+
+pub fn (b &Buddy) zba_extra_ref_ptr(reference u32, index u64) voidptr {
+	assert b.extra_base != 0 && reference & zba_has_extra_bit != 0
+	assert index < (u64(64) << (reference >> zba_order_shift))
+	offs := u64(reference & zba_ptr_mask) * 64
+	assert ((offs + index + 1) << b.extra_shift) <= b.extra_bytes
+	return voidptr(b.extra_base + ((offs + index) << b.extra_shift))
+}
+
+pub fn (mut b Buddy) zone_meta_bits_alloc_init(count u32, nbits u32, with_extra bool) u32 {
+	if nbits == 0 || nbits > 8192 || count > nbits {
+		return 0
+	}
+	mut scale := (nbits - 1) / 64
+	mut order := u32(0)
+	for scale != 0 {
+		order++
+		scale >>= 1
+	}
+	addr := b.zba_alloc(order, with_extra)
+	if addr == 0 {
+		return 0
+	}
+	zone_bits_init_ref(unsafe { &u64(addr) }, u32(1) << order, count)
+	return u32((addr - b.base) / 8) | (order << zba_order_shift) |
+		if with_extra { zba_has_extra_bit } else { u32(0) }
+}
+
+pub fn (mut b Buddy) zone_bits_free(reference u32) {
+	addr := u64(b.zba_bits_ref_ptr(reference))
+	b.zba_free(addr, reference >> zba_order_shift, reference & zba_has_extra_bit != 0)
+}

--- a/kernel/modules/xnualloc/magazine.v
+++ b/kernel/modules/xnualloc/magazine.v
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2000-2020 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/*
+ * @OSF_COPYRIGHT@
+ */
+/*
+ * Mach Operating System
+ * Copyright (c) 1991,1990,1989,1988,1987 Carnegie Mellon University
+ * All Rights Reserved.
+ *
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ *
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+ * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ *
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie Mellon
+ * the rights to redistribute these changes.
+ */
+// Modified 2026-09-11: C-to-V translation and explicitly documented adaptations.
+// Upstream: apple-oss-distributions/xnu f6217f891ac0bb64f3d375211650a4c1ff8ca1ea,
+// osfmk/kern/zalloc.c. See docs/xnualloc/PORT_STATUS.md and
+// kernel/modules/xnualloc/APPLE_LICENSE.
+// These translations retain APSL 2.0; they are NOT relicensed as GPL.
+
+
+@[manualfree]
+module xnualloc
+
+// Data-structure translations only. These are NOT enabled as Vinix per-CPU
+// caches. Their callers must supply CPU pinning, locks, ownership transitions,
+// refill, accounting and safe reclamation. No SMR grace-period implementation
+// is hidden behind a successful stub. Depot polling requires an explicit poll
+// callback when SMR is requested.
+//
+// Storage adaptation: the flexible C array has a fixed 32-element capacity.
+pub const magazine_capacity = u16(32)
+
+pub struct Magazine {
+pub mut:
+	next  &Magazine = unsafe { nil }
+	seq   u64
+	elems [32]u64
+}
+
+pub struct Cache {
+pub mut:
+	alloc_cur u16
+	free_cur  u16
+	alloc_mag &Magazine = unsafe { nil }
+	free_mag  &Magazine = unsafe { nil }
+}
+
+// One chain, as in XNU: full magazines precede empty magazines, and tail is
+// the address of the link separating the two portions. A Depot MUST NOT MOVE
+// after init(), because tail may point to its own head field.
+pub struct Depot {
+pub mut:
+	head  &Magazine = unsafe { nil }
+	tail  &&Magazine = unsafe { nil }
+	full  u32
+	empty u32
+}
+
+// The zone's recirculation minima are explicit parameters in this port.
+pub struct RecircMinimum {
+pub mut:
+	full  u32
+	empty u32
+}
+
+pub fn (mut d Depot) zone_depot_init() {
+	d.head = unsafe { nil }
+	d.full = 0
+	d.empty = 0
+	unsafe { d.tail = &d.head }
+}
+
+pub fn (mut d Depot) zone_depot_insert_head_full(mut mag Magazine) {
+	assert d.tail != unsafe { nil }
+	if d.full == 0 {
+		unsafe { d.tail = &mag.next }
+	}
+	d.full++
+	mag.next = d.head
+	unsafe { d.head = mag }
+}
+
+pub fn (mut d Depot) zone_depot_insert_tail_full(mut mag Magazine) {
+	assert d.tail != unsafe { nil }
+	d.full++
+	unsafe {
+		mag.next = *d.tail
+		*d.tail = mag
+		d.tail = &mag.next
+	}
+}
+
+pub fn (mut d Depot) zone_depot_insert_head_empty(mut mag Magazine) {
+	assert d.tail != unsafe { nil }
+	d.empty++
+	unsafe {
+		mag.next = *d.tail
+		*d.tail = mag
+	}
+}
+
+pub fn (mut d Depot) zone_depot_pop_head_full(minimum &RecircMinimum) &Magazine {
+	assert d.full != 0
+	mut mag := d.head
+	d.full--
+	unsafe {
+		if minimum != nil && minimum.full > d.full {
+			mut m := minimum
+			m.full = d.full
+		}
+		d.head = mag.next
+		if d.full == 0 {
+			d.tail = &d.head
+		}
+		mag.next = nil
+	}
+	return mag
+}
+
+pub fn (mut d Depot) zone_depot_pop_head_empty(minimum &RecircMinimum) &Magazine {
+	assert d.empty != 0
+	unsafe {
+		mut mag := *d.tail
+		d.empty--
+		if minimum != nil && minimum.empty > d.empty {
+			mut m := minimum
+			m.empty = d.empty
+		}
+		*d.tail = mag.next
+		mag.next = nil
+		return mag
+	}
+}
+
+// lifo is the supplied equivalent of zone_security_array[zid].z_lifo.
+// Source and destination must be distinct, initialized, externally locked.
+pub fn (mut dst Depot) zone_depot_move_full(mut src Depot, n u32,
+	minimum &RecircMinimum, lifo bool) u64 {
+	assert n > 0 && src.full >= n && &dst != &src
+	src.full -= n
+	unsafe {
+		if minimum != nil && minimum.full > src.full {
+			mut m := minimum
+			m.full = src.full
+		}
+		head := src.head
+		mut last := head
+		for i := u32(1); i < n; i++ {
+			last = last.next
+		}
+		src.head = last.next
+		if src.full == 0 {
+			src.tail = &src.head
+		}
+		if lifo {
+			if dst.full == 0 {
+				dst.tail = &last.next
+			}
+			last.next = dst.head
+			dst.head = head
+		} else {
+			last.next = *dst.tail
+			*dst.tail = head
+			dst.tail = &last.next
+		}
+		dst.full += n
+		return last.seq
+	}
+}
+
+pub fn (mut dst Depot) zone_depot_move_empty(mut src Depot, n u32,
+	minimum &RecircMinimum) {
+	assert n > 0 && src.empty >= n && &dst != &src
+	src.empty -= n
+	unsafe {
+		if minimum != nil && minimum.empty > src.empty {
+			mut m := minimum
+			m.empty = src.empty
+		}
+		head := *src.tail
+		mut last := head
+		for i := u32(1); i < n; i++ {
+			last = last.next
+		}
+		*src.tail = last.next
+		dst.empty += n
+		last.next = *dst.tail
+		*dst.tail = head
+	}
+}
+
+pub fn (d &Depot) zone_depot_poll(use_smr bool, poll fn (u64) bool) bool {
+	if d.full == 0 {
+		return false
+	}
+	if !use_smr {
+		return true
+	}
+	// Explicit failure is essential: treating every SMR sequence as ready
+	// would permit use-after-free of still-observed objects.
+	if poll == unsafe { nil } {
+		return false
+	}
+	return poll(d.head.seq)
+}
+
+pub fn (mut c Cache) zone_cache_swap_magazines() {
+	assert c.alloc_cur <= magazine_capacity && c.free_cur <= magazine_capacity
+	count_a := c.alloc_cur
+	count_f := c.free_cur
+	elems_a := c.alloc_mag
+	elems_f := c.free_mag
+	c.alloc_cur = count_f
+	c.free_cur = count_a
+	c.alloc_mag = elems_f
+	c.free_mag = elems_a
+}
+
+pub fn (mut c Cache) zone_magazine_replace(mut mag Magazine, empty bool) &Magazine {
+	mag.seq = 0 // SMR_SEQ_INVALID
+	mut old := unsafe { &Magazine(nil) }
+	if empty {
+		old = c.free_mag
+		c.free_cur = 0
+		unsafe { c.free_mag = mag }
+	} else {
+		old = c.alloc_mag
+		c.alloc_cur = magazine_capacity
+		unsafe { c.alloc_mag = mag }
+	}
+	return old
+}
+
+// Non-SMR fast-path operations from zalloc/zfree's cache paths, exposed for
+// differential testing. 0/false asks the caller to refill/trim; it is not OOM.
+pub fn (mut c Cache) try_alloc() u64 {
+	assert c.alloc_mag != unsafe { nil } && c.free_mag != unsafe { nil }
+	if c.alloc_cur == 0 && c.free_cur != 0 {
+		c.zone_cache_swap_magazines()
+	}
+	if c.alloc_cur == 0 {
+		return 0
+	}
+	c.alloc_cur--
+	value := c.alloc_mag.elems[int(c.alloc_cur)]
+	c.alloc_mag.elems[int(c.alloc_cur)] = 0
+	return value
+}
+
+pub fn (mut c Cache) try_free(value u64) bool {
+	assert value != 0 && c.alloc_mag != unsafe { nil } && c.free_mag != unsafe { nil }
+	if c.free_cur == magazine_capacity && c.alloc_cur < magazine_capacity {
+		c.zone_cache_swap_magazines()
+	}
+	if c.free_cur == magazine_capacity {
+		return false
+	}
+	c.free_mag.elems[int(c.free_cur)] = value
+	c.free_cur++
+	return true
+}

--- a/kernel/modules/xnualloc/magazine.v
+++ b/kernel/modules/xnualloc/magazine.v
@@ -63,11 +63,11 @@
 @[manualfree]
 module xnualloc
 
-// Data-structure translations only. These are NOT enabled as Vinix per-CPU
-// caches. Their callers must supply CPU pinning, locks, ownership transitions,
-// refill, accounting and safe reclamation. No SMR grace-period implementation
-// is hidden behind a successful stub. Depot polling requires an explicit poll
-// callback when SMR is requested.
+// Data-structure translations used by zone.v and its opt-in Vinix adapter.
+// Callers supply CPU pinning, locks, ownership transitions, refill, accounting
+// and safe reclamation. No SMR grace-period implementation is hidden behind
+// a successful stub. Depot polling requires an explicit poll callback when
+// SMR is requested; the zone.v backend is strictly non-SMR.
 //
 // Storage adaptation: the flexible C array has a fixed 32-element capacity.
 pub const magazine_capacity = u16(32)
@@ -178,7 +178,7 @@ pub fn (mut d Depot) zone_depot_pop_head_empty(minimum &RecircMinimum) &Magazine
 // Source and destination must be distinct, initialized, externally locked.
 pub fn (mut dst Depot) zone_depot_move_full(mut src Depot, n u32,
 	minimum &RecircMinimum, lifo bool) u64 {
-	assert n > 0 && src.full >= n && &dst != &src
+	assert n > 0 && src.full >= n && u64(&dst) != u64(&src)
 	src.full -= n
 	unsafe {
 		if minimum != nil && minimum.full > src.full {
@@ -212,7 +212,7 @@ pub fn (mut dst Depot) zone_depot_move_full(mut src Depot, n u32,
 
 pub fn (mut dst Depot) zone_depot_move_empty(mut src Depot, n u32,
 	minimum &RecircMinimum) {
-	assert n > 0 && src.empty >= n && &dst != &src
+	assert n > 0 && src.empty >= n && u64(&dst) != u64(&src)
 	src.empty -= n
 	unsafe {
 		if minimum != nil && minimum.empty > src.empty {

--- a/kernel/modules/xnualloc/zone.v
+++ b/kernel/modules/xnualloc/zone.v
@@ -1,0 +1,586 @@
+/*
+ * Copyright (c) 2000-2020 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/*
+ * @OSF_COPYRIGHT@
+ */
+/*
+ * Mach Operating System
+ * Copyright (c) 1991,1990,1989,1988,1987 Carnegie Mellon University
+ * All Rights Reserved.
+ *
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ *
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+ * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ *
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie Mellon
+ * the rights to redistribute these changes.
+ */
+// Modified 2026-09-11: C-to-V translation and explicitly documented adaptations.
+// Upstream: apple-oss-distributions/xnu f6217f891ac0bb64f3d375211650a4c1ff8ca1ea,
+// osfmk/kern/zalloc.c. See docs/xnualloc/PORT_STATUS.md and
+// kernel/modules/xnualloc/APPLE_LICENSE.
+// These translations retain APSL 2.0; they are NOT relicensed as GPL.
+
+
+@[manualfree]
+module xnualloc
+
+// Adapted translations of the ordinary, non-SMR zone paths in zalloc.c.
+// Every entry below requires ONE external lock covering the Zone, its chunks,
+// all CPU caches and both depot layers. This deliberately does not claim XNU's
+// lock-free CPU fast path. No function allocates from a language/runtime heap.
+// Storage providers own mapping, CPU pinning, allocation failure and page free.
+// Addresses and identities are compared numerically (not V struct equality).
+
+pub enum ChunkQueue {
+	detached
+	empty
+	partial
+	full
+}
+
+pub struct ZoneChunk {
+pub mut:
+	owner    u64
+	base     u64
+	bytes    u64
+	offset   u64
+	pages    u32
+	capacity u32
+	reserved u32 // includes cached objects, not only client-live objects
+	words    u32
+	bits     &u64 = unsafe { nil } // 1 = available to zone import
+	live     &u64 = unsafe { nil } // port addition: 1 = handed to a client
+	prev     &ZoneChunk = unsafe { nil }
+	next     &ZoneChunk = unsafe { nil }
+	queue    ChunkQueue
+}
+
+pub struct Zone {
+pub mut:
+	elem_size    u64
+	empty        &ZoneChunk = unsafe { nil }
+	partial      &ZoneChunk = unsafe { nil }
+	full         &ZoneChunk = unsafe { nil }
+	elems_avail  u64
+	elems_free   u64
+	live_count   u64
+	wired        u64
+	wired_empty  u64
+	free_min     u64
+	alloc_rr     u16
+	recirc       Depot
+	minimum      RecircMinimum
+	// Non-SMR depot cap, in magazines. 0 means direct recirculation.
+	depot_max    u32
+	lifo         bool
+	// Optional O(1) metadata lookup. Must return stable, owned metadata for
+	// valid objects. Arbitrary/unmapped pointers are not a supported input.
+	resolve      fn (u64) &ZoneChunk = unsafe { nil }
+}
+
+pub struct CpuCache {
+pub mut:
+	cache        Cache
+	depot        Depot
+	alloc_rr     u16
+	ready        bool
+	// Two active magazines plus four spare containers. All have stable
+	// addresses for the lifetime of the Zone, even when owned by recirc.
+	storage      [6]Magazine
+}
+
+pub fn (mut z Zone) zone_init(size u64, depot_max u32) bool {
+	if z.elem_size != 0 || size == 0 || size > 32768 || depot_max > 4 {
+		return false
+	}
+	z.elem_size = size
+	z.depot_max = depot_max
+	z.recirc.zone_depot_init()
+	return true
+}
+
+pub fn (mut c CpuCache) cache_init() bool {
+	if c.ready {
+		return false
+	}
+	c.depot.zone_depot_init()
+	unsafe {
+		c.cache.alloc_mag = &c.storage[0]
+		c.cache.free_mag = &c.storage[1]
+	}
+	for i := 2; i < 6; i++ {
+		c.depot.zone_depot_insert_head_empty(mut c.storage[i])
+	}
+	c.ready = true
+	return true
+}
+
+fn (mut z Zone) queue_head(q ChunkQueue) &ZoneChunk {
+	return match q {
+		.empty { z.empty }
+		.partial { z.partial }
+		.full { z.full }
+		else { unsafe { nil } }
+	}
+}
+
+fn (mut z Zone) queue_set_head(q ChunkQueue, p &ZoneChunk) {
+	match q {
+		.empty { unsafe { z.empty = p } }
+		.partial { unsafe { z.partial = p } }
+		.full { unsafe { z.full = p } }
+		else { assert false }
+	}
+}
+
+// zone_meta_queue_push/remqueue/requeue with explicit pointers rather than
+// XNU's packed zone-page virtual-address indices.
+fn (mut z Zone) zone_meta_remqueue(mut p ZoneChunk) {
+	assert p.owner == u64(&z) && p.queue != .detached
+	if p.prev == unsafe { nil } {
+		assert u64(z.queue_head(p.queue)) == u64(&p)
+		z.queue_set_head(p.queue, p.next)
+	} else {
+		assert u64(p.prev.next) == u64(&p)
+		p.prev.next = p.next
+	}
+	if p.next != unsafe { nil } {
+		assert u64(p.next.prev) == u64(&p)
+		p.next.prev = p.prev
+	}
+	p.prev = unsafe { nil }
+	p.next = unsafe { nil }
+	p.queue = .detached
+}
+
+fn (mut z Zone) zone_meta_queue_push(mut p ZoneChunk, q ChunkQueue) {
+	assert p.queue == .detached && q != .detached
+	p.next = z.queue_head(q)
+	p.prev = unsafe { nil }
+	if p.next != unsafe { nil } {
+		unsafe { p.next.prev = &p }
+	}
+	z.queue_set_head(q, &p)
+	p.queue = q
+}
+
+fn (mut z Zone) zone_meta_requeue(mut p ZoneChunk, q ChunkQueue) {
+	if p.queue == q {
+		return
+	}
+	z.zone_meta_remqueue(mut p)
+	z.zone_meta_queue_push(mut p, q)
+}
+
+// Fully backed chunk installation: the completed-population portion of zcram.
+// Partial Mach VM population/secondary-page metadata are not synthesized.
+// The bitmap word count must be a power of two, at most 128, as in zba.
+pub fn (mut z Zone) zcram(mut p ZoneChunk) bool {
+	if z.elem_size == 0 || p.owner != 0 || p.queue != .detached || p.base == 0
+		|| p.bytes == 0 || p.base > u64(-1) - p.bytes || p.offset >= p.bytes
+		|| p.pages == 0 || p.words == 0 || p.words > 128
+		|| p.words & (p.words - 1) != 0 || p.bits == unsafe { nil }
+		|| p.live == unsafe { nil } || u64(p.bits) == u64(p.live) {
+		return false
+	}
+	capacity := (p.bytes - p.offset) / z.elem_size
+	if capacity == 0 || capacity > u64(p.words) * 64
+		|| z.elems_avail > u64(-1) - capacity || z.wired > u64(-1) - p.pages {
+		return false
+	}
+	p.owner = u64(&z)
+	p.capacity = u32(capacity)
+	p.reserved = 0
+	zone_bits_init_ref(p.bits, p.words, p.capacity)
+	unsafe {
+		for i := u32(0); i < p.words; i++ {
+			p.live[i] = 0
+		}
+	}
+	z.zone_meta_queue_push(mut p, .empty)
+	z.elems_avail += capacity
+	z.elems_free += capacity
+	z.wired += p.pages
+	z.wired_empty += p.pages
+	return true
+}
+
+pub fn (mut z Zone) zone_element_resolve(addr u64) &ZoneChunk {
+	if z.resolve != unsafe { nil } {
+		p := z.resolve(addr)
+		if p != unsafe { nil } && p.owner == u64(&z) && z.slot(p, addr) != no_element {
+			return p
+		}
+		return unsafe { nil }
+	}
+	// Portable/test fallback. A Vinix resolver avoids this list traversal.
+	heads := [z.full, z.partial, z.empty]!
+	for head in heads {
+		mut p := head
+		for p != unsafe { nil } {
+			if z.slot(p, addr) != no_element {
+				return p
+			}
+			p = p.next
+		}
+	}
+	return unsafe { nil }
+}
+
+fn (z &Zone) slot(p &ZoneChunk, addr u64) u64 {
+	if p.owner != u64(z) || p.queue == .detached || addr < p.base + p.offset {
+		return no_element
+	}
+	offs := addr - p.base - p.offset
+	if offs % z.elem_size != 0 || offs / z.elem_size >= p.capacity {
+		return no_element
+	}
+	return offs / z.elem_size
+}
+
+// Translation of zalloc_import's bitmap reservation and queue transitions.
+// Reserve n elements; none is client-live until zone_mark_valid. n==0 is a
+// port-defined no-op. No mutation occurs for an unavailable batch.
+pub fn (mut z Zone) zalloc_import(out &u64, n u32, rr &u16) bool {
+	if n == 0 {
+		return true
+	}
+	if out == unsafe { nil } || rr == unsafe { nil } || u64(n) > z.elems_free {
+		return false
+	}
+	mut done := u32(0)
+	for done < n {
+		mut p := z.partial
+		if p == unsafe { nil } {
+			p = z.empty
+		}
+		assert p != unsafe { nil }
+		old := p.reserved
+		if old == 0 {
+			z.wired_empty -= p.pages
+		}
+		for done < n && p.reserved < p.capacity {
+			// Normalize across chunks with different bitmap capacities.
+			start := (u64(unsafe { *rr }) + 1) % (u64(p.words) * 64)
+			index := zba_scan_bitmap_ref(p.bits, p.words, start)
+			assert index < p.capacity
+			unsafe { *rr = u16(index) }
+			unsafe { out[done] = p.base + p.offset + index * z.elem_size }
+			p.reserved++
+			done++
+		}
+		if p.reserved == p.capacity {
+			z.zone_meta_requeue(mut p, .full)
+		} else if old == 0 {
+			z.zone_meta_requeue(mut p, .partial)
+		}
+	}
+	z.elems_free -= n
+	if z.free_min > z.elems_free {
+		z.free_min = z.elems_free
+	}
+	return true
+}
+
+// Extra client-live bitmap prevents accepting a second free into a cache.
+// It does not detect stale pointers after the slot is reallocated.
+pub fn (mut z Zone) zone_mark_valid(addr u64) bool {
+	mut p := z.zone_element_resolve(addr)
+	if p == unsafe { nil } {
+		return false
+	}
+	i := z.slot(p, addr)
+	bit := u64(1) << (i % 64)
+	unsafe {
+		if p.bits[i / 64] & bit != 0 || p.live[i / 64] & bit != 0 {
+			return false
+		}
+		p.live[i / 64] |= bit
+	}
+	z.live_count++
+	return true
+}
+
+pub fn (mut z Zone) zone_mark_invalid(addr u64) bool {
+	mut p := z.zone_element_resolve(addr)
+	if p == unsafe { nil } {
+		return false
+	}
+	i := z.slot(p, addr)
+	bit := u64(1) << (i % 64)
+	unsafe {
+		if p.bits[i / 64] & bit != 0 || p.live[i / 64] & bit == 0 {
+			return false
+		}
+		p.live[i / 64] &= ~bit
+	}
+	assert z.live_count != 0
+	z.live_count--
+	return true
+}
+
+// Translation of zfree_drop. Caller has already invalidated the client
+// object or is returning a never-exposed reserved object during cache drain.
+pub fn (mut z Zone) zfree_drop(addr u64) bool {
+	mut p := z.zone_element_resolve(addr)
+	if p == unsafe { nil } || p.reserved == 0 {
+		return false
+	}
+	i := z.slot(p, addr)
+	unsafe {
+		if p.live[i / 64] & (u64(1) << (i % 64)) != 0 {
+			return false
+		}
+	}
+	if !zone_bits_mark_free_ref(p.bits, p.words, i) {
+		return false
+	}
+	old := p.reserved
+	p.reserved--
+	z.elems_free++
+	if p.reserved == 0 {
+		z.zone_meta_requeue(mut p, .empty)
+		z.wired_empty += p.pages
+	} else if old == p.capacity {
+		z.zone_meta_requeue(mut p, .partial)
+	}
+	return true
+}
+
+// Adapted zone_reclaim_chunk: detach metadata and account under the lock;
+// the adapter MUST release backing after unlocking and never touch it again.
+pub fn (mut z Zone) zone_reclaim_chunk() &ZoneChunk {
+	mut p := z.empty
+	if p == unsafe { nil } {
+		return unsafe { nil }
+	}
+	assert p.reserved == 0
+	z.zone_meta_remqueue(mut p)
+	z.elems_avail -= p.capacity
+	z.elems_free -= p.capacity
+	z.wired -= p.pages
+	z.wired_empty -= p.pages
+	if z.free_min > z.elems_free {
+		z.free_min = z.elems_free
+	}
+	p.owner = 0
+	return p
+}
+
+pub fn (mut z Zone) zone_reclaim_elements(elems &u64, n u16) {
+	assert n <= magazine_capacity
+	unsafe {
+		for i := u16(0); i < n; i++ {
+			addr := elems[i]
+			elems[i] = 0
+			ok := z.zfree_drop(addr)
+			assert ok
+		}
+	}
+}
+
+// Non-SMR translations of zalloc_cached_depot_recirculate and prime.
+fn (mut z Zone) zalloc_cached_depot_recirculate(mut c CpuCache) {
+	max := z.depot_max
+	assert max != 0
+	if c.depot.empty >= max {
+		z.recirc.zone_depot_move_empty(mut c.depot, c.depot.empty - max / 2,
+			unsafe { nil })
+	}
+	mut n := max - c.depot.empty
+	if n > z.recirc.full {
+		n = z.recirc.full
+	}
+	if n != 0 {
+		c.depot.zone_depot_move_full(mut z.recirc, n, &z.minimum, z.lifo)
+	}
+}
+
+fn (mut z Zone) zalloc_cached_prime(mut c CpuCache) {
+	if z.depot_max != 0 {
+		if c.depot.full == 0 {
+			z.zalloc_cached_depot_recirculate(mut c)
+		}
+		if c.depot.full != 0 {
+			mut mag := c.depot.zone_depot_pop_head_full(unsafe { nil })
+			mut old := c.cache.zone_magazine_replace(mut mag, false)
+			c.depot.zone_depot_insert_head_empty(mut old)
+		}
+	} else if z.recirc.full != 0 {
+		mut mag := z.recirc.zone_depot_pop_head_full(&z.minimum)
+		mut old := c.cache.zone_magazine_replace(mut mag, false)
+		z.recirc.zone_depot_insert_head_empty(mut old)
+	}
+	if c.cache.alloc_cur == 0 && z.elems_free != 0 {
+		mut n := u32(magazine_capacity)
+		if z.elems_free < n {
+			n = u32(z.elems_free)
+		}
+		ok := z.zalloc_import(unsafe { &c.cache.alloc_mag.elems[0] }, n, &c.alloc_rr)
+		assert ok
+		c.cache.alloc_cur = u16(n)
+	}
+}
+
+// Return 0 on exhaustion. The adapter can expand outside this state machine
+// and retry. No WAITOK/NOFAIL promises or fake page waits are exposed here.
+pub fn (mut z Zone) zalloc_ext(cache &CpuCache) u64 {
+	mut addr := u64(0)
+	if cache != unsafe { nil } {
+		mut c := unsafe { cache }
+		assert c.ready
+		addr = c.cache.try_alloc()
+		if addr == 0 {
+			z.zalloc_cached_prime(mut c)
+			addr = c.cache.try_alloc()
+		}
+	} else if z.elems_free != 0 {
+		ok := z.zalloc_import(&addr, 1, &z.alloc_rr)
+		assert ok
+	}
+	if addr != 0 {
+		ok := z.zone_mark_valid(addr)
+		assert ok
+	}
+	return addr
+}
+
+fn (mut z Zone) zfree_cached_depot_recirculate(mut c CpuCache) {
+	max := z.depot_max
+	assert max != 0
+	if c.depot.full >= max {
+		z.recirc.zone_depot_move_full(mut c.depot, c.depot.full - max / 2,
+			unsafe { nil }, z.lifo)
+	}
+	mut n := max - c.depot.full
+	if n > z.recirc.empty {
+		n = z.recirc.empty
+	}
+	if n != 0 {
+		c.depot.zone_depot_move_empty(mut z.recirc, n, &z.minimum)
+	}
+}
+
+fn (mut z Zone) zfree_cached_trim(mut c CpuCache) bool {
+	if z.depot_max != 0 {
+		if c.depot.empty == 0 {
+			z.zfree_cached_depot_recirculate(mut c)
+		}
+		if c.depot.empty != 0 {
+			mut mag := c.depot.zone_depot_pop_head_empty(unsafe { nil })
+			mut old := c.cache.zone_magazine_replace(mut mag, true)
+			c.depot.zone_depot_insert_tail_full(mut old)
+			return true
+		}
+	} else {
+		// Fixed container pool adaptation: take a local empty container before
+		// central empties, instead of recursively allocating magazine objects.
+		mut mag := unsafe { &Magazine(nil) }
+		if z.recirc.empty != 0 {
+			mag = z.recirc.zone_depot_pop_head_empty(&z.minimum)
+		} else if c.depot.empty != 0 {
+			mag = c.depot.zone_depot_pop_head_empty(unsafe { nil })
+		}
+		if mag != unsafe { nil } {
+			mut old := c.cache.zone_magazine_replace(mut mag, true)
+			if z.lifo {
+				z.recirc.zone_depot_insert_head_full(mut old)
+			} else {
+				z.recirc.zone_depot_insert_tail_full(mut old)
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// Call after zone_mark_invalid AND any poison/zero operation. The split
+// interface ensures no object is published before the adapter sanitizes it.
+pub fn (mut z Zone) zfree_ext(addr u64, cache &CpuCache) bool {
+	p := z.zone_element_resolve(addr)
+	if p == unsafe { nil } {
+		return false
+	}
+	i := z.slot(p, addr)
+	unsafe {
+		bit := u64(1) << (i % 64)
+		if p.bits[i / 64] & bit != 0 || p.live[i / 64] & bit != 0 {
+			return false
+		}
+	}
+	if cache != unsafe { nil } {
+		mut c := unsafe { cache }
+		assert c.ready
+		if c.cache.try_free(addr) {
+			return true
+		}
+		if z.zfree_cached_trim(mut c) {
+			ok := c.cache.try_free(addr)
+			assert ok
+			return true
+		}
+	}
+	return z.zfree_drop(addr)
+}
+
+// Drain active magazines AND the local depot. This is serialized with every
+// alloc/free by the external lock; the adapter need not interrupt other CPUs.
+pub fn (mut z Zone) zone_drain_cache(mut c CpuCache) {
+	assert c.ready
+	z.zone_reclaim_elements(unsafe { &c.cache.alloc_mag.elems[0] }, c.cache.alloc_cur)
+	z.zone_reclaim_elements(unsafe { &c.cache.free_mag.elems[0] }, c.cache.free_cur)
+	c.cache.alloc_cur = 0
+	c.cache.free_cur = 0
+	for c.depot.full != 0 {
+		mut mag := c.depot.zone_depot_pop_head_full(unsafe { nil })
+		z.zone_reclaim_elements(unsafe { &mag.elems[0] }, magazine_capacity)
+		c.depot.zone_depot_insert_head_empty(mut mag)
+	}
+}
+
+pub fn (mut z Zone) zone_drain_recirc() {
+	for z.recirc.full != 0 {
+		mut mag := z.recirc.zone_depot_pop_head_full(&z.minimum)
+		z.zone_reclaim_elements(unsafe { &mag.elems[0] }, magazine_capacity)
+		z.recirc.zone_depot_insert_head_empty(mut mag)
+	}
+}

--- a/tests/memory/README.md
+++ b/tests/memory/README.md
@@ -1,0 +1,146 @@
+# Reclaimable Vinix heap: draft implementation and comparison
+
+## Status and provenance
+
+Prepared 2026-09-11 against Vinix commit
+`7c085707f535e498ff2ce9a6447d8a5b59844388`. The original `physical.v` and
+`klock_amd64.v` blobs were reconstructed from the GitHub connector and checked
+against Git blob hashes `f8b11f618825eefa39a32bc33e5b2e8af43a3e99` and
+`9dfd1a9c85549b011a9fe286b13ef0c2b4a7855e` respectively.
+
+This is an independent V implementation of familiar slab techniques, NOT a
+C-to-V translation of Apple's allocator. No XNU implementation is copied.
+XNU's inspected `zalloc.c` carries APSL 2.0 terms; Vinix carries GPL v2.
+Source translation must not be treated as permission to discard the original
+license. A literal import needs licensing review and suitable permissions.
+
+**Draft, not production-validated:** ten Python model/source-check tests passed,
+including 100,000 mixed-size operations. `git diff --check` passed. No V compiler
+or QEMU was installed in the authoring environment; the V kernel was not compiled
+or booted there. The Python model is not execution of the V implementation and
+is not an SMP, weak-memory-ordering, or interrupt-safety test. The supplied V boot
+self-test has not been run there. No latency or throughput result is claimed.
+
+## Comparison with XNU
+
+Reference: Apple's public XNU commit
+`f6217f891ac0bb64f3d375211650a4c1ff8ca1ea` (import named `xnu-12377.1.9`). This
+pins the inspected source; it is not a claim that every Apple shipping kernel
+uses exactly that revision or configuration.
+
+Vinix currently allocates physical pages with a globally locked bitmap scan.
+Its heap uses nine classes, 8 through 2048 bytes in powers of two. Each class
+has one lock and an intrusive free-object chain. Slab pages never return to the
+PMM. Larger heap objects use contiguous physical pages plus a whole metadata
+page. Page allocations, kernel virtual mappings, and heap objects are distinct
+layers; replacing the small-object heap does not replace the other two.
+
+XNU's zone layer tracks allocation state and page/chunk occupancy, can reclaim
+empty backing, and offers per-CPU magazines, depots, and batched circulation.
+Its cache design explicitly depends on preemption control. General allocations
+also involve kalloc heaps and, on the relevant paths, type-based segregation.
+VM-backed allocations use Mach VM facilities rather than Vinix's direct PMM
+path. The zone source imports scheduling, locks, VM, pmap, diagnostics and
+security infrastructure: it is not a self-contained malloc.c to translate.
+
+These are substantial architectural advantages in reclaimability, scalability
+and hardening, not evidence of a measured speedup on Vinix. A small, uncontended
+intrusive allocator can have a shorter fast path. XNU itself cites Bonwick and
+Adams' magazine design and FreeBSD UMA in its cache description.
+
+Primary references:
+
+- Vinix heap and PMM: https://github.com/vlang/vinix/blob/7c085707f535e498ff2ce9a6447d8a5b59844388/kernel/modules/memory/physical.v
+- XNU zone implementation, including cache design near lines 250-370: https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/osfmk/kern/zalloc.c
+- Apple's allocator architecture and type-isolation explanation: https://security.apple.com/blog/towards-the-next-generation-of-xnu-memory-safety/
+- Existing ARM64 interrupt-state snapshot: https://github.com/vlang/vinix/blob/7c085707f535e498ff2ce9a6447d8a5b59844388/kernel/modules/klock/klock_arm64.v
+
+## Implemented scope
+
+`slab.v` replaces the original Slab implementation, and `physical.v` wires it
+into the existing malloc/free/realloc/calloc entry points. Initialization is
+lazy, without heap allocation. The 14 classes are 16, 32, 48, 64, 96, 128, 192,
+256, 384, 512, 768, 1024, 1536 and 2048 bytes.
+
+Each page has an 80-byte header on the intended 64-bit layouts, including four
+64-bit allocation words. Payload begins at a 16-byte-aligned offset. Tail bits
+are permanently occupied. A partial-page list supports constant-time list
+changes; full pages need no list. Allocation checks at most four bitmap words
+and uses bounded bit search. Partial pages are preferred over an empty spare.
+
+When the last object is freed, at most one empty page is retained per class.
+Further empty pages are detached under the class lock and returned to the PMM
+after releasing it. `memory.heap_trim()` releases all currently observed spare
+pages, returning bytes released. It is not yet wired into an OOM callback.
+Idle spare retention is at most 14 * 4096 = 56 KiB when quiescent; temporary
+in-flight detached pages and partially occupied pages are outside that bound.
+
+Malloc zeroing and free poisoning remain. Allocation zeroing is outside the
+class lock, after the slot is marked live. Header and slot checks catch some
+invalid frees and double frees while the page is still owned by that slab.
+They do NOT establish arbitrary-pointer validation or reliable detection after
+address reuse. Headers share writable pages with objects, so this is not
+XNU-style protected/external metadata, type isolation, or VA sequestering.
+
+Additional fixes reject calloc multiplication and large-allocation rounding
+/metadata-page overflow; failed growing realloc keeps its original allocation.
+The x86 lock now snapshots interrupt state before publishing unlock, matching
+the ordering already used by Vinix's ARM64 lock.
+
+The physical allocator and virtual-memory implementation are otherwise
+unchanged. Infallible PMM exhaustion still panics. Large heap allocations still
+need contiguous physical backing and the extra metadata page. Realloc-zero
+behavior is retained rather than imposing a new API contract.
+
+## Tradeoffs and work not included
+
+Intermediate size classes reduce rounding for some requests (for example,
+65 bytes uses a 96-byte class rather than 128). This is geometry, not a measured
+workload result. The larger header reduces object density in existing classes;
+small allocations now consume at least 16 bytes instead of 8. More classes can
+increase partially occupied-page fragmentation. One cached spare avoids PMM
+churn in single-object reuse but does not eliminate burst-induced churn.
+
+There are no per-CPU magazines, cross-CPU return queues, allocator reserves,
+NOWAIT semantics, type-aware heaps, separate metadata mappings, guard pages,
+or a noncontiguous VM-backed large-object allocator in this patch. Adding
+magazines requires retaining page liveness for every cached object and draining
+caches before reclamation; otherwise a speed optimization can introduce UAF.
+
+## Validation
+
+From a complete patched Vinix checkout:
+
+```sh
+python3 tests/memory/heap_model_test.py
+```
+
+The model checks all size classes across several pages, full/partial/empty
+transitions including one-slot pages, partial-before-spare selection, payload
+zeroing/poisoning, resident-page invalid/double frees, tail bits, arithmetic
+bounds, x86 snapshot source order, and mixed-size churn. It deliberately models
+an abstract PMM rather than claiming to execute the kernel PMM.
+
+Build the actual kernel in debug and production with the repository's toolchain
+and dependencies. Enable the boot tests by adding `VFLAGS='-d heap_selftest'`
+to the kernel make invocation. For example, using the native Linux CI flags:
+
+```sh
+# V must name an already built V compiler by absolute path.
+cd kernel
+./get-deps
+make PROD=false V="$V" VFLAGS='-d heap_selftest' \
+  CFLAGS='-Ulinux -U__linux -U__linux__ -U__gnu_linux__ -D__vinix__ -O2 -g -pipe'
+```
+
+This is a validation recipe, not a recorded successful build. Boot the resulting
+image through the repository's normal image workflow. The expected successful
+serial marker is `heap: self-test passed`. The self-test runs from pmm_init
+before SMP startup; its free-page comparisons require no concurrent clients.
+It exercises the actual V allocator and allocation API, not the Python model.
+
+Before merge, also boot both x86_64 and ARM64, run SMP allocation/free on different
+CPUs, interrupt-heavy workloads, concurrent trimming, and OOM/fragmentation
+stress. Compare identical workloads against the pinned base using throughput,
+p50/p99 latency, lock contention, peak pages, and pages retained after churn.
+Do not enable production deployment based on the Python model alone.

--- a/tests/memory/heap_model_test.py
+++ b/tests/memory/heap_model_test.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Executable specification, NOT a test of compiled V or kernel concurrency.
+
+Models the slab.v list/bitmap transitions with an abstract PMM. Source checks
+keep geometry and size classes aligned with the implementation. The separate
+V boot self-test exercises actual kernel code when a kernel can be built.
+"""
+from __future__ import annotations
+
+import ctypes
+from dataclasses import dataclass, field
+from pathlib import Path
+import random
+import re
+import unittest
+
+PAGE = 4096
+MASK = (1 << 64) - 1
+CLASSES = (16, 32, 48, 64, 96, 128, 192, 256, 384, 512, 768, 1024, 1536, 2048)
+
+
+class HeaderLayout(ctypes.Structure):
+    _fields_ = [(name, ctypes.c_uint64) for name in
+                ('slab', 'magic', 'prev', 'next', 'capacity', 'in_use')]
+    _fields_.append(('used', ctypes.c_uint64 * 4))
+
+
+OFFSET = (ctypes.sizeof(HeaderLayout) + 15) & ~15
+
+
+def first_zero(word: int) -> int:
+    bits = (~word) & MASK
+    if not bits:
+        raise ValueError('requires a zero bit')
+    index = 0
+    for shift in (32, 16, 8, 4, 2):
+        if bits & ((1 << shift) - 1) == 0:
+            index += shift
+            bits >>= shift
+    if bits & 1 == 0:
+        index += 1
+    return index
+
+
+@dataclass
+class Page:
+    base: int
+    size: int
+    prev: int = 0
+    next: int = 0
+    count: int = 0
+    bits: list[int] = field(default_factory=lambda: [MASK] * 4)
+    payload: bytearray = field(default_factory=lambda: bytearray([0xAA] * PAGE))
+
+    @property
+    def capacity(self) -> int:
+        return (PAGE - OFFSET) // self.size
+
+    def __post_init__(self) -> None:
+        for slot in range(self.capacity):
+            self.bits[slot // 64] &= ~(1 << (slot % 64))
+
+
+class PMM:
+    def __init__(self) -> None:
+        self.pages: dict[int, Page] = {}
+        self.returned: list[int] = []
+        self.next_base = PAGE
+        self.allocations = 0
+        self.frees = 0
+
+    def alloc(self, size: int) -> Page:
+        if self.returned:
+            base = self.returned.pop()
+        else:
+            base = self.next_base
+            self.next_base += PAGE
+        page = Page(base, size)
+        self.pages[base] = page
+        self.allocations += 1
+        return page
+
+    def free(self, page: Page) -> None:
+        assert page.count == 0
+        assert self.pages.pop(page.base) is page
+        self.returned.append(page.base)
+        self.frees += 1
+
+
+class Slab:
+    def __init__(self, pmm: PMM, size: int) -> None:
+        self.pmm, self.size = pmm, size
+        self.partial = self.spare = 0
+        self.owned: set[int] = set()
+        self.live: set[int] = set()
+
+    def add(self, page: Page) -> None:
+        page.prev, page.next = 0, self.partial
+        if self.partial:
+            self.pmm.pages[self.partial].prev = page.base
+        self.partial = page.base
+
+    def remove(self, page: Page) -> None:
+        if page.prev == 0:
+            self.partial = page.next
+        else:
+            self.pmm.pages[page.prev].next = page.next
+        if page.next:
+            self.pmm.pages[page.next].prev = page.prev
+        page.prev = page.next = 0
+
+    def alloc(self) -> int:
+        if not self.partial:
+            if self.spare:
+                page = self.pmm.pages[self.spare]
+                self.spare = 0
+            else:
+                page = self.pmm.alloc(self.size)
+                self.owned.add(page.base)
+            self.add(page)
+        page = self.pmm.pages[self.partial]
+        for i, word in enumerate(page.bits):
+            if word != MASK:
+                bit = first_zero(word)
+                page.bits[i] |= 1 << bit
+                slot = i * 64 + bit
+                break
+        else:
+            raise AssertionError('no slot on a partial page')
+        assert slot < page.capacity
+        page.count += 1
+        if page.count == page.capacity:
+            self.remove(page)
+        address = page.base + OFFSET + slot * self.size
+        assert address not in self.live and address % 16 == 0
+        self.live.add(address)
+        offset = address - page.base
+        page.payload[offset:offset + self.size] = bytes(self.size)
+        return address
+
+    def free(self, address: int) -> None:
+        if not address:
+            return
+        base, offset = address & ~(PAGE - 1), address & (PAGE - 1)
+        if base not in self.owned or offset < OFFSET:
+            raise ValueError('invalid header')
+        page = self.pmm.pages[base]
+        slot, remainder = divmod(offset - OFFSET, self.size)
+        if remainder or slot >= page.capacity:
+            raise ValueError('invalid alignment')
+        word, bit = slot // 64, 1 << (slot % 64)
+        if page.bits[word] & bit == 0 or page.count == 0:
+            raise ValueError('double free')
+        full = page.count == page.capacity
+        page.payload[offset:offset + self.size] = bytes([0xAA]) * self.size
+        page.bits[word] &= ~bit
+        page.count -= 1
+        self.live.remove(address)
+        if page.count == 0:
+            if not full:
+                self.remove(page)
+            if not self.spare:
+                self.spare = base
+            else:
+                self.owned.remove(base)
+                self.pmm.free(page)
+        elif full:
+            self.add(page)
+
+    def trim(self) -> int:
+        if not self.spare:
+            return 0
+        base, self.spare = self.spare, 0
+        self.owned.remove(base)
+        self.pmm.free(self.pmm.pages[base])
+        return PAGE
+
+    def check(self) -> None:
+        linked: set[int] = set()
+        base, prev = self.partial, 0
+        while base:
+            assert base not in linked
+            linked.add(base)
+            page = self.pmm.pages[base]
+            assert page.prev == prev and 0 < page.count < page.capacity
+            prev, base = base, page.next
+        expected_partial: set[int] = set()
+        expected_live: set[int] = set()
+        for base in self.owned:
+            page = self.pmm.pages[base]
+            assert 0 <= page.count <= page.capacity
+            active = 0
+            for slot in range(256):
+                used = bool(page.bits[slot // 64] & (1 << (slot % 64)))
+                if slot >= page.capacity:
+                    assert used, 'tail slot became available'
+                elif used:
+                    active += 1
+                    expected_live.add(base + OFFSET + slot * self.size)
+            assert active == page.count
+            if page.count == 0:
+                assert base == self.spare and page.prev == page.next == 0
+            elif page.count < page.capacity:
+                expected_partial.add(base)
+            else:
+                assert page.prev == page.next == 0
+        assert linked == expected_partial
+        assert self.live == expected_live
+        if self.spare:
+            assert self.spare in self.owned
+
+
+class HeapModelTests(unittest.TestCase):
+    def test_source_geometry_and_classes(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        source = (root / 'kernel/modules/memory/physical.v').read_text()
+        sizes = tuple(map(int, re.findall(r'slabs\[\d+\]\.init\((\d+)\)', source)))
+        self.assertEqual(sizes, CLASSES)
+        self.assertEqual(OFFSET, 80)
+        slab = (root / 'kernel/modules/memory/slab.v').read_text()
+        self.assertRegex(slab, r'used\s+\[4\]u64')
+        self.assertIn('const slab_alignment = u64(16)', slab)
+        for size in CLASSES:
+            self.assertEqual(size % 16, 0)
+            self.assertTrue(1 <= (PAGE - OFFSET) // size <= 256)
+
+    def test_bit_search_all_positions_and_random_words(self) -> None:
+        for bit in range(64):
+            self.assertEqual(first_zero(MASK ^ (1 << bit)), bit)
+        rng = random.Random(12345)
+        for _ in range(20000):
+            word = rng.getrandbits(64)
+            if word != MASK:
+                free = (~word) & MASK
+                self.assertEqual(first_zero(word), (free & -free).bit_length() - 1)
+
+    def test_all_classes_multi_page_lifecycle(self) -> None:
+        for size in CLASSES:
+            with self.subTest(size=size):
+                pmm = PMM()
+                slab = Slab(pmm, size)
+                capacity = (PAGE - OFFSET) // size
+                objects = [slab.alloc() for _ in range(3 * capacity + 1)]
+                self.assertEqual(len(pmm.pages), 4)
+                slab.check()
+                for address in objects[::2] + objects[1::2]:
+                    slab.free(address)
+                    slab.check()
+                self.assertEqual(len(pmm.pages), 1)
+                self.assertEqual(slab.trim(), PAGE)
+                self.assertEqual(slab.trim(), 0)
+                slab.check()
+                self.assertFalse(pmm.pages)
+                self.assertEqual(pmm.allocations, pmm.frees)
+
+    def test_single_slot_full_to_empty(self) -> None:
+        pmm, size = PMM(), 2048
+        slab = Slab(pmm, size)
+        a, b = slab.alloc(), slab.alloc()
+        slab.free(a)
+        slab.free(b)
+        slab.check()
+        self.assertEqual(len(pmm.pages), 1)
+        self.assertEqual(slab.alloc(), a)
+        slab.check()
+
+    def test_partial_preferred_to_spare(self) -> None:
+        pmm = PMM()
+        slab = Slab(pmm, 1024)
+        objects = [slab.alloc() for _ in range(7)]
+        slab.free(objects[6])  # third page becomes spare
+        slab.free(objects[1])  # first page becomes partial
+        self.assertEqual(slab.alloc(), objects[1])
+        self.assertNotEqual(slab.spare, 0)
+        slab.check()
+
+    def test_payload_poison_and_zero_on_reuse(self) -> None:
+        pmm = PMM()
+        slab = Slab(pmm, 64)
+        a, keeper = slab.alloc(), slab.alloc()
+        page = pmm.pages[a & ~(PAGE - 1)]
+        offset = a % PAGE
+        page.payload[offset:offset + 64] = bytes([0x13]) * 64
+        slab.free(a)
+        self.assertEqual(page.payload[offset:offset + 64], bytes([0xAA]) * 64)
+        self.assertEqual(slab.alloc(), a)
+        self.assertEqual(page.payload[offset:offset + 64], bytes(64))
+        slab.free(a)
+        slab.free(keeper)
+        slab.check()
+
+    def test_invalid_and_double_free_on_resident_page(self) -> None:
+        slab = Slab(PMM(), 64)
+        a, keeper = slab.alloc(), slab.alloc()
+        for bad in (a + 1, a - 1, a & ~(PAGE - 1)):
+            with self.assertRaises(ValueError):
+                slab.free(bad)
+        slab.free(a)
+        with self.assertRaises(ValueError):
+            slab.free(a)
+        slab.free(keeper)
+        slab.check()
+
+    def test_random_mixed_size_churn(self) -> None:
+        rng, pmm = random.Random(0x584E55), PMM()
+        slabs = [Slab(pmm, size) for size in CLASSES]
+        live: list[tuple[Slab, int]] = []
+        for i in range(100000):
+            if not live or (len(live) < 2048 and rng.random() < .52):
+                slab = rng.choice(slabs)
+                live.append((slab, slab.alloc()))
+            else:
+                index = rng.randrange(len(live))
+                slab, address = live[index]
+                live[index] = live[-1]
+                live.pop()
+                slab.free(address)
+            if i % 251 == 0:
+                rng.choice(slabs).trim()
+                for slab in slabs:
+                    slab.check()
+        rng.shuffle(live)
+        for slab, address in live:
+            slab.free(address)
+        self.assertLessEqual(len(pmm.pages), len(CLASSES))
+        for slab in slabs:
+            slab.trim()
+            slab.check()
+        self.assertFalse(pmm.pages)
+        self.assertEqual(pmm.allocations, pmm.frees)
+
+    def test_arithmetic_guards(self) -> None:
+        def checked_product(a: int, b: int) -> int | None:
+            return None if b and a > MASK // b else a * b
+        self.assertIsNone(checked_product(1 << 63, 2))
+        self.assertEqual(checked_product(MASK, 0), 0)
+        self.assertEqual(checked_product(7, 13), 91)
+        maximum = (MASK // PAGE - 1) * PAGE
+        for value in (0, 1, 2049, maximum - 1, maximum):
+            pages = (value + PAGE - 1) // PAGE
+            self.assertLessEqual((pages + 1) * PAGE, MASK)
+        self.assertGreater(((maximum + 1 + PAGE - 1) // PAGE + 1) * PAGE, MASK)
+        root = Path(__file__).resolve().parents[2]
+        source = (root / 'kernel/modules/memory/physical.v').read_text()
+        self.assertIn('if b != 0 && a > u64(-1) / b', source)
+        self.assertIn('if new_ptr == unsafe { nil }', source)
+        self.assertEqual(source.count('(u64(-1) / page_size - 1) * page_size'), 2)
+
+    def test_irq_snapshot_source_order(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        source = (root / 'kernel/modules/klock/klock_amd64.v').read_text()
+        release = source.split('pub fn (mut l Lock) release() {', 1)[1].split('\n}', 1)[0]
+        self.assertLess(release.index('ints := l.ints'), release.index('katomic.store'))
+        self.assertIn('cpu.interrupt_toggle(ints)', release)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/xnualloc/APPLE_LICENSE
+++ b/tests/xnualloc/APPLE_LICENSE
@@ -1,0 +1,367 @@
+APPLE PUBLIC SOURCE LICENSE
+Version 2.0 - August 6, 2003
+
+Please read this License carefully before downloading this software.
+By downloading or using this software, you are agreeing to be bound by
+the terms of this License. If you do not or cannot agree to the terms
+of this License, please do not download or use the software.
+
+1. General; Definitions. This License applies to any program or other
+work which Apple Computer, Inc. ("Apple") makes publicly available and
+which contains a notice placed by Apple identifying such program or
+work as "Original Code" and stating that it is subject to the terms of
+this Apple Public Source License version 2.0 ("License"). As used in
+this License:
+
+1.1 "Applicable Patent Rights" mean: (a) in the case where Apple is
+the grantor of rights, (i) claims of patents that are now or hereafter
+acquired, owned by or assigned to Apple and (ii) that cover subject
+matter contained in the Original Code, but only to the extent
+necessary to use, reproduce and/or distribute the Original Code
+without infringement; and (b) in the case where You are the grantor of
+rights, (i) claims of patents that are now or hereafter acquired,
+owned by or assigned to You and (ii) that cover subject matter in Your
+Modifications, taken alone or in combination with Original Code.
+
+1.2 "Contributor" means any person or entity that creates or
+contributes to the creation of Modifications.
+
+1.3 "Covered Code" means the Original Code, Modifications, the
+combination of Original Code and any Modifications, and/or any
+respective portions thereof.
+
+1.4 "Externally Deploy" means: (a) to sublicense, distribute or
+otherwise make Covered Code available, directly or indirectly, to
+anyone other than You; and/or (b) to use Covered Code, alone or as
+part of a Larger Work, in any way to provide a service, including but
+not limited to delivery of content, through electronic communication
+with a client other than You.
+
+1.5 "Larger Work" means a work which combines Covered Code or portions
+thereof with code not governed by the terms of this License.
+
+1.6 "Modifications" mean any addition to, deletion from, and/or change
+to, the substance and/or structure of the Original Code, any previous
+Modifications, the combination of Original Code and any previous
+Modifications, and/or any respective portions thereof. When code is
+released as a series of files, a Modification is: (a) any addition to
+or deletion from the contents of a file containing Covered Code;
+and/or (b) any new file or other representation of computer program
+statements that contains any part of Covered Code.
+
+1.7 "Original Code" means (a) the Source Code of a program or other
+work as originally made available by Apple under this License,
+including the Source Code of any updates or upgrades to such programs
+or works made available by Apple under this License, and that has been
+expressly identified by Apple as such in the header file(s) of such
+work; and (b) the object code compiled from such Source Code and
+originally made available by Apple under this License.
+
+1.8 "Source Code" means the human readable form of a program or other
+work that is suitable for making modifications to it, including all
+modules it contains, plus any associated interface definition files,
+scripts used to control compilation and installation of an executable
+(object code).
+
+1.9 "You" or "Your" means an individual or a legal entity exercising
+rights under this License. For legal entities, "You" or "Your"
+includes any entity which controls, is controlled by, or is under
+common control with, You, where "control" means (a) the power, direct
+or indirect, to cause the direction or management of such entity,
+whether by contract or otherwise, or (b) ownership of fifty percent
+(50%) or more of the outstanding shares or beneficial ownership of
+such entity.
+
+2. Permitted Uses; Conditions & Restrictions. Subject to the terms
+and conditions of this License, Apple hereby grants You, effective on
+the date You accept this License and download the Original Code, a
+world-wide, royalty-free, non-exclusive license, to the extent of
+Apple's Applicable Patent Rights and copyrights covering the Original
+Code, to do the following:
+
+2.1 Unmodified Code. You may use, reproduce, display, perform,
+internally distribute within Your organization, and Externally Deploy
+verbatim, unmodified copies of the Original Code, for commercial or
+non-commercial purposes, provided that in each instance:
+
+(a) You must retain and reproduce in all copies of Original Code the
+copyright and other proprietary notices and disclaimers of Apple as
+they appear in the Original Code, and keep intact all notices in the
+Original Code that refer to this License; and
+
+(b) You must include a copy of this License with every copy of Source
+Code of Covered Code and documentation You distribute or Externally
+Deploy, and You may not offer or impose any terms on such Source Code
+that alter or restrict this License or the recipients' rights
+hereunder, except as permitted under Section 6.
+
+2.2 Modified Code. You may modify Covered Code and use, reproduce,
+display, perform, internally distribute within Your organization, and
+Externally Deploy Your Modifications and Covered Code, for commercial
+or non-commercial purposes, provided that in each instance You also
+meet all of these conditions:
+
+(a) You must satisfy all the conditions of Section 2.1 with respect to
+the Source Code of the Covered Code;
+
+(b) You must duplicate, to the extent it does not already exist, the
+notice in Exhibit A in each file of the Source Code of all Your
+Modifications, and cause the modified files to carry prominent notices
+stating that You changed the files and the date of any change; and
+
+(c) If You Externally Deploy Your Modifications, You must make
+Source Code of all Your Externally Deployed Modifications either
+available to those to whom You have Externally Deployed Your
+Modifications, or publicly available. Source Code of Your Externally
+Deployed Modifications must be released under the terms set forth in
+this License, including the license grants set forth in Section 3
+below, for as long as you Externally Deploy the Covered Code or twelve
+(12) months from the date of initial External Deployment, whichever is
+longer. You should preferably distribute the Source Code of Your
+Externally Deployed Modifications electronically (e.g. download from a
+web site).
+
+2.3 Distribution of Executable Versions. In addition, if You
+Externally Deploy Covered Code (Original Code and/or Modifications) in
+object code, executable form only, You must include a prominent
+notice, in the code itself as well as in related documentation,
+stating that Source Code of the Covered Code is available under the
+terms of this License with information on how and where to obtain such
+Source Code.
+
+2.4 Third Party Rights. You expressly acknowledge and agree that
+although Apple and each Contributor grants the licenses to their
+respective portions of the Covered Code set forth herein, no
+assurances are provided by Apple or any Contributor that the Covered
+Code does not infringe the patent or other intellectual property
+rights of any other entity. Apple and each Contributor disclaim any
+liability to You for claims brought by any other entity based on
+infringement of intellectual property rights or otherwise. As a
+condition to exercising the rights and licenses granted hereunder, You
+hereby assume sole responsibility to secure any other intellectual
+property rights needed, if any. For example, if a third party patent
+license is required to allow You to distribute the Covered Code, it is
+Your responsibility to acquire that license before distributing the
+Covered Code.
+
+3. Your Grants. In consideration of, and as a condition to, the
+licenses granted to You under this License, You hereby grant to any
+person or entity receiving or distributing Covered Code under this
+License a non-exclusive, royalty-free, perpetual, irrevocable license,
+under Your Applicable Patent Rights and other intellectual property
+rights (other than patent) owned or controlled by You, to use,
+reproduce, display, perform, modify, sublicense, distribute and
+Externally Deploy Your Modifications of the same scope and extent as
+Apple's licenses under Sections 2.1 and 2.2 above.
+
+4. Larger Works. You may create a Larger Work by combining Covered
+Code with other code not governed by the terms of this License and
+distribute the Larger Work as a single product. In each such instance,
+You must make sure the requirements of this License are fulfilled for
+the Covered Code or any portion thereof.
+
+5. Limitations on Patent License. Except as expressly stated in
+Section 2, no other patent rights, express or implied, are granted by
+Apple herein. Modifications and/or Larger Works may require additional
+patent licenses from Apple which Apple may grant in its sole
+discretion.
+
+6. Additional Terms. You may choose to offer, and to charge a fee for,
+warranty, support, indemnity or liability obligations and/or other
+rights consistent with the scope of the license granted herein
+("Additional Terms") to one or more recipients of Covered Code.
+However, You may do so only on Your own behalf and as Your sole
+responsibility, and not on behalf of Apple or any Contributor. You
+must obtain the recipient's agreement that any such Additional Terms
+are offered by You alone, and You hereby agree to indemnify, defend
+and hold Apple and every Contributor harmless for any liability
+incurred by or claims asserted against Apple or such Contributor by
+reason of any such Additional Terms.
+
+7. Versions of the License. Apple may publish revised and/or new
+versions of this License from time to time. Each version will be given
+a distinguishing version number. Once Original Code has been published
+under a particular version of this License, You may continue to use it
+under the terms of that version. You may also choose to use such
+Original Code under the terms of any subsequent version of this
+License published by Apple. No one other than Apple has the right to
+modify the terms applicable to Covered Code created under this
+License.
+
+8. NO WARRANTY OR SUPPORT. The Covered Code may contain in whole or in
+part pre-release, untested, or not fully tested works. The Covered
+Code may contain errors that could cause failures or loss of data, and
+may be incomplete or contain inaccuracies. You expressly acknowledge
+and agree that use of the Covered Code, or any portion thereof, is at
+Your sole and entire risk. THE COVERED CODE IS PROVIDED "AS IS" AND
+WITHOUT WARRANTY, UPGRADES OR SUPPORT OF ANY KIND AND APPLE AND
+APPLE'S LICENSOR(S) (COLLECTIVELY REFERRED TO AS "APPLE" FOR THE
+PURPOSES OF SECTIONS 8 AND 9) AND ALL CONTRIBUTORS EXPRESSLY DISCLAIM
+ALL WARRANTIES AND/OR CONDITIONS, EXPRESS OR IMPLIED, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES AND/OR CONDITIONS OF
+MERCHANTABILITY, OF SATISFACTORY QUALITY, OF FITNESS FOR A PARTICULAR
+PURPOSE, OF ACCURACY, OF QUIET ENJOYMENT, AND NONINFRINGEMENT OF THIRD
+PARTY RIGHTS. APPLE AND EACH CONTRIBUTOR DOES NOT WARRANT AGAINST
+INTERFERENCE WITH YOUR ENJOYMENT OF THE COVERED CODE, THAT THE
+FUNCTIONS CONTAINED IN THE COVERED CODE WILL MEET YOUR REQUIREMENTS,
+THAT THE OPERATION OF THE COVERED CODE WILL BE UNINTERRUPTED OR
+ERROR-FREE, OR THAT DEFECTS IN THE COVERED CODE WILL BE CORRECTED. NO
+ORAL OR WRITTEN INFORMATION OR ADVICE GIVEN BY APPLE, AN APPLE
+AUTHORIZED REPRESENTATIVE OR ANY CONTRIBUTOR SHALL CREATE A WARRANTY.
+You acknowledge that the Covered Code is not intended for use in the
+operation of nuclear facilities, aircraft navigation, communication
+systems, or air traffic control machines in which case the failure of
+the Covered Code could lead to death, personal injury, or severe
+physical or environmental damage.
+
+9. LIMITATION OF LIABILITY. TO THE EXTENT NOT PROHIBITED BY LAW, IN NO
+EVENT SHALL APPLE OR ANY CONTRIBUTOR BE LIABLE FOR ANY INCIDENTAL,
+SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR RELATING
+TO THIS LICENSE OR YOUR USE OR INABILITY TO USE THE COVERED CODE, OR
+ANY PORTION THEREOF, WHETHER UNDER A THEORY OF CONTRACT, WARRANTY,
+TORT (INCLUDING NEGLIGENCE), PRODUCTS LIABILITY OR OTHERWISE, EVEN IF
+APPLE OR SUCH CONTRIBUTOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES AND NOTWITHSTANDING THE FAILURE OF ESSENTIAL PURPOSE OF ANY
+REMEDY. SOME JURISDICTIONS DO NOT ALLOW THE LIMITATION OF LIABILITY OF
+INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS LIMITATION MAY NOT APPLY
+TO YOU. In no event shall Apple's total liability to You for all
+damages (other than as may be required by applicable law) under this
+License exceed the amount of fifty dollars ($50.00).
+
+10. Trademarks. This License does not grant any rights to use the
+trademarks or trade names "Apple", "Apple Computer", "Mac", "Mac OS",
+"QuickTime", "QuickTime Streaming Server" or any other trademarks,
+service marks, logos or trade names belonging to Apple (collectively
+"Apple Marks") or to any trademark, service mark, logo or trade name
+belonging to any Contributor. You agree not to use any Apple Marks in
+or as part of the name of products derived from the Original Code or
+to endorse or promote products derived from the Original Code other
+than as expressly permitted by and in strict compliance at all times
+with Apple's third party trademark usage guidelines which are posted
+at http://www.apple.com/legal/guidelinesfor3rdparties.html.
+
+11. Ownership. Subject to the licenses granted under this License,
+each Contributor retains all rights, title and interest in and to any
+Modifications made by such Contributor. Apple retains all rights,
+title and interest in and to the Original Code and any Modifications
+made by or on behalf of Apple ("Apple Modifications"), and such Apple
+Modifications will not be automatically subject to this License. Apple
+may, at its sole discretion, choose to license such Apple
+Modifications under this License, or on different terms from those
+contained in this License or may choose not to license them at all.
+
+12. Termination.
+
+12.1 Termination. This License and the rights granted hereunder will
+terminate:
+
+(a) automatically without notice from Apple if You fail to comply with
+any term(s) of this License and fail to cure such breach within 30
+days of becoming aware of such breach;
+
+(b) immediately in the event of the circumstances described in Section
+13.5(b); or
+
+(c) automatically without notice from Apple if You, at any time during
+the term of this License, commence an action for patent infringement
+against Apple; provided that Apple did not first commence
+an action for patent infringement against You in that instance.
+
+12.2 Effect of Termination. Upon termination, You agree to immediately
+stop any further use, reproduction, modification, sublicensing and
+distribution of the Covered Code. All sublicenses to the Covered Code
+which have been properly granted prior to termination shall survive
+any termination of this License. Provisions which, by their nature,
+should remain in effect beyond the termination of this License shall
+survive, including but not limited to Sections 3, 5, 8, 9, 10, 11,
+12.2 and 13. No party will be liable to any other for compensation,
+indemnity or damages of any sort solely as a result of terminating
+this License in accordance with its terms, and termination of this
+License will be without prejudice to any other right or remedy of
+any party.
+
+13. Miscellaneous.
+
+13.1 Government End Users. The Covered Code is a "commercial item" as
+defined in FAR 2.101. Government software and technical data rights in
+the Covered Code include only those rights customarily provided to the
+public as defined in this License. This customary commercial license
+in technical data and software is provided in accordance with FAR
+12.211 (Technical Data) and 12.212 (Computer Software) and, for
+Department of Defense purchases, DFAR 252.227-7015 (Technical Data --
+Commercial Items) and 227.7202-3 (Rights in Commercial Computer
+Software or Computer Software Documentation). Accordingly, all U.S.
+Government End Users acquire Covered Code with only those rights set
+forth herein.
+
+13.2 Relationship of Parties. This License will not be construed as
+creating an agency, partnership, joint venture or any other form of
+legal association between or among You, Apple or any Contributor, and
+You will not represent to the contrary, whether expressly, by
+implication, appearance or otherwise.
+
+13.3 Independent Development. Nothing in this License will impair
+Apple's right to acquire, license, develop, have others develop for
+it, market and/or distribute technology or products that perform the
+same or similar functions as, or otherwise compete with,
+Modifications, Larger Works, technology or products that You may
+develop, produce, market or distribute.
+
+13.4 Waiver; Construction. Failure by Apple or any Contributor to
+enforce any provision of this License will not be deemed a waiver of
+future enforcement of that or any other provision. Any law or
+regulation which provides that the language of a contract shall be
+construed against the drafter will not apply to this License.
+
+13.5 Severability. (a) If for any reason a court of competent
+jurisdiction finds any provision of this License, or portion thereof,
+to be unenforceable, that provision of the License will be enforced to
+the maximum extent permissible so as to effect the economic benefits
+and intent of the parties, and the remainder of this License will
+continue in full force and effect. (b) Notwithstanding the foregoing,
+if applicable law prohibits or restricts You from fully and/or
+specifically complying with Sections 2 and/or 3 or prevents the
+enforceability of either of those Sections, this License will
+immediately terminate and You must immediately discontinue any use of
+the Covered Code and destroy all copies of it that are in your
+possession or control.
+
+13.6 Dispute Resolution. Any litigation or other dispute resolution
+between You and Apple relating to this License shall take place in the
+Northern District of California, and You and Apple hereby consent to
+the personal jurisdiction of, and venue in, the state and federal
+courts within that District with respect to this License. The
+application of the United Nations Convention on Contracts for the
+International Sale of Goods is expressly excluded.
+
+13.7 Entire Agreement; Governing Law. This License constitutes the
+entire agreement between the parties with respect to the subject
+matter hereof. This License shall be governed by the laws of the
+United States and the State of California, except that body of
+California law concerning conflicts of law.
+
+Where You are located in the province of Quebec, Canada, the following
+clause applies: The parties hereby confirm that they have requested
+that this License and all related documents be drafted in English. Les
+parties ont exige que le present contrat et tous les documents
+connexes soient rediges en anglais.
+
+EXHIBIT A.
+
+"Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+Reserved.
+
+This file contains Original Code and/or Modifications of Original Code
+as defined in and that are subject to the Apple Public Source License
+Version 2.0 (the 'License'). You may not use this file except in
+compliance with the License. Please obtain a copy of the License at
+http://www.opensource.apple.com/apsl/ and read it before using this
+file.
+
+The Original Code and all software distributed under the License are
+distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+Please see the License for the specific language governing rights and
+limitations under the License."

--- a/tests/xnualloc/README.md
+++ b/tests/xnualloc/README.md
@@ -1,0 +1,46 @@
+# XNU allocator port tests
+
+Experimental, partial translation. Read `docs/xnualloc/PORT_STATUS.md` before
+using this kernel backend. Source and extracted-reference notices are retained;
+APPLE_LICENSE accompanies this directory. This is not a GPL relicensing.
+
+From the repository root, the checks executable without V are:
+
+```sh
+python3 tests/memory/heap_model_test.py
+python3 tests/xnualloc/reference_test.py
+python3 tests/xnualloc/zone_model_test.py
+```
+
+They passed locally: 10 independent slab-model tests, 4 C-reference/model tests
+and 6 non-SMR zone-protocol/source tests. They do not execute V. The reference
+suite requires a C compiler with UBSan; set `CC` to its executable if necessary.
+The zone model uses four logical CPU caches, not concurrent hardware threads.
+
+Actual V host tests (18 functions, supplied but not run locally):
+
+```sh
+v -cc gcc -gc none \
+  -path "@vlib|@vmodules|$(pwd)/kernel/modules" test tests/xnualloc
+v -prod -cc gcc -gc none \
+  -path "@vlib|@vmodules|$(pwd)/kernel/modules" test tests/xnualloc
+```
+
+On a normal Linux x86-64 Vinix build machine, with a compatible V compiler:
+
+```sh
+cd kernel
+./get-deps
+make clean
+make PROD=false V=/absolute/path/to/v \
+  VFLAGS='-d xnu_zone -d heap_selftest' \
+  CFLAGS='-Ulinux -U__linux -U__linux__ -U__gnu_linux__ -D__vinix__ -O2 -g -pipe'
+```
+
+This is a build recipe, not a claim that it succeeds. Use the repository's
+architecture-specific tooling for ARM64. Also build flag-off and `-d xnu_bitmap`
+configurations. For each architecture boot the resulting image using its normal
+Vinix deployment procedure, and require the serial marker
+`heap: self-test passed`. This boot test executes before SMP, so separate
+interrupt-heavy, cross-CPU allocation/free/trim and OOM tests are still required.
+No production image was built or deployed by this work.

--- a/tests/xnualloc/port_test.v
+++ b/tests/xnualloc/port_test.v
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2000-2020 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/*
+ * @OSF_COPYRIGHT@
+ */
+/*
+ * Mach Operating System
+ * Copyright (c) 1991,1990,1989,1988,1987 Carnegie Mellon University
+ * All Rights Reserved.
+ *
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ *
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+ * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ *
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie Mellon
+ * the rights to redistribute these changes.
+ */
+// Modified 2026-09-11: C-to-V translation and explicitly documented adaptations.
+// Upstream: apple-oss-distributions/xnu f6217f891ac0bb64f3d375211650a4c1ff8ca1ea,
+// osfmk/kern/zalloc.c. See docs/xnualloc/PORT_STATUS.md and APPLE_LICENSE.
+// These translations retain APSL 2.0; they are NOT relicensed as GPL.
+
+
+// Original tests for the translation, made available under APSL 2.0.
+// See kernel/modules/xnualloc/APPLE_LICENSE. Modified 2026-09-11.
+// Run from the repository root:
+// v -gc none -path "@vlib|@vmodules|$(pwd)/kernel/modules" test tests/xnualloc
+module main
+
+import xnualloc
+
+#include <stdlib.h>
+fn C.posix_memalign(&voidptr, usize, usize) int
+fn C.free(voidptr)
+
+fn arena_alloc(bytes u64, alignment u64) voidptr {
+	mut ptr := voidptr(0)
+	assert C.posix_memalign(&ptr, usize(alignment), usize(bytes)) == 0
+	return ptr
+}
+
+fn test_metadata_layout_and_masks() {
+	assert sizeof(xnualloc.PageMetadata) == 16
+	meta := xnualloc.PageMetadata{bits: u16((7 << 12) | (1 << 11) | 25)}
+	assert meta.chunk_len() == 7
+	assert meta.is_inline()
+}
+
+fn test_ref_bitmap_boundaries_and_wrap() {
+	counts := [u32(0), 1, 31, 32, 33, 63, 64, 65, 127, 128, 129,
+		255, 256, 511, 512, 8191, 8192]
+	for count in counts {
+		mut bits := [128]u64{}
+		mut seen := [8192]bool{}
+		xnualloc.zone_bits_init_ref(unsafe { &bits[0] }, 128, count)
+		mut cursor := u64(8192) // exact end must wrap without reading past the map
+		for _ in 0 .. int(count) {
+			index := xnualloc.zba_scan_bitmap_ref(unsafe { &bits[0] }, 128, cursor)
+			assert index < count && !seen[int(index)]
+			seen[int(index)] = true
+			cursor = index + 1
+		}
+		assert xnualloc.zba_scan_bitmap_ref(unsafe { &bits[0] }, 128, cursor) == xnualloc.no_element
+		for i in 0 .. int(count) {
+			assert seen[i]
+		}
+	}
+}
+
+fn test_ref_rotation_and_double_free() {
+	mut bits := [4]u64{}
+	for i in [u64(0), 3, 64, 129] {
+		assert xnualloc.zone_bits_mark_free_ref(unsafe { &bits[0] }, 4, i)
+		assert !xnualloc.zone_bits_mark_free_ref(unsafe { &bits[0] }, 4, i)
+	}
+	starts := [u64(2), 4, 65, 130]
+	expected := [u64(3), 64, 129, 0]
+	for i in 0 .. starts.len {
+		assert xnualloc.zba_scan_bitmap_ref(unsafe { &bits[0] }, 4, starts[i]) == expected[i]
+	}
+	assert xnualloc.zba_scan_bitmap_ref(unsafe { &bits[0] }, 4, 0) == xnualloc.no_element
+}
+
+fn test_merge_ranges() {
+	for first in [u32(0), 1, 31, 32, 63, 64, 65, 127, 128, 255, 256] {
+		for end in [u32(0), 1, 31, 32, 63, 64, 65, 127, 128, 255, 256] {
+			if first > end {
+				continue
+			}
+			mut bits := [4]u64{}
+			mut meta := [8]xnualloc.PageMetadata{}
+			xnualloc.zone_bits_merge_ref(unsafe { &bits[0] }, 4, first, end)
+			xnualloc.zone_bits_merge_inline(unsafe { &meta[0] }, 8, first, end)
+			for i := u32(0); i < 256; i++ {
+				expected := i >= first && i < end
+				assert xnualloc.zone_bits_is_free_ref(unsafe { &bits[0] }, 4, i) == expected
+				assert (meta[int(i / 32)].bitmap & (u32(1) << (i % 32)) != 0) == expected
+			}
+		}
+	}
+}
+
+fn test_inline_bitmap_and_metadata_stride() {
+	for count := u32(0); count <= 256; count++ {
+		mut meta := [8]xnualloc.PageMetadata{}
+		for mut m in meta {
+			m.page_next = 0x5aa5
+		}
+		xnualloc.zone_meta_bits_init_inline(unsafe { &meta[0] }, count, 8)
+		mut cursor := u64(256)
+		for _ in 0 .. int(count) {
+			index := xnualloc.zba_scan_bitmap_inline(unsafe { &meta[0] }, 8, cursor)
+			assert index < count
+			cursor = index + 1
+		}
+		assert xnualloc.zba_scan_bitmap_inline(unsafe { &meta[0] }, 8, cursor) == xnualloc.no_element
+		for m in meta {
+			assert m.page_next == 0x5aa5
+		}
+	}
+}
+
+fn test_buddy_exhaustion_reuse_both_geometries() {
+	for shift in [u32(12), 14] {
+		page := u64(1) << shift
+		ptr := arena_alloc(4 * page, page)
+		mut b := xnualloc.buddy_init(ptr, 4 * page, shift) or { panic('buddy_init') }
+		mut refs := []u32{}
+		for {
+			reference := b.zone_meta_bits_alloc_init(129, 256, false)
+			if reference == 0 {
+				break
+			}
+			assert reference >> xnualloc.zba_order_shift == 2
+			addr := u64(b.zba_bits_ref_ptr(reference))
+			assert addr % 32 == 0 && addr >= u64(ptr) && addr + 32 <= u64(ptr) + 4 * page
+			for old in refs {
+				assert reference != old
+			}
+			refs << reference
+		}
+		assert refs.len > 100
+		first_count := refs.len
+		for i := refs.len - 1; i >= 0; i-- {
+			b.zone_bits_free(refs[i])
+		}
+		refs.clear()
+		for {
+			reference := b.zone_meta_bits_alloc_init(129, 256, false)
+			if reference == 0 { break }
+			refs << reference
+		}
+		assert refs.len == first_count
+		for reference in refs {
+			b.zone_bits_free(reference)
+		}
+		unsafe { C.free(ptr) }
+	}
+}
+
+struct LiveBlock {
+	address u64
+	order u32
+	stamp u64
+}
+
+fn rng_step(state &u64) u64 {
+	unsafe {
+		mut x := *state
+		x ^= x << 13
+		x ^= x >> 7
+		x ^= x << 17
+		*state = x
+		return x
+	}
+}
+
+fn test_buddy_mixed_orders_and_live_payloads() {
+	ptr := arena_alloc(65536, 4096)
+	defer { unsafe { C.free(ptr) } }
+	mut b := xnualloc.buddy_init(ptr, 65536, 12) or { panic('buddy_init') }
+	mut live := []LiveBlock{}
+	mut state := u64(0x584e555f504f5254)
+	for step in 0 .. 20000 {
+		r := rng_step(&state)
+		if live.len == 0 || (live.len < 256 && r & 3 != 0) {
+			order := u32((r >> 8) % 9)
+			addr := b.zba_alloc(order, false)
+			if addr == 0 { continue }
+			size := u64(8) << order
+			for block in live {
+				assert addr + size <= block.address || block.address + (u64(8) << block.order) <= addr
+			}
+			stamp := u64(step + 1)
+			unsafe {
+				mut data := &u64(addr)
+				for i := u64(0); i < size / 8; i++ { data[i] = stamp }
+			}
+			live << LiveBlock{address: addr, order: order, stamp: stamp}
+		} else {
+			i := int((r >> 16) % u64(live.len))
+			block := live[i]
+			unsafe {
+				data := &u64(block.address)
+				for j := u64(0); j < (u64(1) << block.order); j++ { assert data[j] == block.stamp }
+			}
+			b.zba_free(block.address, block.order, false)
+			live[i] = live[live.len - 1]
+			live.delete_last()
+		}
+	}
+	for block in live {
+		b.zba_free(block.address, block.order, false)
+	}
+	// All chunks coalesce back to their original free-block decomposition.
+	mut large := []u64{}
+	for { a := b.zba_alloc(8, false); if a == 0 { break }; large << a }
+	assert large.len == 16
+	for a in large { b.zba_free(a, 8, false) }
+}
+
+fn test_packed_ref_metadata_and_extra_shadow() {
+	ptr := arena_alloc(16384, 4096)
+	extra := arena_alloc(16384 * 16, 4096)
+	defer { unsafe { C.free(ptr); C.free(extra) } }
+	mut b := xnualloc.buddy_init(ptr, 16384, 12) or { panic('buddy_init') }
+	assert b.zone_meta_bits_alloc_init(64, 64, true) == 0
+	assert b.configure_extra(extra, 16384 * 16, 1)
+	reference := b.zone_meta_bits_alloc_init(65, 128, true)
+	assert reference != 0 && reference & xnualloc.zba_has_extra_bit != 0
+	mut meta := xnualloc.PageMetadata{bitmap: reference}
+	mut last := u16(0)
+	assert xnualloc.zone_meta_find_and_clear_bit(&meta, &b, 1, &last) == 1
+	assert !xnualloc.zone_meta_is_free(&meta, &b, 1, 1)
+	assert xnualloc.zone_meta_mark_free(&meta, &b, 1, 1)
+	assert !xnualloc.zone_meta_mark_free(&meta, &b, 1, 1)
+	xnualloc.zone_meta_bits_merge(&meta, &b, 1, 65, 128)
+	assert xnualloc.zone_meta_is_free(&meta, &b, 1, 127)
+	tag := b.zba_extra_ref_ptr(reference, 64)
+	assert u64(tag) >= u64(extra) && u64(tag) + 2 <= u64(extra) + 16384 * 16
+	unsafe { assert *(&u16(tag)) == 0; *(&u16(tag)) = 0x1234 }
+	b.zone_bits_free(reference)
+}
+
+fn test_depot_full_empty_partition_and_minima() {
+	mut mags := [10]xnualloc.Magazine{}
+	mut a := xnualloc.Depot{}
+	mut b := xnualloc.Depot{}
+	a.zone_depot_init()
+	b.zone_depot_init()
+	for i in 0 .. 4 {
+		mags[i].seq = u64(i + 1)
+		a.zone_depot_insert_tail_full(mut mags[i])
+	}
+	a.zone_depot_insert_head_empty(mut mags[4])
+	a.zone_depot_insert_head_empty(mut mags[5])
+	mut minimum := xnualloc.RecircMinimum{full: 4, empty: 2}
+	assert b.zone_depot_move_full(mut a, 2, &minimum, false) == 2
+	assert minimum.full == 2 && a.full == 2 && b.full == 2
+	b.zone_depot_move_empty(mut a, 1, &minimum)
+	assert minimum.empty == 1 && b.empty == 1
+	assert u64(b.zone_depot_pop_head_full(unsafe { nil })) == u64(&mags[0])
+	assert u64(b.zone_depot_pop_head_full(unsafe { nil })) == u64(&mags[1])
+	assert b.full == 0 && u64(unsafe { *b.tail }) == u64(&mags[5])
+	assert u64(b.zone_depot_pop_head_empty(unsafe { nil })) == u64(&mags[5])
+	b.zone_depot_insert_tail_full(mut mags[6])
+	b.zone_depot_move_full(mut a, 2, &minimum, true)
+	assert u64(b.zone_depot_pop_head_full(unsafe { nil })) == u64(&mags[2])
+	assert u64(b.zone_depot_pop_head_full(unsafe { nil })) == u64(&mags[3])
+	assert u64(b.zone_depot_pop_head_full(unsafe { nil })) == u64(&mags[6])
+	assert u64(a.zone_depot_pop_head_empty(unsafe { nil })) == u64(&mags[4])
+	assert a.head == unsafe { nil } && b.head == unsafe { nil }
+}
+
+fn denied(_ u64) bool { return false }
+fn permitted(seq u64) bool { return seq == 7 }
+
+fn test_smr_poll_is_not_a_success_stub() {
+	mut d := xnualloc.Depot{}
+	mut mag := xnualloc.Magazine{seq: 7}
+	d.zone_depot_init()
+	assert !d.zone_depot_poll(false, denied)
+	d.zone_depot_insert_tail_full(mut mag)
+	assert d.zone_depot_poll(false, denied)
+	assert !d.zone_depot_poll(true, denied)
+	assert d.zone_depot_poll(true, permitted)
+}
+
+fn test_magazine_swap_replace_and_non_smr_fast_paths() {
+	mut a := xnualloc.Magazine{}
+	mut f := xnualloc.Magazine{}
+	mut full := xnualloc.Magazine{}
+	mut c := xnualloc.Cache{alloc_mag: &a, free_mag: &f}
+	for i := u64(1); i <= 33; i++ { assert c.try_free(i) }
+	assert c.alloc_cur == 32 && c.free_cur == 1
+	for i := u64(32); i > 0; i-- { assert c.try_alloc() == i }
+	assert c.try_alloc() == 33
+	assert c.try_alloc() == 0
+	for i in 0 .. 32 { full.elems[i] = u64(i + 100) }
+	old := c.zone_magazine_replace(mut full, false)
+	assert u64(old) != u64(&full) && c.try_alloc() == 131
+}
+
+fn test_free_swap_with_partial_alloc_magazine() {
+	mut a := xnualloc.Magazine{}
+	mut f := xnualloc.Magazine{}
+	a.elems[0] = 1000
+	for i in 0 .. 32 { f.elems[i] = u64(i + 1) }
+	mut c := xnualloc.Cache{alloc_mag: &a, free_mag: &f, alloc_cur: 1, free_cur: 32}
+	assert c.try_free(1001)
+	assert c.alloc_cur == 32 && c.free_cur == 2
+	assert c.free_mag.elems[0] == 1000 && c.free_mag.elems[1] == 1001
+	assert c.try_alloc() == 32
+}

--- a/tests/xnualloc/reference.c
+++ b/tests/xnualloc/reference.c
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2000-2020 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/*
+ * @OSF_COPYRIGHT@
+ */
+/*
+ * Mach Operating System
+ * Copyright (c) 1991,1990,1989,1988,1987 Carnegie Mellon University
+ * All Rights Reserved.
+ *
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ *
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+ * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ *
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie Mellon
+ * the rights to redistribute these changes.
+ */
+// Modified 2026-09-11: C-to-V translation and explicitly documented adaptations.
+// Upstream: apple-oss-distributions/xnu f6217f891ac0bb64f3d375211650a4c1ff8ca1ea,
+// osfmk/kern/zalloc.c. See docs/xnualloc/PORT_STATUS.md and
+// kernel/modules/xnualloc/APPLE_LICENSE.
+// These translations retain APSL 2.0; they are NOT relicensed as GPL.
+
+/* C reference extracted from zalloc.c. Harness adaptations: prebacked arenas,
+ * explicit pointer/count arguments for scans, and checked-exhaustion wrappers.
+ * The split/coalesce/list formulas and bitmap scan/merge/free logic are kept.
+ * This reference is NOT the translated V implementation.
+ */
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#ifndef PAGE_MAX_SHIFT
+#define PAGE_MAX_SHIFT 12
+#endif
+#define ZBA_CHUNK_SIZE (1u << PAGE_MAX_SHIFT)
+#define ZBA_GRANULE sizeof(uint64_t)
+#define ZBA_MAX_ORDER (PAGE_MAX_SHIFT - 4)
+#define ZBA_SLOTS (ZBA_CHUNK_SIZE / ZBA_GRANULE)
+#define ZBA_HEADS_COUNT (ZBA_MAX_ORDER + 1)
+struct zone_bits_chain { uint32_t zbc_next, zbc_prev; };
+struct zone_bits_head { uint32_t zbh_next, zbh_unused; };
+struct zone_bits_allocator_meta {
+    uint32_t zbam_left, zbam_right;
+    struct zone_bits_head zbam_lists[ZBA_HEADS_COUNT];
+    struct zone_bits_head zbam_lists_with_extra[ZBA_HEADS_COUNT];
+};
+struct zone_bits_allocator_header { uint64_t zbah_bits[ZBA_SLOTS / 64]; };
+static uint8_t *arena;
+static size_t arena_bytes;
+static struct zone_bits_allocator_header *zba_base_header(void) { return (void *)arena; }
+static struct zone_bits_allocator_meta *zba_meta(void) { return (void *)&zba_base_header()[1]; }
+static uint64_t *zba_slot_base(void) { return (void *)arena; }
+static struct zone_bits_head *zba_head(uint32_t order, bool with_extra) {
+    return with_extra ? &zba_meta()->zbam_lists_with_extra[order] : &zba_meta()->zbam_lists[order];
+}
+static uint32_t zba_head_index(struct zone_bits_head *hd) { return (uint32_t)((uint64_t *)hd - zba_slot_base()); }
+static struct zone_bits_chain *zba_chain_for_index(uint32_t index) { return (void *)(zba_slot_base() + index); }
+static uint32_t zba_chain_to_index(const struct zone_bits_chain *zbc) { return (uint32_t)((const uint64_t *)zbc - zba_slot_base()); }
+static void zba_push_block(struct zone_bits_chain *zbc, uint32_t order, bool with_extra) {
+    struct zone_bits_head *hd = zba_head(order, with_extra);
+    uint32_t hd_index = zba_head_index(hd), index = zba_chain_to_index(zbc);
+    struct zone_bits_chain *next;
+    if (hd->zbh_next) {
+        next = zba_chain_for_index(hd->zbh_next);
+        assert(next->zbc_prev == hd_index);
+        next->zbc_prev = index;
+    }
+    zbc->zbc_next = hd->zbh_next;
+    zbc->zbc_prev = hd_index;
+    hd->zbh_next = index;
+}
+static void zba_remove_block(struct zone_bits_chain *zbc) {
+    struct zone_bits_chain *prev = zba_chain_for_index(zbc->zbc_prev);
+    uint32_t index = zba_chain_to_index(zbc);
+    assert(prev->zbc_next == index);
+    if ((prev->zbc_next = zbc->zbc_next)) {
+        struct zone_bits_chain *next = zba_chain_for_index(zbc->zbc_next);
+        assert(next->zbc_prev == index);
+        next->zbc_prev = zbc->zbc_prev;
+    }
+}
+static uintptr_t zba_try_pop_block(uint32_t order, bool with_extra) {
+    struct zone_bits_head *hd = zba_head(order, with_extra);
+    if (hd->zbh_next == 0) return 0;
+    struct zone_bits_chain *zbc = zba_chain_for_index(hd->zbh_next);
+    zba_remove_block(zbc);
+    return (uintptr_t)zbc;
+}
+static struct zone_bits_allocator_header *zba_header(uintptr_t addr) { return (void *)(addr & -(uintptr_t)ZBA_CHUNK_SIZE); }
+static size_t zba_node_parent(size_t node) { return (node - 1) / 2; }
+static size_t zba_node_left_child(size_t node) { return node * 2 + 1; }
+static size_t zba_node_buddy(size_t node) { return ((node - 1) ^ 1) + 1; }
+static size_t zba_node(uintptr_t addr, uint32_t order) {
+    uintptr_t offs = (addr % ZBA_CHUNK_SIZE) / ZBA_GRANULE;
+    return (offs >> order) + (1u << (ZBA_MAX_ORDER - order + 1)) - 1;
+}
+static struct zone_bits_chain *zba_chain_for_node(struct zone_bits_allocator_header *zbah, size_t node, uint32_t order) {
+    uintptr_t offs = (node - (1u << (ZBA_MAX_ORDER - order + 1)) + 1) << order;
+    return (void *)((uintptr_t)zbah + offs * ZBA_GRANULE);
+}
+static void zba_node_flip_split(struct zone_bits_allocator_header *zbah, size_t node) { zbah->zbah_bits[node / 64] ^= 1ull << (node % 64); }
+static bool zba_node_is_split(struct zone_bits_allocator_header *zbah, size_t node) { return zbah->zbah_bits[node / 64] & (1ull << (node % 64)); }
+static void zba_free(uintptr_t addr, uint32_t order, bool with_extra) {
+    struct zone_bits_allocator_header *zbah = zba_header(addr);
+    size_t node = zba_node(addr, order);
+    while (node) {
+        size_t parent = zba_node_parent(node);
+        zba_node_flip_split(zbah, parent);
+        if (zba_node_is_split(zbah, parent)) break;
+        struct zone_bits_chain *zbc = zba_chain_for_node(zbah, zba_node_buddy(node), order);
+        zba_remove_block(zbc);
+        order++;
+        node = parent;
+    }
+    zba_push_block(zba_chain_for_node(zbah, node, order), order, with_extra);
+}
+static size_t zba_chunk_header_size(uint32_t n) {
+    return sizeof(struct zone_bits_allocator_header) + (n == 0 ? sizeof(struct zone_bits_allocator_meta) : 0);
+}
+static void zba_init_chunk(uint32_t n, bool with_extra) {
+    size_t hdr_size = zba_chunk_header_size(n), size = ZBA_CHUNK_SIZE;
+    uintptr_t page = (uintptr_t)zba_base_header() + n * ZBA_CHUNK_SIZE;
+    struct zone_bits_allocator_header *zbah = zba_header(page);
+    for (uint32_t o = ZBA_MAX_ORDER + 1; o-- > 0;) {
+        if (size < hdr_size + (ZBA_GRANULE << o)) continue;
+        size -= ZBA_GRANULE << o;
+        size_t node = zba_node(page + size, o);
+        zba_node_flip_split(zbah, zba_node_parent(node));
+        zba_push_block(zba_chain_for_node(zbah, node, o), o, with_extra);
+    }
+}
+static void zba_grow(bool with_extra) {
+    struct zone_bits_allocator_meta *meta = zba_meta();
+    assert(meta->zbam_left < meta->zbam_right);
+    uint32_t chunk = with_extra ? meta->zbam_right - 1 : meta->zbam_left;
+    memset(arena + chunk * ZBA_CHUNK_SIZE, 0, ZBA_CHUNK_SIZE);
+    if (with_extra) meta->zbam_right--; else meta->zbam_left++;
+    zba_init_chunk(chunk, with_extra);
+}
+static uintptr_t zba_alloc(uint32_t order, bool with_extra) {
+    uint32_t cur = order;
+    uintptr_t addr;
+    while ((addr = zba_try_pop_block(cur, with_extra)) == 0) {
+        if (cur++ >= ZBA_MAX_ORDER) { zba_grow(with_extra); cur = order; }
+    }
+    struct zone_bits_allocator_header *zbah = zba_header(addr);
+    size_t node = zba_node(addr, cur);
+    zba_node_flip_split(zbah, zba_node_parent(node));
+    while (cur > order) {
+        cur--;
+        zba_node_flip_split(zbah, node);
+        node = zba_node_left_child(node);
+        zba_push_block(zba_chain_for_node(zbah, node + 1, cur), cur, with_extra);
+    }
+    return addr;
+}
+int ref_buddy_init(uint32_t chunks) {
+    free(arena); arena = NULL;
+    arena_bytes = (size_t)chunks * ZBA_CHUNK_SIZE;
+    if (!chunks || posix_memalign((void **)&arena, ZBA_CHUNK_SIZE, arena_bytes)) return -1;
+    memset(arena, 0, arena_bytes);
+    zba_meta()->zbam_left = 1; zba_meta()->zbam_right = chunks;
+    zba_init_chunk(0, false);
+    return 0;
+}
+uint64_t ref_buddy_alloc(uint32_t order, bool extra) {
+    if (order > ZBA_MAX_ORDER) return 0;
+    bool available = zba_meta()->zbam_left < zba_meta()->zbam_right;
+    for (uint32_t o = order; o <= ZBA_MAX_ORDER; o++) available |= zba_head(o, extra)->zbh_next != 0;
+    if (!available) return 0;
+    return (uint64_t)(zba_alloc(order, extra) - (uintptr_t)arena);
+}
+void ref_buddy_free(uint64_t offset, uint32_t order, bool extra) { zba_free((uintptr_t)arena + offset, order, extra); }
+void ref_buddy_snapshot(void *out) { memcpy(out, arena, arena_bytes); }
+void ref_buddy_destroy(void) { free(arena); arena = NULL; }
+uint64_t ref_scan64(uint64_t *bits, uint32_t words, uint64_t eidx) {
+    size_t i = eidx / 64;
+    uint64_t map;
+    if (eidx % 64) {
+        map = bits[i] & (-(1ull << (eidx % 64)));
+        if (map) { eidx = __builtin_ctzll(map); bits[i] ^= 1ull << eidx; return i * 64 + eidx; }
+        i++;
+    }
+    for (uint32_t j = 0; j < words; i++, j++) {
+        if (i >= words) i = 0;
+        if ((map = bits[i])) { bits[i] &= map - 1; return i * 64 + __builtin_ctzll(map); }
+    }
+    return UINT64_MAX;
+}
+void ref_merge64(uint64_t *bits, uint32_t start, uint32_t end) {
+    while (start < end) {
+        size_t s_i = start / 64, s_e = end / 64;
+        if (s_i == s_e) { bits[s_i] |= ((1ull << (end % 64)) - 1) & (-(1ull << (start % 64))); break; }
+        bits[s_i] |= -(1ull << (start % 64));
+        start += 64 - start % 64;
+    }
+}
+bool ref_mark_free64(uint64_t *bits, uint64_t eidx) {
+    uint64_t bit = 1ull << (eidx % 64);
+    if (bits[eidx / 64] & bit) return false;
+    bits[eidx / 64] ^= bit;
+    return true;
+}

--- a/tests/xnualloc/reference_test.py
+++ b/tests/xnualloc/reference_test.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+# Copyright (c) 2000-2020 Apple Inc. All rights reserved.
+#
+# @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+#
+# This file contains Original Code and/or Modifications of Original Code
+# as defined in and that are subject to the Apple Public Source License
+# Version 2.0 (the 'License'). You may not use this file except in
+# compliance with the License. The rights granted to you under the License
+# may not be used to create, or enable the creation or redistribution of,
+# unlawful or unlicensed copies of an Apple operating system, or to
+# circumvent, violate, or enable the circumvention or violation of, any
+# terms of an Apple operating system software license agreement.
+#
+# Please obtain a copy of the License at
+# http://www.opensource.apple.com/apsl/ and read it before using this file.
+#
+# The Original Code and all software distributed under the License are
+# distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+# EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+# INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+# Please see the License for the specific language governing rights and
+# limitations under the License.
+#
+# @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+# @OSF_COPYRIGHT@
+# Mach Operating System
+# Copyright (c) 1991,1990,1989,1988,1987 Carnegie Mellon University
+# All Rights Reserved.
+#
+# Permission to use, copy, modify and distribute this software and its
+# documentation is hereby granted, provided that both the copyright
+# notice and this permission notice appear in all copies of the
+# software, derivative works or modified versions, and any portions
+# thereof, and that both notices appear in supporting documentation.
+#
+# CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+# CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+# ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+#
+# Carnegie Mellon requests users of this software to return to
+#
+# Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+# School of Computer Science
+# Carnegie Mellon University
+# Pittsburgh PA 15213-3890
+#
+# any improvements or extensions that they make and grant Carnegie Mellon
+# the rights to redistribute these changes.
+# Modified 2026-09-11: Python differential harness and translated buddy model.
+# Upstream: apple-oss-distributions/xnu f6217f891ac0bb64f3d375211650a4c1ff8ca1ea,
+# osfmk/kern/zalloc.c. See docs/xnualloc/PORT_STATUS.md and
+# kernel/modules/xnualloc/APPLE_LICENSE.
+# These translations retain APSL 2.0; they are NOT relicensed as GPL.
+#
+
+"""Executable C-reference checks, not execution of the V implementation.
+
+Builds the extracted C reference using UBSan. Tests it against a byte-oriented
+buddy model and an independent bit-by-bit oracle. V execution is a separate
+step (port_test.v); passing this file does not establish V compiler correctness
+or kernel/SMP correctness.
+"""
+from __future__ import annotations
+
+import ctypes as C
+import os
+from pathlib import Path
+import random
+import struct
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+MASK = (1 << 64) - 1
+
+
+class BuddyModel:
+    """Test model of the translated relative-index/split-bit representation."""
+    def __init__(self, shift: int, chunks: int) -> None:
+        self.page = 1 << shift
+        self.order = shift - 4
+        self.heads = self.order + 1
+        self.hdr = self.page // 64
+        self.data = bytearray(self.page * chunks)
+        self.w32(self.hdr, 1)
+        self.w32(self.hdr + 4, chunks)
+        self.init_chunk(0, False)
+
+    def r32(self, offset: int) -> int:
+        return struct.unpack_from('<I', self.data, offset)[0]
+
+    def w32(self, offset: int, value: int) -> None:
+        struct.pack_into('<I', self.data, offset, value)
+
+    def head(self, order: int, extra: bool) -> int:
+        return (self.hdr + 8 + ((self.heads if extra else 0) + order) * 8) // 8
+
+    def push(self, index: int, order: int, extra: bool) -> None:
+        hd = self.head(order, extra)
+        nxt = self.r32(hd * 8)
+        if nxt:
+            assert self.r32(nxt * 8 + 4) == hd
+            self.w32(nxt * 8 + 4, index)
+        self.w32(index * 8, nxt)
+        self.w32(index * 8 + 4, hd)
+        self.w32(hd * 8, index)
+
+    def remove(self, index: int) -> None:
+        nxt, prev = self.r32(index * 8), self.r32(index * 8 + 4)
+        assert self.r32(prev * 8) == index
+        self.w32(prev * 8, nxt)
+        if nxt:
+            assert self.r32(nxt * 8 + 4) == index
+            self.w32(nxt * 8 + 4, prev)
+
+    def pop(self, order: int, extra: bool) -> int:
+        index = self.r32(self.head(order, extra) * 8)
+        if index:
+            self.remove(index)
+        return index * 8
+
+    def node(self, address: int, order: int) -> int:
+        return ((address % self.page // 8) >> order) + (1 << (self.order - order + 1)) - 1
+
+    def address(self, page: int, node: int, order: int) -> int:
+        return page + ((node - (1 << (self.order - order + 1)) + 1) << order) * 8
+
+    def flip(self, page: int, node: int) -> None:
+        pos = page + (node // 64) * 8
+        word = struct.unpack_from('<Q', self.data, pos)[0]
+        struct.pack_into('<Q', self.data, pos, word ^ (1 << (node % 64)))
+
+    def split(self, page: int, node: int) -> bool:
+        word = struct.unpack_from('<Q', self.data, page + (node // 64) * 8)[0]
+        return bool(word & (1 << (node % 64)))
+
+    def init_chunk(self, index: int, extra: bool) -> None:
+        header = self.hdr + (8 + self.heads * 16 if index == 0 else 0)
+        page, size = index * self.page, self.page
+        for order in range(self.order, -1, -1):
+            block = 8 << order
+            if size < header + block:
+                continue
+            size -= block
+            node = self.node(page + size, order)
+            self.flip(page, (node - 1) // 2)
+            self.push(self.address(page, node, order) // 8, order, extra)
+
+    def grow(self, extra: bool) -> bool:
+        left, right = self.r32(self.hdr), self.r32(self.hdr + 4)
+        if left >= right:
+            return False
+        index = right - 1 if extra else left
+        self.data[index * self.page:(index + 1) * self.page] = bytes(self.page)
+        self.w32(self.hdr + (4 if extra else 0), right - 1 if extra else left + 1)
+        self.init_chunk(index, extra)
+        return True
+
+    def alloc(self, order: int, extra: bool) -> int:
+        current = order
+        address = self.pop(current, extra)
+        while not address:
+            if current >= self.order:
+                if not self.grow(extra):
+                    return 0
+                current = order
+            else:
+                current += 1
+            address = self.pop(current, extra)
+        page = address & -self.page
+        node = self.node(address, current)
+        self.flip(page, (node - 1) // 2)
+        while current > order:
+            current -= 1
+            self.flip(page, node)
+            node = node * 2 + 1
+            self.push(self.address(page, node + 1, current) // 8, current, extra)
+        return address
+
+    def free(self, address: int, order: int, extra: bool) -> None:
+        page, node = address & -self.page, self.node(address, order)
+        while node:
+            parent = (node - 1) // 2
+            self.flip(page, parent)
+            if self.split(page, parent):
+                break
+            self.remove(self.address(page, ((node - 1) ^ 1) + 1, order) // 8)
+            order += 1
+            node = parent
+        assert order <= self.order
+        self.push(self.address(page, node, order) // 8, order, extra)
+
+    def check_lists(self) -> None:
+        visited: set[int] = set()
+        for extra in (False, True):
+            for order in range(self.heads):
+                previous = self.head(order, extra)
+                index = self.r32(previous * 8)
+                while index:
+                    assert index not in visited
+                    visited.add(index)
+                    assert self.r32(index * 8 + 4) == previous
+                    assert (index * 8) % (8 << order) == 0
+                    assert index * 8 + (8 << order) <= len(self.data)
+                    previous, index = index, self.r32(index * 8)
+
+
+def load_library(shift: int, destination: Path) -> C.CDLL:
+    output = destination / f'ref{shift}.so'
+    command = [os.environ.get('CC', 'cc'), '-std=c11', '-D_POSIX_C_SOURCE=200809L',
+               f'-DPAGE_MAX_SHIFT={shift}', '-O1', '-g', '-Wall', '-Wextra', '-Werror',
+               '-fsanitize=undefined', '-fno-sanitize-recover=all', '-shared', '-fPIC',
+               str(ROOT / 'tests/xnualloc/reference.c'), '-o', str(output)]
+    subprocess.run(command, check=True)
+    lib = C.CDLL(str(output))
+    lib.ref_buddy_init.argtypes, lib.ref_buddy_init.restype = [C.c_uint32], C.c_int
+    lib.ref_buddy_alloc.argtypes, lib.ref_buddy_alloc.restype = [C.c_uint32, C.c_bool], C.c_uint64
+    lib.ref_buddy_free.argtypes = [C.c_uint64, C.c_uint32, C.c_bool]
+    lib.ref_buddy_snapshot.argtypes = [C.c_void_p]
+    lib.ref_scan64.argtypes, lib.ref_scan64.restype = [C.POINTER(C.c_uint64), C.c_uint32, C.c_uint64], C.c_uint64
+    lib.ref_merge64.argtypes = [C.POINTER(C.c_uint64), C.c_uint32, C.c_uint32]
+    lib.ref_mark_free64.argtypes, lib.ref_mark_free64.restype = [C.POINTER(C.c_uint64), C.c_uint64], C.c_bool
+    return lib
+
+
+class ReferenceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.temp = tempfile.TemporaryDirectory(prefix='xnu-reference-')
+        cls.libs = {s: load_library(s, Path(cls.temp.name)) for s in (12, 14)}
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        for lib in cls.libs.values():
+            lib.ref_buddy_destroy()
+        cls.temp.cleanup()
+
+    def test_rotating_scan_against_bit_by_bit_oracle(self) -> None:
+        rng = random.Random(0x584E55)
+        lib = self.libs[12]
+        for n in range(12000):
+            words = 1 << rng.randrange(8)
+            values = [rng.getrandbits(64) if n % 3 == 0 else 0 for _ in range(words)]
+            if n % 3 == 1:
+                slot = rng.randrange(words * 64)
+                values[slot // 64] = 1 << (slot % 64)
+            start = rng.randrange(words * 64 + 1)
+            wanted = MASK
+            for step in range(words * 64):
+                i = (start + step) % (words * 64)
+                if values[i // 64] & (1 << (i % 64)):
+                    wanted = i
+                    break
+            array = (C.c_uint64 * words)(*values)
+            actual = lib.ref_scan64(array, words, start)
+            self.assertEqual(actual, wanted)
+            if wanted != MASK:
+                values[wanted // 64] &= ~(1 << (wanted % 64))
+            self.assertEqual(list(array), values)
+
+    def test_merge_and_duplicate_free(self) -> None:
+        lib = self.libs[12]
+        rng = random.Random(7)
+        boundaries = [0, 1, 31, 32, 33, 63, 64, 65, 127, 128, 129, 255, 256]
+        pairs = [(a, b) for a in boundaries for b in boundaries if a <= b]
+        pairs += [tuple(sorted((rng.randrange(257), rng.randrange(257)))) for _ in range(3000)]
+        for first, end in pairs:
+            array = (C.c_uint64 * 4)()
+            lib.ref_merge64(array, first, end)
+            expected = ((1 << end) - 1) ^ ((1 << first) - 1)
+            self.assertEqual(list(array), [(expected >> (64 * i)) & MASK for i in range(4)])
+            slot = rng.randrange(256)
+            was_free = bool(expected & (1 << slot))
+            self.assertEqual(lib.ref_mark_free64(array, slot), not was_free)
+            self.assertFalse(lib.ref_mark_free64(array, slot))
+
+    def test_buddy_mixed_orders_banks_and_exact_arena_state(self) -> None:
+        for shift, lib in self.libs.items():
+            self.assertEqual(lib.ref_buddy_init(16), 0)
+            model = BuddyModel(shift, 16)
+            snapshot = (C.c_ubyte * len(model.data))()
+            rng = random.Random(shift)
+            live: list[tuple[int, int, bool]] = []
+            for step in range(20000):
+                if not live or (len(live) < 512 and rng.randrange(4)):
+                    order = rng.randrange(model.order + 1)
+                    extra = bool(rng.randrange(2))
+                    actual = lib.ref_buddy_alloc(order, extra)
+                    expected = model.alloc(order, extra)
+                    self.assertEqual(actual, expected)
+                    if actual:
+                        size = 8 << order
+                        for address, old_order, _ in live:
+                            self.assertTrue(actual + size <= address or address + (8 << old_order) <= actual)
+                        live.append((actual, order, extra))
+                else:
+                    idx = rng.randrange(len(live))
+                    address, order, extra = live.pop(idx)
+                    lib.ref_buddy_free(address, order, extra)
+                    model.free(address, order, extra)
+                if step % 37 == 0:
+                    lib.ref_buddy_snapshot(snapshot)
+                    self.assertEqual(bytes(snapshot), model.data)
+                    model.check_lists()
+            for address, order, extra in live:
+                lib.ref_buddy_free(address, order, extra)
+                model.free(address, order, extra)
+            lib.ref_buddy_snapshot(snapshot)
+            self.assertEqual(bytes(snapshot), model.data)
+            model.check_lists()
+            total = 0
+            for extra in (False, True):
+                while (address := lib.ref_buddy_alloc(model.order, extra)):
+                    self.assertEqual(address, model.alloc(model.order, extra))
+                    total += 1
+            self.assertEqual(total, 16)
+
+    def test_single_chunk_exhaustion_and_reuse(self) -> None:
+        for shift, lib in self.libs.items():
+            self.assertEqual(lib.ref_buddy_init(1), 0)
+            model = BuddyModel(shift, 1)
+            values = []
+            while (address := lib.ref_buddy_alloc(0, False)):
+                self.assertEqual(address, model.alloc(0, False))
+                values.append(address)
+            self.assertEqual(model.alloc(0, False), 0)
+            expected = ((1 << shift) - model.hdr - 8 - model.heads * 16) // 8
+            self.assertEqual(len(values), expected)
+            for address in reversed(values):
+                lib.ref_buddy_free(address, 0, False)
+                model.free(address, 0, False)
+            second = []
+            while (address := lib.ref_buddy_alloc(0, False)):
+                self.assertEqual(address, model.alloc(0, False))
+                second.append(address)
+            self.assertEqual(len(second), len(values))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/xnualloc/smoke_test.v
+++ b/tests/xnualloc/smoke_test.v
@@ -1,0 +1,11 @@
+module main
+
+import xnualloc
+
+fn test_published_bitmap_module() {
+	assert sizeof(xnualloc.PageMetadata) == 16
+	mut bits := [4]u64{}
+	xnualloc.zone_bits_init_ref(unsafe { &bits[0] }, 4, 64)
+	assert xnualloc.zba_scan_bitmap_ref(unsafe { &bits[0] }, 4, 1) == 1
+	assert xnualloc.zone_bits_mark_free_ref(unsafe { &bits[0] }, 4, 1)
+}

--- a/tests/xnualloc/zone_model_test.py
+++ b/tests/xnualloc/zone_model_test.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Executable specification of the non-SMR port protocol; DOES NOT execute V.
+
+Checks the adapter's single-lock ownership discipline with an independent
+address-set oracle after every operation. Not a concurrency or performance test.
+"""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from pathlib import Path
+import random
+import unittest
+
+N = 32
+
+@dataclass(eq=False)
+class Magazine:
+    items: list[int] = field(default_factory=list)
+
+@dataclass
+class Depot:
+    full: list[Magazine] = field(default_factory=list)
+    empty: list[Magazine] = field(default_factory=list)
+
+@dataclass
+class Cache:
+    alloc: Magazine = field(default_factory=Magazine)
+    free: Magazine = field(default_factory=Magazine)
+    depot: Depot = field(default_factory=lambda: Depot(empty=[Magazine() for _ in range(4)]))
+    rr: int = 0
+
+    def pop(self) -> int:
+        if not self.alloc.items and self.free.items:
+            self.alloc, self.free = self.free, self.alloc
+        return self.alloc.items.pop() if self.alloc.items else 0
+
+    def push(self, addr: int) -> bool:
+        if len(self.free.items) == N and len(self.alloc.items) < N:
+            self.alloc, self.free = self.free, self.alloc
+        if len(self.free.items) == N:
+            return False
+        self.free.items.append(addr)
+        return True
+
+class Zone:
+    def __init__(self, capacity: int, pages: int, limit: int):
+        assert 0 < capacity <= 256 and 0 <= limit <= 4
+        self.capacity = capacity
+        self.free = [set(range(capacity)) for _ in range(pages)]
+        self.empty = list(reversed(range(pages)))
+        self.partial: list[int] = []
+        self.full: list[int] = []
+        self.detached: set[int] = set()
+        self.live: set[int] = set()
+        self.recirc = Depot()
+        self.limit = limit
+
+    def encode(self, page: int, slot: int) -> int:
+        return (page + 1) * 4096 + slot * 16
+
+    def decode(self, addr: int) -> tuple[int, int]:
+        return addr // 4096 - 1, addr % 4096 // 16
+
+    def available(self) -> int:
+        return sum(len(f) for p, f in enumerate(self.free) if p not in self.detached)
+
+    def queue(self, p: int) -> None:
+        for q in (self.empty, self.partial, self.full):
+            if p in q:
+                q.remove(p)
+        if len(self.free[p]) == self.capacity:
+            self.empty.insert(0, p)
+        elif self.free[p]:
+            self.partial.insert(0, p)
+        else:
+            self.full.insert(0, p)
+
+    def reserve(self, n: int, cache: Cache) -> list[int] | None:
+        if n > self.available():
+            return None
+        result = []
+        while len(result) < n:
+            p = self.partial[0] if self.partial else self.empty[0]
+            while len(result) < n and self.free[p]:
+                start = (cache.rr + 1) % 256
+                after = [s for s in self.free[p] if s >= start]
+                s = min(after or self.free[p])
+                self.free[p].remove(s)
+                cache.rr = s
+                result.append(self.encode(p, s))
+            self.queue(p)
+        return result
+
+    def drop(self, addr: int) -> None:
+        p, s = self.decode(addr)
+        assert p not in self.detached and addr not in self.live
+        assert s not in self.free[p]
+        self.free[p].add(s)
+        self.queue(p)
+
+    @staticmethod
+    def move(src: list[Magazine], dst: list[Magazine], n: int, head: bool) -> None:
+        assert 0 < n <= len(src)
+        items, src[:n] = src[:n], []
+        if head:
+            dst[:0] = items
+        else:
+            dst.extend(items)
+
+    def alloc(self, c: Cache) -> int:
+        addr = c.pop()
+        if not addr:
+            if self.limit:
+                if not c.depot.full:
+                    if len(c.depot.empty) >= self.limit:
+                        self.move(c.depot.empty, self.recirc.empty,
+                                  len(c.depot.empty) - self.limit // 2, True)
+                    n = min(self.limit - len(c.depot.empty), len(self.recirc.full))
+                    if n:
+                        self.move(self.recirc.full, c.depot.full, n, False)
+                if c.depot.full:
+                    old, c.alloc = c.alloc, c.depot.full.pop(0)
+                    assert not old.items
+                    c.depot.empty.insert(0, old)
+            elif self.recirc.full:
+                old, c.alloc = c.alloc, self.recirc.full.pop(0)
+                assert not old.items
+                self.recirc.empty.insert(0, old)
+            if not c.alloc.items and self.available():
+                c.alloc.items = self.reserve(min(N, self.available()), c) or []
+            addr = c.pop()
+        if addr:
+            assert addr not in self.live
+            self.live.add(addr)
+        return addr
+
+    def release(self, addr: int, c: Cache | None) -> bool:
+        if addr not in self.live:
+            return False
+        self.live.remove(addr)
+        if c is not None:
+            if c.push(addr):
+                return True
+            mag = None
+            if self.limit:
+                if not c.depot.empty:
+                    if len(c.depot.full) >= self.limit:
+                        self.move(c.depot.full, self.recirc.full,
+                                  len(c.depot.full) - self.limit // 2, False)
+                    n = min(self.limit - len(c.depot.full), len(self.recirc.empty))
+                    if n:
+                        self.move(self.recirc.empty, c.depot.empty, n, True)
+                if c.depot.empty:
+                    mag = c.depot.empty.pop(0)
+                if mag:
+                    old, c.free = c.free, mag
+                    assert len(old.items) == N and not mag.items
+                    c.depot.full.append(old)
+            else:
+                if self.recirc.empty:
+                    mag = self.recirc.empty.pop(0)
+                elif c.depot.empty:
+                    mag = c.depot.empty.pop(0)
+                if mag:
+                    old, c.free = c.free, mag
+                    assert len(old.items) == N and not mag.items
+                    self.recirc.full.append(old)
+            if mag:
+                assert c.push(addr)
+                return True
+        self.drop(addr)
+        return True
+
+    def drain_mag(self, m: Magazine) -> None:
+        for a in m.items:
+            self.drop(a)
+        m.items.clear()
+
+    def drain(self, c: Cache) -> None:
+        self.drain_mag(c.alloc)
+        self.drain_mag(c.free)
+        while c.depot.full:
+            mag = c.depot.full.pop(0)
+            self.drain_mag(mag)
+            c.depot.empty.insert(0, mag)
+
+    def drain_recirc(self) -> None:
+        while self.recirc.full:
+            mag = self.recirc.full.pop(0)
+            self.drain_mag(mag)
+            self.recirc.empty.insert(0, mag)
+
+    def reclaim(self) -> int | None:
+        if not self.empty:
+            return None
+        p = self.empty.pop(0)
+        assert len(self.free[p]) == self.capacity
+        self.detached.add(p)
+        return p
+
+    def check(self, caches: list[Cache]) -> None:
+        magazines = list(self.recirc.full) + list(self.recirc.empty)
+        for c in caches:
+            assert len(c.alloc.items) <= N and len(c.free.items) <= N
+            magazines += [c.alloc, c.free] + c.depot.full + c.depot.empty
+        assert len(magazines) == len(caches) * 6
+        assert len({id(m) for m in magazines}) == len(magazines)
+        cached = [a for m in magazines for a in m.items]
+        assert len(cached) == len(set(cached))
+        assert not (set(cached) & self.live)
+        for d in [self.recirc] + [c.depot for c in caches]:
+            assert all(len(m.items) == N for m in d.full)
+            assert all(not m.items for m in d.empty)
+        reserved = {self.encode(p, s) for p, free in enumerate(self.free)
+                    if p not in self.detached for s in range(self.capacity) if s not in free}
+        assert reserved == set(cached) | self.live
+        queue_pages = self.empty + self.partial + self.full
+        assert len(queue_pages) == len(set(queue_pages))
+        assert set(queue_pages) == set(range(len(self.free))) - self.detached
+        assert all(len(self.free[p]) == self.capacity for p in self.empty)
+        assert all(0 < len(self.free[p]) < self.capacity for p in self.partial)
+        assert all(not self.free[p] for p in self.full)
+
+class ProtocolTests(unittest.TestCase):
+    def test_random_migrating_ownership_and_cache_drains(self):
+        for limit in (0, 1, 2, 4):
+            rng = random.Random(0x584E55 + limit)
+            z, caches = Zone(127, 8, limit), [Cache() for _ in range(4)]
+            live: list[int] = []
+            for step in range(20000):
+                c = caches[rng.randrange(4)]
+                if not live or (len(live) < 800 and rng.randrange(10) < 6):
+                    a = z.alloc(c)
+                    if a:
+                        self.assertNotIn(a, live)
+                        live.append(a)
+                else:
+                    i = rng.randrange(len(live))
+                    a = live.pop(i)
+                    self.assertTrue(z.release(a, c))
+                    self.assertFalse(z.release(a, c))
+                if step % 71 == 0:
+                    z.drain(c)
+                    z.drain_recirc()
+                z.check(caches)
+                self.assertEqual(set(live), z.live)
+            for a in live:
+                self.assertTrue(z.release(a, caches[0]))
+            for c in caches:
+                z.drain(c)
+            z.drain_recirc()
+            z.check(caches)
+            self.assertEqual(z.available(), 127 * 8)
+            while z.reclaim() is not None:
+                z.check(caches)
+            self.assertEqual(z.available(), 0)
+
+    def test_cached_pages_are_not_reclaimable(self):
+        z, c = Zone(64, 1, 2), Cache()
+        a = z.alloc(c)
+        self.assertTrue(z.release(a, c))
+        self.assertIsNone(z.reclaim())
+        z.drain(c)
+        z.drain_recirc()
+        self.assertEqual(z.reclaim(), 0)
+        z.check([c])
+
+    def test_live_survivor_pins_backing(self):
+        z, c = Zone(64, 1, 2), Cache()
+        a = z.alloc(c)
+        z.drain(c)
+        z.drain_recirc()
+        self.assertIsNone(z.reclaim())
+        self.assertEqual(z.available(), 63)
+        self.assertTrue(z.release(a, None))
+        self.assertEqual(z.reclaim(), 0)
+        z.check([c])
+
+    def test_failed_batch_does_not_reserve_anything(self):
+        z, c = Zone(64, 1, 2), Cache()
+        self.assertIsNone(z.reserve(65, c))
+        self.assertEqual(z.available(), 64)
+        z.check([c])
+
+    def test_partial_allocation_magazine_free_swap(self):
+        c = Cache()
+        c.alloc.items = [1, 2]
+        c.free.items = list(range(3, 35))
+        self.assertTrue(c.push(99))
+        self.assertEqual(c.free.items, [1, 2, 99])
+        self.assertEqual(len(c.alloc.items), N)
+
+    def test_source_integration_contract(self):
+        root = Path(__file__).resolve().parents[2]
+        zone = (root / 'kernel/modules/xnualloc/zone.v').read_text()
+        bridge = (root / 'kernel/modules/memory/xnu_zone_heap.v').read_text()
+        physical = (root / 'kernel/modules/memory/physical.v').read_text()
+        self.assertNotIn('mut rr u16', zone)
+        self.assertIn('heads := [z.full, z.partial, z.empty]!', zone)
+        self.assertIn('z.zone_mark_valid(addr)', zone)
+        free = bridge.split('fn xnu_heap_free(')[1].split('fn xnu_heap_realloc')[0]
+        self.assertLess(free.index('zone_mark_invalid'), free.index('C.memset'))
+        self.assertLess(free.index('C.memset'), free.index('zfree_ext'))
+        cache = bridge.split('fn (mut h XnuHeapClass) cache_locked')[1].split('fn (mut h XnuHeapClass) grow_locked')[0]
+        self.assertLess(cache.index('if count == 0'), cache.index('xnu_heap_cpu_number()'))
+        self.assertIn('allow_create && h.zone.elems_free != 0', cache)
+        self.assertIn('return xnu_heap_alloc(size)', physical)
+        self.assertIn('return xnu_heap_realloc(ptr, new_size)', physical)
+        for arch in ('x86', 'aarch64'):
+            smp = (root / f'kernel/modules/{arch}/smp/smp.v').read_text()
+            self.assertLess(smp.index('for katomic.load(&cpu_local.online)'),
+                            smp.index('memory.heap_enable_cpu_caches'))
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/xnualloc/zone_test.v
+++ b/tests/xnualloc/zone_test.v
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2000-2020 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/*
+ * @OSF_COPYRIGHT@
+ */
+/*
+ * Mach Operating System
+ * Copyright (c) 1991,1990,1989,1988,1987 Carnegie Mellon University
+ * All Rights Reserved.
+ *
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ *
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+ * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ *
+ * Carnegie Mellon requests users of this software to return to
+ *
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ *
+ * any improvements or extensions that they make and grant Carnegie Mellon
+ * the rights to redistribute these changes.
+ */
+// Modified 2026-09-11: C-to-V translation and explicitly documented adaptations.
+// Upstream: apple-oss-distributions/xnu f6217f891ac0bb64f3d375211650a4c1ff8ca1ea,
+// osfmk/kern/zalloc.c. See docs/xnualloc/PORT_STATUS.md and
+// kernel/modules/xnualloc/APPLE_LICENSE.
+// These translations retain APSL 2.0; they are NOT relicensed as GPL.
+
+
+// Ordinary zone and cache state-machine tests. These execute V when run by vtest.
+module main
+
+import xnualloc
+
+fn zn_install(mut z xnualloc.Zone, mut p xnualloc.ZoneChunk, bits &u64,
+	live &u64, base u64, offset u64) {
+	p.base = base
+	p.bytes = 4096
+	p.offset = offset
+	p.pages = 1
+	p.words = 4
+	unsafe {
+		p.bits = bits
+		p.live = live
+	}
+	assert z.zcram(mut p)
+}
+
+fn zn_bitcount(value u64) u64 {
+	mut v := value
+	mut n := u64(0)
+	for v != 0 {
+		v &= v - 1
+		n++
+	}
+	return n
+}
+
+fn zn_check(z &xnualloc.Zone, chunks &xnualloc.ZoneChunk, count int) {
+	mut capacity := u64(0)
+	mut free := u64(0)
+	mut live := u64(0)
+	mut pages := u64(0)
+	mut empty := u64(0)
+	unsafe {
+		for j := 0; j < count; j++ {
+			p := &chunks[j]
+			if p.owner == 0 {
+				assert p.queue == .detached
+				continue
+			}
+			assert p.owner == u64(z)
+			mut available := u64(0)
+			mut active := u64(0)
+			for i := u32(0); i < p.words; i++ {
+				assert p.bits[i] & p.live[i] == 0
+				available += zn_bitcount(p.bits[i])
+				active += zn_bitcount(p.live[i])
+			}
+			assert available + p.reserved == p.capacity
+			assert active <= p.reserved
+			expected := if p.reserved == 0 { xnualloc.ChunkQueue.empty }
+				else if p.reserved == p.capacity { xnualloc.ChunkQueue.full }
+				else { xnualloc.ChunkQueue.partial }
+			assert p.queue == expected
+			capacity += p.capacity
+			free += available
+			live += active
+			pages += p.pages
+			if p.reserved == 0 { empty += p.pages }
+		}
+	}
+	assert z.elems_avail == capacity && z.elems_free == free
+	assert z.live_count == live && z.wired == pages && z.wired_empty == empty
+	mut seen := map[u64]bool{}
+	heads := [z.empty, z.partial, z.full]!
+	for head in heads {
+		mut p := head
+		mut prev := u64(0)
+		for p != unsafe { nil } {
+			assert !seen[u64(p)]
+			seen[u64(p)] = true
+			assert u64(p.prev) == prev
+			prev = u64(p)
+			p = p.next
+		}
+	}
+	assert u64(seen.len) == pages
+}
+
+fn test_zone_queue_transitions_and_batch_atomicity() {
+	mut z := xnualloc.Zone{}
+	assert z.zone_init(64, 2)
+	mut p := [2]xnualloc.ZoneChunk{}
+	mut bits := [2][4]u64{}
+	mut live := [2][4]u64{}
+	for i := 0; i < 2; i++ {
+		zn_install(mut z, mut p[i], unsafe { &bits[i][0] }, unsafe { &live[i][0] },
+			u64(i + 1) * 4096, 0)
+	}
+	mut out := [128]u64{}
+	mut rr := u16(0)
+	assert !z.zalloc_import(unsafe { &out[0] }, 129, &rr)
+	assert z.elems_free == 128 && out[0] == 0
+	assert z.zalloc_import(unsafe { &out[0] }, 65, &rr)
+	assert p[1].queue == .full && p[0].queue == .partial
+	assert p[1].reserved == 64 && p[0].reserved == 1
+	zn_check(&z, unsafe { &p[0] }, 2)
+	for i := 0; i < 65; i++ { assert z.zfree_drop(out[i]) }
+	zn_check(&z, unsafe { &p[0] }, 2)
+	assert z.wired_empty == 2
+	for _ in 0 .. 2 { assert z.zone_reclaim_chunk() != unsafe { nil } }
+	assert z.zone_reclaim_chunk() == unsafe { nil }
+	zn_check(&z, unsafe { &p[0] }, 2)
+}
+
+fn test_zone_rejects_misaligned_and_cached_double_free() {
+	mut z := xnualloc.Zone{}
+	assert z.zone_init(48, 2)
+	mut p := xnualloc.ZoneChunk{}
+	mut bits := [4]u64{}
+	mut live := [4]u64{}
+	zn_install(mut z, mut p, unsafe { &bits[0] }, unsafe { &live[0] }, 4096, 16)
+	mut c := xnualloc.CpuCache{}
+	assert c.cache_init()
+	addr := z.zalloc_ext(&c)
+	assert addr != 0 && z.live_count == 1
+	assert !z.zone_mark_invalid(addr + 1)
+	assert !z.zfree_drop(addr)
+	assert z.zone_mark_invalid(addr)
+	assert z.zfree_ext(addr, &c)
+	assert !z.zone_mark_invalid(addr)
+	assert z.live_count == 0 && p.reserved > 0
+	assert z.zone_reclaim_chunk() == unsafe { nil }
+	z.zone_drain_cache(mut c)
+	z.zone_drain_recirc()
+	assert p.reserved == 0 && z.elems_free == p.capacity
+	assert z.zone_reclaim_chunk() != unsafe { nil }
+}
+
+fn test_zone_reclaim_does_not_drop_live_survivor() {
+	mut z := xnualloc.Zone{}
+	assert z.zone_init(16, 2)
+	mut p := xnualloc.ZoneChunk{}
+	mut bits := [4]u64{}
+	mut live := [4]u64{}
+	zn_install(mut z, mut p, unsafe { &bits[0] }, unsafe { &live[0] }, 4096, 0)
+	mut c := xnualloc.CpuCache{}
+	assert c.cache_init()
+	addr := z.zalloc_ext(&c)
+	z.zone_drain_cache(mut c)
+	z.zone_drain_recirc()
+	assert p.reserved == 1 && z.live_count == 1
+	assert z.zone_reclaim_chunk() == unsafe { nil }
+	assert z.zone_mark_invalid(addr)
+	assert z.zfree_ext(addr, unsafe { nil })
+	assert z.zone_reclaim_chunk() != unsafe { nil }
+}
+
+fn zn_random(state &u64) u64 {
+	unsafe {
+		mut v := *state
+		v ^= v << 13
+		v ^= v >> 7
+		v ^= v << 17
+		*state = v
+		return v
+	}
+}
+
+fn test_zone_multi_cpu_migration_and_drain_sequences() {
+	for depot_max in [u32(0), 1, 2, 4] {
+		mut z := xnualloc.Zone{}
+		assert z.zone_init(16, depot_max)
+		mut p := [4]xnualloc.ZoneChunk{}
+		mut bits := [4][4]u64{}
+		mut live_bits := [4][4]u64{}
+		mut cpus := [4]xnualloc.CpuCache{}
+		for i := 0; i < 4; i++ {
+			zn_install(mut z, mut p[i], unsafe { &bits[i][0] }, unsafe { &live_bits[i][0] },
+				u64(i + 1) * 4096, 0)
+			assert cpus[i].cache_init()
+		}
+		mut live := []u64{}
+		mut state := u64(0x1234567812345678) + depot_max
+		for step in 0 .. 20000 {
+			r := zn_random(&state)
+			cpu := int((r >> 12) & 3)
+			if live.len == 0 || (live.len < 800 && r & 1 == 0) {
+				addr := z.zalloc_ext(unsafe { &cpus[cpu] })
+				if addr != 0 {
+					assert addr !in live
+					live << addr
+				}
+			} else {
+				i := int((r >> 20) % u64(live.len))
+				addr := live[i]
+				assert z.zone_mark_invalid(addr)
+				assert z.zfree_ext(addr, unsafe { &cpus[cpu] })
+				live.delete(i)
+			}
+			if step % 71 == 0 {
+				z.zone_drain_cache(mut cpus[cpu])
+				z.zone_drain_recirc()
+			}
+			zn_check(&z, unsafe { &p[0] }, 4)
+			assert z.live_count == u64(live.len)
+		}
+		for addr in live {
+			assert z.zone_mark_invalid(addr)
+			assert z.zfree_ext(addr, unsafe { &cpus[0] })
+		}
+		for i := 0; i < 4; i++ { z.zone_drain_cache(mut cpus[i]) }
+		z.zone_drain_recirc()
+		zn_check(&z, unsafe { &p[0] }, 4)
+		assert z.elems_free == 1024 && z.live_count == 0
+		for _ in 0 .. 4 { assert z.zone_reclaim_chunk() != unsafe { nil } }
+		zn_check(&z, unsafe { &p[0] }, 4)
+	}
+}
+
+fn test_zone_geometry_rejection_and_no_backing_failure() {
+	mut z := xnualloc.Zone{}
+	assert !z.zone_init(0, 2)
+	assert !z.zone_init(16, 5)
+	assert z.zone_init(16, 2)
+	assert !z.zone_init(16, 2)
+	assert z.zalloc_ext(unsafe { nil }) == 0
+	mut p := xnualloc.ZoneChunk{base: u64(-1) - 1024, bytes: 4096}
+	assert !z.zcram(mut p)
+	assert p.owner == 0 && z.elems_avail == 0
+}


### PR DESCRIPTION
## Published continuation

Continues #178 with three new commits, ending at `183c323fc3ef0f75538d1f3b9c4164323d916741`. The continuation changes 25 files relative to `1dc68880818947654a69de85193d8800be0e4749`. This branch does not modify master or the head of #178.

**This is a partial, adapted translation—not the entire XNU allocator and not production validated.** Source is pinned to Apple XNU `f6217f891ac0bb64f3d375211650a4c1ff8ca1ea`, principally `osfmk/kern/zalloc.c`. Apple/CMU notices and the exact APSL license are retained. Translations are not relicensed as GPL; no combined-distribution compatibility or license exception is asserted.

## New implementation

- Publish the formerly local bitmap, bitmap-metadata buddy, and magazine/depot translations.
- Add `xnualloc/zone.v`: ordinary fully backed chunk installation; full/partial/empty queues; batch import; rotating bitmap reservation; live-object validation; allocation/free accounting; non-SMR cache refill/overflow; local/central depot movement; cache drains and empty-chunk reclamation.
- Add an opt-in `-d xnu_zone` Vinix backend wired to small malloc/free/realloc and heap_trim. `-d xnu_bitmap` remains the narrower bitmap-only alternative.
- Publish cache readiness only after both architectures' SMP initialization installs CPU numbers. First 64 logical CPUs can use lazily PMM-allocated caches; early boot, unavailable caches and higher CPU IDs use the uncached path. Do not allocate new cache metadata until a payload slot is available.
- Invalidate and poison before publishing a free object; reserve a live slot before unlocking and zeroing an allocation. Drain cached references before reclaiming pages, and release detached backing outside the class lock. Update the boot self-test to exercise the selected public heap backend.

## Important adaptations and remaining work

**One interrupt-disabling class lock covers the zone, all its CPU caches and both depot layers.** These are real per-CPU cache objects, but NOT XNU's scalable per-CPU fast path. Cached/recirculating objects stay bitmap-reserved until draining, unlike XNU's more elaborate accounting. Cache metadata is retained permanently; headers remain in writable payload pages. There is no CPU-offline teardown. No speedup or security-equivalence claim.

The full kalloc dispatch and typed/variable heaps, complete zone startup/configuration, permanent/per-CPU/read-only zones, SMR deferred frees, custom cache callbacks, split-lock/preemption protocol, guarded/tagged/sanitized paths, adaptive working-set policy and diagnostics remain incomplete. Mach VM population, partial expansion, waits/NOFAIL contracts, VA sequestering and pressure/jetsam are not emulated. Large requests retain Vinix's contiguous PMM-backed implementation. The translated buddy remains a library, not live metadata backing or a replacement PMM.

See `docs/xnualloc/PORT_STATUS.md` for the source-to-V coverage table and exact locking/lifetime contracts. Source is visible to the V compiler even with the flags off, so default builds also need validation.

## Validation actually executed locally

| Check | Result |
|---|---|
| Independent slab model/source checks | 10 passed; includes 100,000 mixed operations |
| Extracted C reference vs models, with UBSan | 4 passed; includes 12,000 bitmap cases and 40,000 buddy operations |
| Non-SMR zone protocol/source checks | 6 passed; includes 80,000 operations, four logical CPU caches, depot limits 0/1/2/4 |
| git diff --check and workflow YAML parsing | Passed |
| Published content verification | All 25 continuation files match their GitHub blob hashes |
| Patch application against exact affected base inputs | Passed; all 28 selected output files match published/retained hashes |

**These passing checks do not execute V and do not test hardware concurrency.** Eighteen actual V host tests are supplied, but were not run locally because no V compiler was available. No QEMU/kernel boot, SMP/interrupt stress, weak-memory-order validation or performance measurements were run.

CI is configured for checksum-pinned V debug/production host tests and dependent x86-64/ARM64 debug kernel builds in flag-off, bitmap-only and zone modes. It cleans between modes because upstream make stamps do not track heap flags. A configured or queued job is not a passing result. Build/test commands are in `tests/xnualloc/README.md`.

Keep draft until actual V and both-architecture builds pass, the kernels boot and self-test, cross-CPU allocation/free/trim survives interrupt and OOM stress, and performance/retention measurements justify the design.