### PR TITLE
pagecache: add bounded EXT2 backing-store caching and writeback hooks

### DIFF
--- a/.github/workflows/pagecache.yml
+++ b/.github/workflows/pagecache.yml
@@ -1,0 +1,21 @@
+name: Page cache tests
+on:
+  pull_request:
+    paths:
+      - 'kernel/modules/pagecache/**'
+      - 'kernel/modules/resource/cache.v'
+      - 'kernel/modules/fs/ext2/**'
+      - 'kernel/modules/file/**'
+      - 'tests/pagecache/**'
+      - '.github/workflows/pagecache.yml'
+permissions:
+  contents: read
+jobs:
+  host-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build current V
+        run: git clone --depth=1 https://github.com/vlang/v.git /tmp/v && make -C /tmp/v
+      - name: Test the kernel cache with instrumented backing I/O
+        run: V=/tmp/v/v sh tests/pagecache/run.sh

--- a/kernel/modules/file/file.v
+++ b/kernel/modules/file/file.v
@@ -292,6 +292,10 @@ pub fn (mut this Handle) write(buf voidptr, count u64) ?i64 {
 	}
 	ret := this.resource.write(voidptr(this), buf, u64(this.loc), count) or { return none }
 	this.loc += ret
+	if this.flags & resource.o_dsync != 0 {
+		mut res := this.resource
+		resource.sync_resource(mut res, voidptr(this)) or { return none }
+	}
 	return ret
 }
 
@@ -512,14 +516,23 @@ pub fn syscall_close_range(_ voidptr, first u32, last u32, flags u32) (u64, u64)
 	return 0, 0
 }
 
-// fsync/fdatasync. Writes here reach the resource as they are made — there is
-// no dirty page cache between a write and its backing store — so there is
-// nothing to flush. The descriptor is still validated, because reporting
-// success for a closed one would hide a real bug in the caller.
+// fsync/fdatasync flush dirty pages through the resource's optional sync hook.
+// In-memory resources need no callback; streams cannot be synchronized.
 pub fn syscall_fsync(_ voidptr, fdnum int) (u64, u64) {
 	mut fd := fd_from_fdnum(unsafe { nil }, fdnum) or { return errno.err, errno.ebadf }
-	fd.unref()
-
+	defer { fd.unref() }
+	mut handle := fd.handle
+	handle.l.acquire()
+	defer { handle.l.release() }
+	if handle.flags & resource.o_path != 0 {
+		return errno.err, errno.ebadf
+	}
+	mut res := handle.resource
+	mode := res.stat.mode
+	if !stat.isreg(mode) && !stat.isdir(mode) && !stat.isblk(mode) {
+		return errno.err, errno.einval
+	}
+	resource.sync_resource(mut res, voidptr(handle)) or { return errno.err, errno.get() }
 	return 0, 0
 }
 
@@ -618,6 +631,9 @@ pub fn syscall_pwrite(_ voidptr, fdnum int, buf voidptr, count u64, offset i64) 
 	ret := res.write(voidptr(handle), buf, u64(offset), count) or {
 		return errno.err, errno.get()
 	}
+	if handle.flags & resource.o_dsync != 0 {
+		resource.sync_resource(mut res, voidptr(handle)) or { return errno.err, errno.get() }
+	}
 	return u64(ret), 0
 }
 
@@ -660,8 +676,7 @@ pub fn syscall_fallocate(_ voidptr, fdnum int, mode int, offset i64, length i64)
 	return 0, 0
 }
 
-// There is no page cache whose policy can be changed yet.  Validate the call
-// exactly where Linux would, then accept the advice as a harmless hint.
+// Dispatch cache advice when supported; other resources may ignore hints.
 pub fn syscall_fadvise64(_ voidptr, fdnum int, offset i64, length i64, advice int) (u64, u64) {
 	if offset < 0 || length < 0 || advice < 0 || advice > 5 {
 		return errno.err, errno.einval
@@ -672,15 +687,24 @@ pub fn syscall_fadvise64(_ voidptr, fdnum int, offset i64, length i64, advice in
 		fd.unref()
 	}
 
-	mode := fd.handle.resource.stat.mode
+	mut handle := fd.handle
+	if handle.flags & resource.o_path != 0 {
+		return errno.err, errno.ebadf
+	}
+	mut res := handle.resource
+	mode := res.stat.mode
 	if stat.isifo(mode) || stat.issock(mode) || mode & stat.ifmt == stat.ifpipe {
 		return errno.err, errno.espipe
+	}
+	resource.advise_resource(mut res, voidptr(handle), u64(offset), u64(length), advice) or {
+		return errno.err, errno.get()
 	}
 	return 0, 0
 }
 
 pub fn syscall_sync_file_range(_ voidptr, fdnum int, offset i64, count i64, flags u32) (u64, u64) {
-	if offset < 0 || count < 0 || flags & ~u32(0x7) != 0 {
+	if offset < 0 || count < 0 || flags & ~u32(0x7) != 0
+		|| u64(count) > u64(0x7fffffffffffffff) - u64(offset) {
 		return errno.err, errno.einval
 	}
 
@@ -695,7 +719,12 @@ pub fn syscall_sync_file_range(_ voidptr, fdnum int, offset i64, count i64, flag
 	if !stat.isreg(fd.handle.resource.stat.mode) {
 		return errno.err, errno.espipe
 	}
-	// Writes are synchronous today, so every valid range is already durable.
+	// A synchronous whole-resource flush is a conservative implementation of
+	// range writeback until resources expose independent writeback ranges.
+	if flags != 0 {
+		mut res := fd.handle.resource
+		resource.sync_resource(mut res, voidptr(fd.handle)) or { return errno.err, errno.get() }
+	}
 	return 0, 0
 }
 

--- a/kernel/modules/fs/ext2/ext2.v
+++ b/kernel/modules/fs/ext2/ext2.v
@@ -8,6 +8,8 @@ import event
 import event.eventstruct
 import memory
 import fs as vfs
+import pagecache
+import katomic
 
 @[packed]
 struct EXT2Superblock {
@@ -129,7 +131,12 @@ fn (mut this EXT2Resource) ioctl(handle voidptr, request u64, argp voidptr) ?int
 }
 
 fn (mut this EXT2Resource) unref(handle voidptr) ? {
-	this.refcount--
+	if !katomic.dec(mut &this.refcount) {
+		// No periodic flusher exists yet. Last-close writeback prevents quiet
+		// files from remaining dirty indefinitely. Failure leaves pages dirty;
+		// callers requiring an observable durability result must use fsync.
+		this.sync(handle) or { return none }
+	}
 }
 
 fn (mut this EXT2Resource) link(_handle voidptr) ? {
@@ -177,6 +184,7 @@ pub mut:
 	bgd_cnt    u64
 
 	backing_device &vfs.VFSNode
+	cache          &pagecache.Cache = unsafe { nil }
 }
 
 fn (mut this EXT2Filesystem) populate(node &vfs.VFSNode) {
@@ -249,6 +257,7 @@ fn (mut bro EXT2Filesystem) instantiate() &vfs.FileSystem {
 		backing_device: bro.backing_device
 		superblock:     bro.superblock
 		root_inode:     bro.root_inode
+		cache:          bro.cache
 	}
 
 	this.block_size = 1024 << this.superblock.block_size
@@ -908,80 +917,29 @@ fn (mut inode EXT2Inode) write_entry(mut filesystem EXT2Filesystem, inode_index 
 	return 0
 }
 
-fn (mut filesystem EXT2Filesystem) raw_device_read(buf voidptr, loc u64, count u64) ?i64 {
-	lba_size := u64(filesystem.backing_device.resource.stat.blksize)
-
-	mut alignment := u64(0)
-	if (loc & (lba_size - 1)) + count > lba_size {
-		alignment = 0
-	}
-
-	lba_start := u64(loc / lba_size)
-	lba_cnt := u64(lib.div_roundup(count, lba_size) + alignment)
-
-	buffer := voidptr(u64(memory.pmm_alloc(lib.div_roundup(lba_cnt * lba_size, page_size))) +
-		higher_half)
-
-	filesystem.backing_device.resource.read(0, buffer, lba_start * lba_size, lba_cnt * lba_size) or {
-		print('ext2: unable to read from device\n')
-		return none
-	}
-
-	lba_offset := loc % lba_size
-
-	unsafe { C.memcpy(buf, voidptr(u64(buffer) + lba_offset), count) }
-
-	memory.pmm_free(voidptr(u64(buffer) - higher_half), lib.div_roundup(lba_cnt * lba_size,
-		page_size))
-
-	return i64(count)
-}
-
-fn (mut filesystem EXT2Filesystem) raw_device_write(buf voidptr, loc u64, count u64) ?i64 {
-	lba_size := u64(filesystem.backing_device.resource.stat.blksize)
-
-	mut alignment := u64(0)
-	if (loc & (lba_size - 1)) + count > lba_size {
-		alignment = 0
-	}
-
-	lba_start := u64(loc / lba_size)
-	lba_cnt := u64(lib.div_roundup(count, lba_size) + alignment)
-
-	buffer := voidptr(u64(memory.pmm_alloc(lib.div_roundup(lba_cnt * lba_size, page_size))) +
-		higher_half)
-
-	filesystem.backing_device.resource.read(0, buffer, lba_start * lba_size, lba_cnt * lba_size) or {
-		print('ext2: unable to write from device\n')
-		return none
-	}
-
-	lba_offset := loc % lba_size
-
-	unsafe { C.memcpy(voidptr(u64(buffer) + lba_offset), buf, count) }
-
-	filesystem.backing_device.resource.write(0, buffer, lba_start * lba_size, lba_cnt * lba_size) or {
-		print('ext2: unable to read from device\n')
-		return none
-	}
-
-	memory.pmm_free(voidptr(u64(buffer) - higher_half), lib.div_roundup(lba_cnt * lba_size,
-		page_size))
-
-	return i64(count)
-}
-
 pub fn ext2_init(backing_device &vfs.VFSNode) (&EXT2Filesystem, bool) {
+	sector_size := u64(backing_device.resource.stat.blksize)
+	if sector_size == 0 || sector_size > pagecache.page_bytes
+		|| pagecache.page_bytes % sector_size != 0 || backing_device.resource.stat.size < 2048
+		|| u64(backing_device.resource.stat.size) % sector_size != 0 {
+		return 0, false
+	}
 	mut new_filesystem := &EXT2Filesystem{
 		backing_device: unsafe { backing_device }
 		superblock:     &EXT2Superblock{}
 		root_inode:     &EXT2Inode{}
+		cache:          &pagecache.Cache{}
 	}
 
-	new_filesystem.raw_device_read(new_filesystem.superblock, u64(backing_device.resource.stat.blksize) * 2,
-		sizeof(EXT2Superblock)) or { return 0, false }
+	// The EXT2 superblock is at byte 1024, regardless of device sector size.
+	new_filesystem.raw_device_read(new_filesystem.superblock, 1024,
+		sizeof(EXT2Superblock)) or {
+		new_filesystem.cache.release(voidptr(backing_device.resource), device_write) or {}
+		return 0, false
+	}
 
 	if new_filesystem.superblock.signature != 0xef53 {
+		new_filesystem.cache.release(voidptr(backing_device.resource), device_write) or {}
 		return 0, false
 	}
 

--- a/kernel/modules/fs/ext2/pagecache.v
+++ b/kernel/modules/fs/ext2/pagecache.v
@@ -1,6 +1,7 @@
 module ext2
 
 import errno
+import memory
 import pagecache
 import resource as resource_mod
 import stat
@@ -9,14 +10,33 @@ import stat
 // Metadata and data therefore share one coherent cache, including byte-sized
 // bitmap updates and sub-sector inode writes. All instances of a detected
 // filesystem share the cache created by ext2_init.
-fn device_read(context voidptr, buf voidptr, loc u64, count u64) ?i64 {
+// Preserve the old raw-I/O adapter's physically contiguous, page-aligned
+// buffers. Cached bytes themselves live in heap allocations and must not be
+// handed straight to a DMA backend. Only misses/writeback allocate a bounce.
+fn device_transfer(context voidptr, buf voidptr, loc u64, count u64, writing bool) ?i64 {
+	if count == 0 { return 0 }
+	if count > pagecache.page_bytes { errno.set(errno.einval); return none }
+	physical := memory.pmm_alloc(1)
+	if physical == unsafe { nil } { errno.set(errno.enomem); return none }
+	bounce := voidptr(u64(physical) + higher_half)
+	defer { memory.pmm_free(physical, 1) }
 	mut device := unsafe { &resource_mod.Resource(context) }
-	return device.read(0, buf, loc, count)
+	if writing {
+		unsafe { C.memcpy(bounce, buf, count) }
+		return device.write(0, bounce, loc, count)
+	}
+	ret := device.read(0, bounce, loc, count) or { return none }
+	if ret < 0 || u64(ret) > count { errno.set(errno.eio); return none }
+	unsafe { C.memcpy(buf, bounce, u64(ret)) }
+	return ret
+}
+
+fn device_read(context voidptr, buf voidptr, loc u64, count u64) ?i64 {
+	return device_transfer(context, buf, loc, count, false)
 }
 
 fn device_write(context voidptr, buf voidptr, loc u64, count u64) ?i64 {
-	mut device := unsafe { &resource_mod.Resource(context) }
-	return device.write(0, buf, loc, count)
+	return device_transfer(context, buf, loc, count, true)
 }
 
 fn (mut filesystem EXT2Filesystem) raw_device_read(buf voidptr, loc u64, count u64) ?i64 {

--- a/kernel/modules/fs/ext2/pagecache.v
+++ b/kernel/modules/fs/ext2/pagecache.v
@@ -1,0 +1,114 @@
+module ext2
+
+import errno
+import pagecache
+import resource as resource_mod
+import stat
+
+// Cache keys are offsets in the backing resource, not inode-relative offsets.
+// Metadata and data therefore share one coherent cache, including byte-sized
+// bitmap updates and sub-sector inode writes. All instances of a detected
+// filesystem share the cache created by ext2_init.
+fn device_read(context voidptr, buf voidptr, loc u64, count u64) ?i64 {
+	mut device := unsafe { &resource_mod.Resource(context) }
+	return device.read(0, buf, loc, count)
+}
+
+fn device_write(context voidptr, buf voidptr, loc u64, count u64) ?i64 {
+	mut device := unsafe { &resource_mod.Resource(context) }
+	return device.write(0, buf, loc, count)
+}
+
+fn (mut filesystem EXT2Filesystem) raw_device_read(buf voidptr, loc u64, count u64) ?i64 {
+	ret := filesystem.cache.read(voidptr(filesystem.backing_device.resource), device_read,
+		device_write, buf, loc, count, u64(filesystem.backing_device.resource.stat.size)) or {
+		return none
+	}
+	// EXT2's internal callers require exact transfers, unlike the Resource API.
+	if ret != i64(count) {
+		errno.set(errno.eio)
+		return none
+	}
+	return ret
+}
+
+fn (mut filesystem EXT2Filesystem) raw_device_write(buf voidptr, loc u64, count u64) ?i64 {
+	ret := filesystem.cache.write(voidptr(filesystem.backing_device.resource), device_read,
+		device_write, buf, loc, count, u64(filesystem.backing_device.resource.stat.size)) or {
+		return none
+	}
+	if ret != i64(count) {
+		errno.set(errno.eio)
+		return none
+	}
+	return ret
+}
+
+fn (mut this EXT2Resource) sync(_handle voidptr) ? {
+	mut device := this.filesystem.backing_device.resource
+	this.filesystem.cache.sync(voidptr(device), device_write) or { return none }
+	// Drivers may additionally implement a hardware cache/barrier operation.
+	// Without one, success means completion at the backing Resource, not a
+	// promise that volatile controller caches survive loss of power.
+	resource_mod.sync_resource(mut device, 0) or { return none }
+}
+
+fn (mut this EXT2Resource) advise(_handle voidptr, offset u64, length u64, advice int) ? {
+	if advice != pagecache.willneed && advice != pagecache.dontneed {
+		return
+	}
+	if !stat.isreg(this.stat.mode) { return }
+	mut inode := EXT2Inode{}
+	inode.read_entry(mut this.filesystem, u32(this.stat.ino)) or { return none }
+	size := u64(inode.size32l)
+	if offset >= size { return }
+	mut end := size
+	if length != 0 && length < size - offset { end = offset + length }
+
+	block_size := this.filesystem.block_size
+	if block_size == 0 { errno.set(errno.eio); return none }
+	device_size := u64(this.filesystem.backing_device.resource.stat.size)
+	context := voidptr(this.filesystem.backing_device.resource)
+	// A hint may cover an enormous file. Bound both metadata walks and fills.
+	mut budget := u64(pagecache.default_capacity) * pagecache.page_bytes / block_size
+	mut block := offset / block_size
+	mut run_start := u64(0)
+	mut run_end := u64(0)
+	for block * block_size < end && budget > 0 {
+		disk_block := inode.get_block(mut this.filesystem, u32(block)) or { break }
+		physical := u64(disk_block) * block_size
+		logical := block * block_size
+		// Coalesce contiguous blocks so a 1 KiB EXT2 filesystem can discard
+		// complete 4 KiB cache pages. Ignore holes and partial boundary blocks.
+		if disk_block != 0 && logical >= offset && block_size <= end - logical {
+			if run_end != physical && run_end > run_start {
+				this.advise_run(context, run_start, run_end - run_start, device_size, advice)
+				run_end = 0
+			}
+			if run_end == 0 { run_start = physical }
+			run_end = physical + block_size
+		} else {
+			if run_end > run_start {
+				this.advise_run(context, run_start, run_end - run_start, device_size, advice)
+			}
+			run_start = 0
+			run_end = 0
+			if advice == pagecache.willneed && disk_block != 0 {
+				this.advise_run(context, physical, block_size, device_size, advice)
+			}
+		}
+		block++
+		budget--
+	}
+	if run_end > run_start {
+		this.advise_run(context, run_start, run_end - run_start, device_size, advice)
+	}
+}
+
+fn (mut this EXT2Resource) advise_run(context voidptr, loc u64, count u64, size u64, advice int) {
+	if advice == pagecache.willneed {
+		this.filesystem.cache.prefetch(context, device_read, device_write, loc, count, size)
+	} else {
+		this.filesystem.cache.discard(loc, count)
+	}
+}

--- a/kernel/modules/pagecache/pagecache.v
+++ b/kernel/modules/pagecache/pagecache.v
@@ -1,0 +1,234 @@
+// A bounded backing-store page cache. The same cache must be used for every
+// access to a backing resource; callbacks must bypass the cache itself.
+module pagecache
+
+import errno
+import klock
+
+pub const page_bytes = u64(4096)
+pub const default_capacity = 128
+pub const willneed = 3
+pub const dontneed = 4
+
+pub type IO = fn (voidptr, voidptr, u64, u64) ?i64
+
+struct Page {
+mut:
+	index u64
+	valid u64
+	dirty bool
+	data  [4096]u8
+}
+
+pub struct Cache {
+mut:
+	l        klock.Lock
+	pages    []&Page // Least recently used first.
+	owner    voidptr
+	size     u64
+pub:
+	capacity int = default_capacity
+}
+
+// Binding prevents accidentally using resident pages with a different device
+// or capacity. Device sizes are fixed for the lifetime of a cache.
+fn (mut this Cache) bind(context voidptr, size u64) ? {
+	if context == unsafe { nil } || this.capacity <= 0 {
+		errno.set(errno.einval)
+		return none
+	}
+	if this.owner == unsafe { nil } {
+		this.owner = context
+		this.size = size
+	} else if this.owner != context || this.size != size {
+		errno.set(errno.einval)
+		return none
+	}
+}
+
+fn valid_range(loc u64, count u64, size u64) bool {
+	return loc <= size && count <= size - loc && count <= u64(0x7fffffffffffffff)
+}
+
+fn (mut page Page) flush(context voidptr, store IO) ? {
+	if !page.dirty {
+		return
+	}
+	ret := store(context, voidptr(&page.data[0]), page.index * page_bytes, page.valid) or {
+		return none
+	}
+	// A short write is not a completed page writeback. Keep the entire page
+	// dirty so a later fsync can retry, including the already-written prefix.
+	if ret != i64(page.valid) {
+		errno.set(errno.eio)
+		return none
+	}
+	page.dirty = false
+}
+
+// Called with l held. A failed fill is never published, and a failed eviction
+// leaves the dirty victim in the cache, still readable and retryable.
+fn (mut this Cache) get(context voidptr, load IO, store IO, index u64, fill bool) ?&Page {
+	for i, page in this.pages {
+		if page.index == index {
+			this.pages.delete(i)
+			this.pages << page
+			return page
+		}
+	}
+
+	mut page := &Page(unsafe { nil })
+	if this.pages.len >= this.capacity {
+		page = this.pages[0]
+		page.flush(context, store) or { return none }
+		this.pages.delete(0)
+	} else {
+		page = unsafe { &Page(malloc(sizeof(Page))) }
+		if page == unsafe { nil } {
+			errno.set(errno.enomem)
+			return none
+		}
+	}
+	unsafe { C.memset(page, 0, sizeof(Page)) }
+	page.index = index
+	page.valid = page_bytes
+	if this.size - index * page_bytes < page.valid {
+		page.valid = this.size - index * page_bytes
+	}
+	if fill {
+		ret := load(context, voidptr(&page.data[0]), index * page_bytes, page.valid) or {
+			unsafe { free(page) }
+			return none
+		}
+		if ret != i64(page.valid) {
+			unsafe { free(page) }
+			errno.set(errno.eio)
+			return none
+		}
+	}
+	this.pages << page
+	return page
+}
+
+// These are exact backing-store transfers, not file reads: an out-of-bounds
+// range is rejected rather than clipped at EOF. On an I/O error after progress,
+// return the completed prefix, as a Resource read/write would.
+pub fn (mut this Cache) read(context voidptr, load IO, store IO, buf voidptr, loc u64, count u64, size u64) ?i64 {
+	this.l.acquire()
+	defer { this.l.release() }
+	this.bind(context, size) or { return none }
+	if !valid_range(loc, count, size) {
+		errno.set(errno.einval)
+		return none
+	}
+	mut done := u64(0)
+	for done < count {
+		index := (loc + done) / page_bytes
+		offset := (loc + done) % page_bytes
+		mut amount := page_bytes - offset
+		if amount > count - done { amount = count - done }
+		page := this.get(context, load, store, index, true) or {
+			if done != 0 { return i64(done) }
+			return none
+		}
+		unsafe { C.memcpy(voidptr(u64(buf) + done), &page.data[int(offset)], amount) }
+		done += amount
+	}
+	return i64(done)
+}
+
+pub fn (mut this Cache) write(context voidptr, load IO, store IO, buf voidptr, loc u64, count u64, size u64) ?i64 {
+	this.l.acquire()
+	defer { this.l.release() }
+	this.bind(context, size) or { return none }
+	if !valid_range(loc, count, size) {
+		errno.set(errno.einval)
+		return none
+	}
+	mut done := u64(0)
+	for done < count {
+		index := (loc + done) / page_bytes
+		offset := (loc + done) % page_bytes
+		mut amount := page_bytes - offset
+		if amount > count - done { amount = count - done }
+		mut valid := page_bytes
+		if size - index * page_bytes < valid { valid = size - index * page_bytes }
+		// Full-page replacements need no read. Partial writes must preserve
+		// every byte outside the requested range, including device tails.
+		mut page := this.get(context, load, store, index, offset != 0 || amount != valid) or {
+			if done != 0 { return i64(done) }
+			return none
+		}
+		unsafe { C.memcpy(&page.data[int(offset)], voidptr(u64(buf) + done), amount) }
+		page.dirty = true
+		done += amount
+	}
+	return i64(done)
+}
+
+pub fn (mut this Cache) sync(context voidptr, store IO) ? {
+	this.l.acquire()
+	defer { this.l.release() }
+	if this.owner == unsafe { nil } { return }
+	if this.owner != context {
+		errno.set(errno.einval)
+		return none
+	}
+	for mut page in this.pages {
+		page.flush(context, store) or { return none }
+	}
+}
+
+// Best-effort prefetch is deliberately bounded and never evicts dirty data.
+// Advice must not turn into an unbounded scan or unexpected writeback storm.
+pub fn (mut this Cache) prefetch(context voidptr, load IO, store IO, loc u64, count u64, size u64) {
+	this.l.acquire()
+	defer { this.l.release() }
+	this.bind(context, size) or { return }
+	if !valid_range(loc, count, size) || count == 0 { return }
+	last := (loc + count - 1) / page_bytes
+	mut index := loc / page_bytes
+	mut budget := this.capacity
+	for index <= last && budget > 0 {
+		if this.pages.len >= this.capacity && this.pages[0].dirty { return }
+		this.get(context, load, store, index, true) or { return }
+		index++
+		budget--
+	}
+}
+
+// Drop only clean pages wholly covered by the physical range. Dirty pages
+// stay resident: DONTNEED is not permission to lose acknowledged writes.
+pub fn (mut this Cache) discard(loc u64, count u64) {
+	this.l.acquire()
+	defer { this.l.release() }
+	if !valid_range(loc, count, this.size) { return }
+	end := loc + count
+	for i := this.pages.len - 1; i >= 0; i-- {
+		page := this.pages[i]
+		start := page.index * page_bytes
+		if !page.dirty && start >= loc && start + page.valid <= end {
+			this.pages.delete(i)
+			unsafe { free(page) }
+		}
+	}
+}
+
+// Teardown is failure-atomic with respect to dirty data. Callers must not
+// destroy the cache/backing resource if release fails.
+pub fn (mut this Cache) release(context voidptr, store IO) ? {
+	this.l.acquire()
+	defer { this.l.release() }
+	if this.owner != unsafe { nil } && this.owner != context {
+		errno.set(errno.einval)
+		return none
+	}
+	for mut page in this.pages {
+		page.flush(context, store) or { return none }
+	}
+	for page in this.pages { unsafe { free(page) } }
+	unsafe { this.pages.free() }
+	this.pages = []&Page{}
+	this.owner = unsafe { nil }
+	this.size = 0
+}

--- a/kernel/modules/resource/cache.v
+++ b/kernel/modules/resource/cache.v
@@ -1,0 +1,25 @@
+module resource
+
+// Optional capabilities keep stream/device resources and in-memory files from
+// needing dummy callbacks merely because disk-backed resources cache writes.
+pub interface SyncableResource {
+mut:
+	sync(handle voidptr) ?
+}
+
+pub interface AdvisableResource {
+mut:
+	advise(handle voidptr, offset u64, length u64, advice int) ?
+}
+
+pub fn sync_resource(mut res Resource, handle voidptr) ? {
+	if mut res is SyncableResource {
+		res.sync(handle) or { return none }
+	}
+}
+
+pub fn advise_resource(mut res Resource, handle voidptr, offset u64, length u64, advice int) ? {
+	if mut res is AdvisableResource {
+		res.advise(handle, offset, length, advice) or { return none }
+	}
+}

--- a/tests/pagecache/README.md
+++ b/tests/pagecache/README.md
@@ -1,0 +1,72 @@
+# EXT2 backing-store page cache
+
+This change adds an initial page-sized **backing-store cache**, not a unified
+inode page cache or a file-backed mmap implementation. EXT2 data, inode tables,
+indirect blocks and bitmaps all use the same cache. Its identity is the backing
+Resource plus a 4 KiB physical offset; instantiated filesystems share the cache
+created during detection. This avoids separate stale copies for file aliases or
+for data accessed through internal EXT2 helpers.
+
+## Writeback and lifetime
+
+The default limit is 128 pages (512 KiB of data per detected filesystem), with
+LRU replacement. Pages are allocated on demand. Full-page overwrites skip reads;
+partial writes preserve the rest of the page. Bounds are checked by subtraction,
+and a sector-aligned device tail may be shorter than a page.
+
+Dirty pages are written on eviction, explicit synchronization, and final resource
+close. Failed or short writeback leaves the page dirty, resident and retryable.
+Failed/short fills are not published. Teardown does not free dirty pages if
+writeback fails. Callers must keep the backing resource alive until teardown
+succeeds. Cache callbacks must bypass the cache and must not re-enter it.
+
+`fsync`/`fdatasync`, `O_SYNC`/`O_DSYNC` writes and nonzero `sync_file_range` requests
+call an optional Resource synchronization capability. EXT2 conservatively flushes
+the entire shared cache, including metadata and unrelated files, rather than
+claiming precise per-file or asynchronous range writeback. An optional underlying
+driver synchronization hook is then called. Physical persistence still depends
+on the backing driver/controller contract. Last-close errors cannot currently be
+reported through Handle destruction; applications must use explicit fsync to
+observe writeback errors.
+
+`POSIX_FADV_WILLNEED` performs bounded best-effort prefetch. `DONTNEED` drops only
+clean, fully covered backing pages, including coalesced adjacent 1 KiB blocks.
+Dirty or partly covered pages remain resident. Advice walks are limited to one
+cache-capacity window; other advice values remain accepted hints without a policy
+change. Devices, pipes and in-memory files do not acquire meaningless caches.
+
+## Deliberate limits and merge gates
+
+There is no periodic flusher, global memory-pressure reclaim, inode page mapping,
+shared writable mmap, dirty-PTE tracking, or msync in this first implementation.
+Do not enable EXT2 mmap merely because this cache exists: these are physical
+backing pages and can contain bytes from different inodes and metadata.
+
+The cache uses the existing kernel lock across backing I/O. Its current ATA
+consumer polls completion and copies through its own DMA buffer. Before using
+other backends, verify buffer/DMA constraints and that completion does not require
+interrupts disabled by that lock; an interrupt-dependent backend needs a
+sleepable lock/explicit in-flight page state. Direct raw-device access outside
+EXT2 is not coherent with this cache, and must not modify a mounted filesystem.
+The existing EXT2 allocator, resize/truncate and concurrent metadata-update
+limitations are not repaired by caching. Crash consistency and on-disk ordering
+are not journaled. Validate on a disposable image before using real data.
+
+## Tests
+
+Run the production cache module on a host with V installed:
+
+```sh
+V=/path/to/v sh tests/pagecache/run.sh
+```
+
+The harness substitutes only the kernel lock and errno modules. The actual cache
+source is copied unchanged and exercised with an instrumented byte-array backing
+store. Tests cover hits, partial/cross-page writes, tail pages, LRU and bounded
+prefetch, clean-only discard, invalid/overflowing ranges, backing identity,
+failed/short fills, failed/short writeback, dirty eviction, teardown retry, and
+400 deterministic randomized operations under a three-page capacity limit.
+The host tests do not validate kernel locks, syscalls, DMA, or EXT2 disk images.
+The pagecache workflow runs these tests; the existing kernel workflow provides
+separate build coverage. Kernel boot, remount persistence, allocation/truncation,
+concurrent descriptor access and power-loss behavior still need integration tests.

--- a/tests/pagecache/README.md
+++ b/tests/pagecache/README.md
@@ -43,9 +43,10 @@ Do not enable EXT2 mmap merely because this cache exists: these are physical
 backing pages and can contain bytes from different inodes and metadata.
 
 The cache uses the existing kernel lock across backing I/O. Its current ATA
-consumer polls completion and copies through its own DMA buffer. Before using
-other backends, verify buffer/DMA constraints and that completion does not require
-interrupts disabled by that lock; an interrupt-dependent backend needs a
+consumer polls completion. Cache misses and writeback retain the old EXT2
+adapter's physically contiguous, page-aligned PMM bounce buffers, releasing them
+on both success and failure. Before using interrupt-dependent backends, verify
+that completion does not require interrupts disabled by that lock; an interrupt-dependent backend needs a
 sleepable lock/explicit in-flight page state. Direct raw-device access outside
 EXT2 is not coherent with this cache, and must not modify a mounted filesystem.
 The existing EXT2 allocator, resize/truncate and concurrent metadata-update

--- a/tests/pagecache/pagecache_test.v
+++ b/tests/pagecache/pagecache_test.v
@@ -1,0 +1,243 @@
+module pagecache
+
+import errno
+
+struct Device {
+mut:
+	bytes       []u8
+	reads       int
+	writes      int
+	fail_read   bool
+	fail_write  bool
+	short_read  bool
+	short_write bool
+}
+
+fn device(size int) &Device {
+	mut d := &Device{bytes: []u8{len: size}}
+	for i in 0 .. size { d.bytes[i] = u8(i % 251) }
+	return d
+}
+
+fn load(context voidptr, buf voidptr, loc u64, count u64) ?i64 {
+	mut d := unsafe { &Device(context) }
+	d.reads++
+	if d.fail_read { errno.set(errno.eio); return none }
+	assert loc <= u64(d.bytes.len) && count <= u64(d.bytes.len) - loc
+	amount := if d.short_read { count / 2 } else { count }
+	if amount != 0 { unsafe { C.memcpy(buf, &d.bytes[int(loc)], amount) } }
+	return i64(amount)
+}
+
+fn store(context voidptr, buf voidptr, loc u64, count u64) ?i64 {
+	mut d := unsafe { &Device(context) }
+	d.writes++
+	if d.fail_write { errno.set(errno.eio); return none }
+	assert loc <= u64(d.bytes.len) && count <= u64(d.bytes.len) - loc
+	amount := if d.short_write { count / 2 } else { count }
+	if amount != 0 { unsafe { C.memcpy(&d.bytes[int(loc)], buf, amount) } }
+	return i64(amount)
+}
+
+fn read_bytes(mut cache Cache, d &Device, loc int, count int) []u8 {
+	mut out := []u8{len: count}
+	mut ptr := voidptr(0)
+	if count != 0 { ptr = unsafe { voidptr(&out[0]) } }
+	got := cache.read(voidptr(d), load, store, ptr, u64(loc), u64(count), u64(d.bytes.len)) or {
+		panic('unexpected cache read failure')
+	}
+	assert got == count
+	return out
+}
+
+fn write_bytes(mut cache Cache, d &Device, loc int, bytes []u8) {
+	mut ptr := voidptr(0)
+	if bytes.len != 0 { ptr = unsafe { voidptr(&bytes[0]) } }
+	got := cache.write(voidptr(d), load, store, ptr, u64(loc), u64(bytes.len), u64(d.bytes.len)) or {
+		panic('unexpected cache write failure')
+	}
+	assert got == bytes.len
+}
+
+fn test_hits_cross_page_writes_and_writeback() {
+	mut d := device(3 * 4096)
+	mut cache := Cache{capacity: 3}
+	defer { cache.release(voidptr(d), store) or { panic('release failed') } }
+	assert read_bytes(mut cache, d, 511, 20) == d.bytes[511..531]
+	assert read_bytes(mut cache, d, 1000, 10) == d.bytes[1000..1010]
+	assert d.reads == 1
+	before := d.bytes.clone()
+	payload := []u8{len: 33, init: 0xa5}
+	write_bytes(mut cache, d, 4090, payload)
+	assert d.bytes == before
+	assert d.writes == 0
+	assert read_bytes(mut cache, d, 4090, 33) == payload
+	assert read_bytes(mut cache, d, 4089, 1)[0] == before[4089]
+	assert read_bytes(mut cache, d, 4123, 1)[0] == before[4123]
+	cache.sync(voidptr(d), store) or { panic('sync failed') }
+	assert d.bytes[4090..4123] == payload
+	assert d.bytes[..4090] == before[..4090]
+	assert d.bytes[4123..] == before[4123..]
+	assert d.writes == 2
+	cache.sync(voidptr(d), store) or { panic('clean sync failed') }
+	assert d.writes == 2
+}
+
+fn test_full_replacement_and_device_tail_need_no_read() {
+	mut d := device(4096 + 512)
+	mut cache := Cache{capacity: 2}
+	defer { cache.release(voidptr(d), store) or { panic('release failed') } }
+	write_bytes(mut cache, d, 0, []u8{len: 4096, init: 0x21})
+	write_bytes(mut cache, d, 4096, []u8{len: 512, init: 0x43})
+	assert d.reads == 0
+	cache.sync(voidptr(d), store) or { panic('sync failed') }
+	assert d.bytes[..4096] == []u8{len: 4096, init: 0x21}
+	assert d.bytes[4096..] == []u8{len: 512, init: 0x43}
+}
+
+fn test_failed_and_short_fills_are_not_published() {
+	mut d := device(4096)
+	mut cache := Cache{}
+	defer { cache.release(voidptr(d), store) or { panic('release failed') } }
+	mut out := u8(0)
+	for short in [false, true] {
+		d.fail_read = !short
+		d.short_read = short
+		mut failed := false
+		cache.read(voidptr(d), load, store, &out, 0, 1, 4096) or { failed = true }
+		assert failed
+		assert cache.pages.len == 0
+	}
+	d.fail_read = false
+	d.short_read = false
+	assert read_bytes(mut cache, d, 0, 20) == d.bytes[..20]
+	assert d.reads == 3
+}
+
+fn test_failed_eviction_retains_dirty_victim_and_retry() {
+	mut d := device(8192)
+	mut cache := Cache{capacity: 1}
+	defer { cache.release(voidptr(d), store) or { panic('release failed') } }
+	payload := []u8{len: 4096, init: 0x71}
+	write_bytes(mut cache, d, 0, payload)
+	d.fail_write = true
+	mut out := u8(0)
+	mut failed := false
+	cache.read(voidptr(d), load, store, &out, 4096, 1, 8192) or { failed = true }
+	assert failed
+	assert cache.pages.len == 1 && cache.pages[0].index == 0 && cache.pages[0].dirty
+	assert read_bytes(mut cache, d, 0, 4096) == payload
+	d.fail_write = false
+	assert read_bytes(mut cache, d, 4096, 1) == d.bytes[4096..4097]
+	assert d.bytes[..4096] == payload
+	assert cache.pages.len == 1 && cache.pages[0].index == 1
+}
+
+fn test_failed_and_short_sync_are_retryable() {
+	mut d := device(4096)
+	mut cache := Cache{}
+	defer { cache.release(voidptr(d), store) or { panic('release failed') } }
+	payload := []u8{len: 4096, init: 0x82}
+	write_bytes(mut cache, d, 0, payload)
+	for short in [false, true] {
+		d.fail_write = !short
+		d.short_write = short
+		mut failed := false
+		cache.sync(voidptr(d), store) or { failed = true }
+		assert failed && cache.pages[0].dirty
+		assert read_bytes(mut cache, d, 0, 4096) == payload
+	}
+	d.fail_write = false
+	d.short_write = false
+	cache.sync(voidptr(d), store) or { panic('retry failed') }
+	assert d.bytes == payload
+	assert !cache.pages[0].dirty
+}
+
+fn test_discard_preserves_dirty_and_partial_pages() {
+	mut d := device(8192)
+	mut cache := Cache{capacity: 2}
+	defer { cache.release(voidptr(d), store) or { panic('release failed') } }
+	read_bytes(mut cache, d, 0, 8192)
+	cache.discard(1, 8190)
+	assert cache.pages.len == 2
+	write_bytes(mut cache, d, 0, [u8(99)])
+	cache.discard(0, 8192)
+	assert cache.pages.len == 1 && cache.pages[0].dirty
+	cache.sync(voidptr(d), store) or { panic('sync failed') }
+	cache.discard(0, 8192)
+	assert cache.pages.len == 0
+	reads := d.reads
+	assert read_bytes(mut cache, d, 0, 1) == [u8(99)]
+	assert d.reads == reads + 1
+}
+
+fn test_lru_and_bounded_prefetch() {
+	mut d := device(10 * 4096)
+	mut cache := Cache{capacity: 2}
+	defer { cache.release(voidptr(d), store) or { panic('release failed') } }
+	cache.prefetch(voidptr(d), load, store, 0, u64(d.bytes.len), u64(d.bytes.len))
+	assert cache.pages.len == 2 && d.reads == 2
+	read_bytes(mut cache, d, 0, 1)
+	read_bytes(mut cache, d, 8192, 1)
+	assert cache.pages[0].index == 0 && cache.pages[1].index == 2
+	write_bytes(mut cache, d, 0, [u8(7)])
+	read_bytes(mut cache, d, 8192, 1) // Dirty page is now LRU.
+	reads := d.reads
+	cache.prefetch(voidptr(d), load, store, 12288, 4096, u64(d.bytes.len))
+	assert d.reads == reads && d.writes == 0
+	assert cache.pages.len == 2
+}
+
+fn test_bounds_binding_zero_length_and_release_failure() {
+	mut d := device(4096)
+	mut other := device(4096)
+	mut cache := Cache{}
+	assert read_bytes(mut cache, d, 4096, 0).len == 0
+	mut out := u8(0)
+	for pair in [[u64(4096), u64(1)], [u64(-1), u64(2)], [u64(1), u64(-1)]] {
+		mut failed := false
+		cache.read(voidptr(d), load, store, &out, pair[0], pair[1], 4096) or { failed = true }
+		assert failed
+	}
+	mut failed := false
+	cache.read(voidptr(other), load, store, &out, 0, 1, 4096) or { failed = true }
+	assert failed
+	write_bytes(mut cache, d, 0, [u8(100)])
+	d.fail_write = true
+	failed = false
+	cache.release(voidptr(d), store) or { failed = true }
+	assert failed && cache.pages.len == 1 && cache.pages[0].dirty
+	d.fail_write = false
+	cache.release(voidptr(d), store) or { panic('release retry failed') }
+	assert cache.pages.len == 0
+	assert read_bytes(mut cache, other, 0, 1) == other.bytes[..1]
+	cache.release(voidptr(other), store) or { panic('release failed') }
+}
+
+fn test_randomized_transfers_match_byte_model_under_pressure() {
+	mut d := device(7 * 4096 + 512)
+	mut expected := d.bytes.clone()
+	mut cache := Cache{capacity: 3}
+	mut seed := u64(0x12345678)
+	for step in 0 .. 400 {
+		seed ^= seed << 13
+		seed ^= seed >> 7
+		seed ^= seed << 17
+		loc := int(seed % u64(expected.len))
+		mut count := int((seed >> 17) % 7000) + 1
+		if count > expected.len - loc { count = expected.len - loc }
+		if step % 3 != 0 {
+			payload := []u8{len: count, init: u8(seed & 255)}
+			write_bytes(mut cache, d, loc, payload)
+			for i in 0 .. count { expected[loc + i] = payload[i] }
+		} else {
+			assert read_bytes(mut cache, d, loc, count) == expected[loc..loc + count]
+		}
+		if step % 23 == 0 { cache.sync(voidptr(d), store) or { panic('sync failed') } }
+		if step % 27 == 0 { cache.discard(0, u64(expected.len)) }
+		assert cache.pages.len <= 3
+	}
+	cache.release(voidptr(d), store) or { panic('release failed') }
+	assert d.bytes == expected
+}

--- a/tests/pagecache/run.sh
+++ b/tests/pagecache/run.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -eu
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+v=${V:-v}
+if ! command -v "$v" >/dev/null 2>&1; then
+    echo "V compiler not found: set V=/path/to/v" >&2
+    exit 127
+fi
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+mkdir -p "$tmp/modules/pagecache" "$tmp/modules/errno" "$tmp/modules/klock"
+cp "$root/kernel/modules/pagecache/pagecache.v" "$tmp/modules/pagecache/"
+cp "$root/tests/pagecache/pagecache_test.v" "$tmp/modules/pagecache/"
+cat > "$tmp/v.mod" <<'MOD'
+Module { name: 'pagecache_host_tests' }
+MOD
+# Only synchronization and errno are substituted. The cache implementation is
+# copied unchanged from the kernel and exercised directly, not reimplemented.
+cat > "$tmp/modules/klock/klock.v" <<'VEOF'
+module klock
+import sync
+pub struct Lock { mut: mutex sync.Mutex }
+pub fn (mut l Lock) acquire() { l.mutex.lock() }
+pub fn (mut l Lock) release() { l.mutex.unlock() }
+VEOF
+cat > "$tmp/modules/errno/errno.v" <<'VEOF'
+@[has_globals]
+module errno
+pub const eio = 5
+pub const enomem = 12
+pub const einval = 22
+__global (last_error int)
+pub fn set(value int) { last_error = value }
+pub fn get() int { return last_error }
+VEOF
+VMODULES="$tmp/modules" "$v" -enable-globals -gc none test "$tmp/modules/pagecache"


### PR DESCRIPTION
## Summary

Adds an initial page-sized **EXT2 backing-store cache**, with the implementation, filesystem/syscall integration, host tests and CI committed on `feat/ext2-page-cache`. This is deliberately not a unified inode/mmap page cache.

- 4 KiB pages, bounded LRU replacement (128 pages / 512 KiB of cached data by default), lazy allocation, read hits and write-back caching.
- Shared cache for EXT2 data and metadata; detected filesystem instances retain the same cache. Keys are physical offsets within the backing Resource, avoiding independent copies for file aliases and internal metadata accesses.
- Partial writes preserve neighboring bytes; full-page replacements skip backing reads. Range checks handle overflow and sector-aligned device tails.
- Failed or short writeback leaves dirty pages resident and retryable. Failed/short fills are never published. Eviction and teardown cannot silently throw away dirty pages.
- Optional Resource synchronization/advice interfaces, without adding dummy callbacks to every stream or in-memory resource.
- `fsync`/`fdatasync`, `O_SYNC`/`O_DSYNC` writes and nonzero `sync_file_range` requests dispatch synchronization. EXT2 conservatively flushes its entire shared cache, including metadata, and then invokes an optional backing-driver sync hook. Final resource close also attempts writeback.
- `WILLNEED` performs bounded best-effort prefetch; `DONTNEED` drops only clean, fully covered backing pages. Contiguous EXT2 blocks are coalesced so 1 KiB blocks can cover a 4 KiB cache page. Other advice values remain accepted no-op hints.
- Cache misses/writeback preserve EXT2's physically contiguous, page-aligned PMM bounce buffers for DMA, with cleanup on both success and failure.
- Corrects superblock probing to byte offset 1024 independent of sector size.

## Tests and validation

The host harness copies the production cache source unchanged and substitutes only kernel locking and errno. Nine tests cover read hits, partial/cross-page writes, tails, bounds/overflow, backing identity, LRU, advisory discard/prefetch, failed/short fills and writeback, dirty eviction, teardown retry, and 400 deterministic randomized operations under a three-page capacity limit.

- **Passed locally:** `sh -n tests/pagecache/run.sh`.
- **Reviewed:** published diffs for the existing EXT2 and file syscall sources; they contain only the intended integration changes.
- **Not run locally:** V host tests (V is unavailable; the runner explicitly exits 127), kernel compilation, QEMU boot or EXT2 remount/persistence tests.
- **Latest CI check at head `ca025141b6a23dc34c8d6be2e353f9c6e20faa90`:** Page cache tests, Build Vinix kernel and M1 Wi-Fi kernel build are all **queued**, with no completed result. No passing build/test result is claimed.

Run the host suite with:

```sh
V=/path/to/v sh tests/pagecache/run.sh
```

## Why this remains draft

Compilation, host-test results, disposable EXT2 image/remount testing, and kernel lock/backend review are required before merge. The cache uses the existing kernel lock across I/O; interrupt-dependent completion paths require particular care. Hardware durability still depends on the backing driver's contract, and errors from final-close destruction are not currently surfaced to userspace: explicit fsync is required to observe writeback failures.

`EXT2Resource.mmap` remains unsupported. Shared writable mappings, msync, dirty-PTE tracking, a periodic flusher, global memory-pressure reclaim and journaled crash consistency are **not implemented**. Existing EXT2 allocation, resize/truncate and concurrent metadata-update limitations are not repaired by caching. Direct raw-device modification outside EXT2 is not coherent with a mounted filesystem's cache. Validate on a disposable image, not real data.

Design and test instructions: `tests/pagecache/README.md`.